### PR TITLE
[V26-358]: Migrate POS register/customer command surfaces

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1484 files · ~0 words
+- 1485 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3716 nodes · 3241 edges · 1399 communities detected
+- 3722 nodes · 3248 edges · 1400 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1409,6 +1409,7 @@
 - [[_COMMUNITY_Community 1396|Community 1396]]
 - [[_COMMUNITY_Community 1397|Community 1397]]
 - [[_COMMUNITY_Community 1398|Community 1398]]
+- [[_COMMUNITY_Community 1399|Community 1399]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1581,72 +1582,72 @@ Cohesion: 0.24
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
 ### Community 36 - "Community 36"
+Cohesion: 0.24
+Nodes (5): hasCustomerSnapshotValue(), normalizeCustomerSnapshot(), persistSessionWorkflowTraceIdBestEffort(), recordSessionLifecycleTraceBestEffort(), resolveCustomerTraceStage()
+
+### Community 37 - "Community 37"
 Cohesion: 0.36
 Nodes (9): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), resolveStockAdjustmentApprovalDecisionWithCtx(), submitStockAdjustmentBatchWithCtx() (+1 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.29
 Nodes (5): handleReviewCloseout(), handleSubmitCloseout(), onReviewCloseout(), onSubmitCloseout(), trimOptional()
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.24
 Nodes (3): buildDepositSubmissionKey(), handleRecordDeposit(), trimOptional()
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.22
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
-
-### Community 52 - "Community 52"
-Cohesion: 0.31
-Nodes (5): hasCustomerSnapshotValue(), normalizeCustomerSnapshot(), persistSessionWorkflowTraceIdBestEffort(), recordSessionLifecycleTraceBestEffort(), resolveCustomerTraceStage()
 
 ### Community 53 - "Community 53"
 Cohesion: 0.28
@@ -1690,19 +1691,19 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 63 - "Community 63"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 64 - "Community 64"
 Cohesion: 0.43
-Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 65 - "Community 65"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
 ### Community 66 - "Community 66"
-Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 67 - "Community 67"
 Cohesion: 0.36
@@ -1713,80 +1714,80 @@ Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
 ### Community 69 - "Community 69"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
 ### Community 70 - "Community 70"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 71 - "Community 71"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 72 - "Community 72"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 73 - "Community 73"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 72 - "Community 72"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 73 - "Community 73"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 74 - "Community 74"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 75 - "Community 75"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.52
 Nodes (5): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability()
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.52
 Nodes (5): buildTraceEvent(), buildTraceRecord(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.33
 Nodes (2): formatCurrency(), SummaryStrip()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.52
 Nodes (6): buildCycleCountDrafts(), buildManualDrafts(), buildStockAdjustmentSubmissionKey(), handleModeChange(), handleSubmit(), trimOptional()
-
-### Community 87 - "Community 87"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 88 - "Community 88"
 Cohesion: 0.48
@@ -1805,16 +1806,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 92 - "Community 92"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 93 - "Community 93"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 94 - "Community 94"
+### Community 93 - "Community 93"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 94 - "Community 94"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 95 - "Community 95"
 Cohesion: 0.52
@@ -1885,16 +1886,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 112 - "Community 112"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 113 - "Community 113"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 114 - "Community 114"
+### Community 113 - "Community 113"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 114 - "Community 114"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 115 - "Community 115"
 Cohesion: 0.33
@@ -1905,52 +1906,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 117 - "Community 117"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 118 - "Community 118"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.4
 Nodes (2): hasCustomerDetails(), useRegisterViewModel()
+
+### Community 120 - "Community 120"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 122 - "Community 122"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 123 - "Community 123"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 124 - "Community 124"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 125 - "Community 125"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 126 - "Community 126"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 127 - "Community 127"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 128 - "Community 128"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 129 - "Community 129"
 Cohesion: 0.53
@@ -2022,19 +2023,19 @@ Nodes (0):
 
 ### Community 146 - "Community 146"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 147 - "Community 147"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 148 - "Community 148"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 149 - "Community 149"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 149 - "Community 149"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 150 - "Community 150"
 Cohesion: 0.4
@@ -2046,7 +2047,7 @@ Nodes (0):
 
 ### Community 152 - "Community 152"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 153 - "Community 153"
 Cohesion: 0.4
@@ -7032,6 +7033,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1399 - "Community 1399"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **Thin community `Community 379`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -7051,2027 +7056,2029 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 387`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 388`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 389`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 390`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 391`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 392`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 393`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 394`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 395`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 396`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
+- **Thin community `Community 397`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `staffProfiles.test.ts`, `createStaffProfilesMutationCtx()`
+- **Thin community `Community 398`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 399`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 400`** (2 nodes): `staffProfiles.test.ts`, `createStaffProfilesMutationCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 401`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 402`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 403`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 404`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 405`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 406`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 407`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 408`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 409`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 410`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 411`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 412`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 413`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 414`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 415`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 416`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 417`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 418`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 419`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 420`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 421`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 422`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 423`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
+- **Thin community `Community 424`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 425`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 426`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 427`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 428`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 429`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 430`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 431`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 432`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 433`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 434`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 435`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 436`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 437`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 438`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 439`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 440`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 441`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 442`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 443`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 444`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 445`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 446`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 447`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 448`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 449`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 450`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 451`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 452`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 453`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 454`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 455`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 456`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 457`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 458`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 459`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 460`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 461`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 462`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 463`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 464`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 465`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 466`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 467`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 468`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 469`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 470`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 471`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 472`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 473`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 474`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 475`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 476`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 477`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 478`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 479`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 480`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 481`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 482`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 483`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 484`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 485`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 486`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 487`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 488`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 489`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 490`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 491`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 492`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 493`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 494`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
+- **Thin community `Community 495`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 496`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 497`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 498`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 499`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 500`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 501`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 502`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 503`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 504`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 505`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 506`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 507`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 508`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 509`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 510`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 511`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 512`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 513`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 514`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 515`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 516`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 517`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 518`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 519`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 520`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 521`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 522`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 523`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 524`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 525`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 526`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 527`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 528`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 529`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 530`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 531`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 532`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 533`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 534`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 535`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 536`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 537`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 538`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 539`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 540`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 541`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 542`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 543`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 544`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 545`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 546`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 547`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 548`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 549`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 550`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 551`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 552`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 553`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 554`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 555`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 556`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 557`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 558`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 559`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 560`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 561`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 562`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 563`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 564`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 565`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 566`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 567`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 568`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 569`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 570`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 571`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 572`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 573`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 574`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 575`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 576`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 577`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 578`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 579`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 580`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 581`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 582`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 583`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 584`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 585`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 586`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 587`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 588`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 589`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 590`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 591`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 592`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 593`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 594`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 595`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 596`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 597`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 598`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 599`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 600`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 601`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 602`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 603`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 604`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 605`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 606`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 607`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 608`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 609`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 610`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 611`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 612`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 613`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 614`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 615`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 616`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 617`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 618`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 619`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 620`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 621`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 622`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 623`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 624`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 625`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 626`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 627`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 628`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 629`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 630`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 631`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 632`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 633`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 634`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 635`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 636`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 637`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 638`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 639`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 640`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 641`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 642`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 643`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 644`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 645`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 646`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 647`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 648`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 649`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 650`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 651`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 652`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 653`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 654`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 655`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 656`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 657`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 658`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 659`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 660`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 661`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 662`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 663`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 664`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 665`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 666`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 667`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 668`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 669`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 670`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 671`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 672`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 673`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 674`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 675`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 676`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 677`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 678`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 679`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 680`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 681`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 682`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 683`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 684`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 685`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 686`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 687`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 688`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 689`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 690`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 691`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 692`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 693`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 694`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 695`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 696`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 697`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 698`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 699`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 700`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 701`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 702`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 703`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 704`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 705`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 706`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 707`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 708`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 709`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 710`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 711`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 712`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 713`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 714`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 715`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 716`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 717`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 718`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 719`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 720`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 721`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 722`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 723`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 724`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 725`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 726`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 727`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 728`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 729`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 730`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `api.d.ts`
+- **Thin community `Community 731`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `api.js`
+- **Thin community `Community 732`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 733`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `server.d.ts`
+- **Thin community `Community 734`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `server.js`
+- **Thin community `Community 735`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `app.ts`
+- **Thin community `Community 736`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `auth.config.js`
+- **Thin community `Community 737`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `auth.ts`
+- **Thin community `Community 738`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 739`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `countries.ts`
+- **Thin community `Community 740`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `email.ts`
+- **Thin community `Community 741`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `ghana.ts`
+- **Thin community `Community 742`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `payment.ts`
+- **Thin community `Community 743`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `crons.ts`
+- **Thin community `Community 744`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 745`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 746`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 747`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 748`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `env.ts`
+- **Thin community `Community 749`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `analytics.ts`
+- **Thin community `Community 750`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `auth.ts`
+- **Thin community `Community 751`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 752`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `categories.ts`
+- **Thin community `Community 753`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `colors.ts`
+- **Thin community `Community 754`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `index.ts`
+- **Thin community `Community 755`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `organizations.ts`
+- **Thin community `Community 756`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `products.ts`
+- **Thin community `Community 757`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `stores.ts`
+- **Thin community `Community 758`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 759`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `index.ts`
+- **Thin community `Community 760`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `bag.ts`
+- **Thin community `Community 761`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `guest.ts`
+- **Thin community `Community 762`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `index.ts`
+- **Thin community `Community 763`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `me.ts`
+- **Thin community `Community 764`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `offers.ts`
+- **Thin community `Community 765`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 766`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `paystack.ts`
+- **Thin community `Community 767`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `reviews.ts`
+- **Thin community `Community 768`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `rewards.ts`
+- **Thin community `Community 769`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 770`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `security.test.ts`
+- **Thin community `Community 771`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `storefront.ts`
+- **Thin community `Community 772`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `upsells.ts`
+- **Thin community `Community 773`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `user.ts`
+- **Thin community `Community 774`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 775`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `health.test.ts`
+- **Thin community `Community 776`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `http.ts`
+- **Thin community `Community 777`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 778`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `auth.ts`
+- **Thin community `Community 779`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 780`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 781`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `categories.ts`
+- **Thin community `Community 782`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `colors.ts`
+- **Thin community `Community 783`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 784`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 785`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 786`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 787`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 788`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 789`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `organizations.ts`
+- **Thin community `Community 790`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `pos.ts`
+- **Thin community `Community 791`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 792`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 793`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 794`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `productSku.ts`
+- **Thin community `Community 795`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 796`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 797`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 798`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 799`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 800`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 801`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 802`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 803`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 804`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `client.test.ts`
+- **Thin community `Community 805`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `config.test.ts`
+- **Thin community `Community 806`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 807`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `types.ts`
+- **Thin community `Community 808`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 809`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 810`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 811`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 812`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 813`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `dto.ts`
+- **Thin community `Community 814`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 815`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 816`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `openDrawer.test.ts`
+- **Thin community `Community 817`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 818`** (1 nodes): `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `types.ts`
+- **Thin community `Community 819`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 820`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `catalog.ts`
+- **Thin community `Community 821`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `customers.ts`
+- **Thin community `Community 822`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `register.ts`
+- **Thin community `Community 823`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `terminals.ts`
+- **Thin community `Community 824`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `transactions.ts`
+- **Thin community `Community 825`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `schema.ts`
+- **Thin community `Community 826`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 827`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 828`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 829`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 830`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `category.ts`
+- **Thin community `Community 831`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `color.ts`
+- **Thin community `Community 832`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 833`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 834`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `index.ts`
+- **Thin community `Community 835`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 836`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `organization.ts`
+- **Thin community `Community 837`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 838`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `product.ts`
+- **Thin community `Community 839`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 840`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 841`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `store.ts`
+- **Thin community `Community 842`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 843`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `index.ts`
+- **Thin community `Community 844`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 845`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 846`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 847`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 848`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 849`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `index.ts`
+- **Thin community `Community 850`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 851`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 852`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 853`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 854`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 855`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 856`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 857`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 858`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 859`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `customer.ts`
+- **Thin community `Community 860`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 861`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 862`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 863`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 864`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `index.ts`
+- **Thin community `Community 865`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `posSession.ts`
+- **Thin community `Community 866`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 867`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 868`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 869`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 870`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `index.ts`
+- **Thin community `Community 871`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 872`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 873`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 874`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 875`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 876`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `index.ts`
+- **Thin community `Community 877`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 878`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 879`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 880`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 881`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `vendor.ts`
+- **Thin community `Community 882`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `analytics.ts`
+- **Thin community `Community 883`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `bag.ts`
+- **Thin community `Community 884`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 885`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 886`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 887`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `customer.ts`
+- **Thin community `Community 888`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `guest.ts`
+- **Thin community `Community 889`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `index.ts`
+- **Thin community `Community 890`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `offer.ts`
+- **Thin community `Community 891`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 892`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 893`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `review.ts`
+- **Thin community `Community 894`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `rewards.ts`
+- **Thin community `Community 895`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 896`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 897`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 898`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 899`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 900`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 901`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 902`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `bag.ts`
+- **Thin community `Community 903`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 904`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `customer.ts`
+- **Thin community `Community 905`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `guest.ts`
+- **Thin community `Community 906`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 907`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 908`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `payment.ts`
+- **Thin community `Community 909`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 910`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 911`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 912`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `users.ts`
+- **Thin community `Community 913`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `payment.ts`
+- **Thin community `Community 914`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `posSale.test.ts`
+- **Thin community `Community 915`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 916`** (1 nodes): `posSale.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 917`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 918`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 919`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `index.ts`
+- **Thin community `Community 920`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 921`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `auth.ts`
+- **Thin community `Community 922`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 923`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 924`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 925`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 926`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 927`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 928`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 929`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `constants.ts`
+- **Thin community `Community 930`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 931`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 932`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 933`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `types.ts`
+- **Thin community `Community 934`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 935`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 936`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 937`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 938`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 939`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 940`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 941`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 942`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `columns.tsx`
+- **Thin community `Community 943`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 944`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 945`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 946`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 947`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `columns.tsx`
+- **Thin community `Community 948`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 949`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 950`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `chart.tsx`
+- **Thin community `Community 951`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `columns.tsx`
+- **Thin community `Community 952`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 953`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 954`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `columns.tsx`
+- **Thin community `Community 955`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `constants.ts`
+- **Thin community `Community 956`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 957`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 958`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 959`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `data.ts`
+- **Thin community `Community 960`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `columns.tsx`
+- **Thin community `Community 961`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 962`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 963`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `columns.tsx`
+- **Thin community `Community 964`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 965`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 967`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 968`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 969`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 970`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 971`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `constants.ts`
+- **Thin community `Community 972`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 973`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data.ts`
+- **Thin community `Community 976`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 977`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 978`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 979`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 980`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 981`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `columns.tsx`
+- **Thin community `Community 982`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 983`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 984`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 985`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 986`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 987`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `columns.tsx`
+- **Thin community `Community 988`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `constants.ts`
+- **Thin community `Community 989`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 990`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 991`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 992`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 994`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 995`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 996`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 997`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 998`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `columns.tsx`
+- **Thin community `Community 999`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1000`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1003`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1004`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1005`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1006`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1007`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1008`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1009`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1010`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `constants.ts`
+- **Thin community `Community 1011`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1012`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1013`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1014`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `data.ts`
+- **Thin community `Community 1015`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1016`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `constants.ts`
+- **Thin community `Community 1017`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1018`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1019`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1020`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1021`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data.ts`
+- **Thin community `Community 1022`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1023`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `constants.ts`
+- **Thin community `Community 1024`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1025`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1026`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1027`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1028`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `data.ts`
+- **Thin community `Community 1029`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1030`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1031`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1032`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1033`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1034`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1035`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1036`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1037`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1038`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1039`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1040`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1041`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1042`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1043`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1044`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1045`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1046`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1047`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1048`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1049`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1050`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1051`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `WorkflowTraceLink.test.tsx`
+- **Thin community `Community 1052`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `types.ts`
+- **Thin community `Community 1053`** (1 nodes): `WorkflowTraceLink.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1054`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1055`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1056`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1057`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1058`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1059`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 1060`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1061`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1062`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1063`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1064`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1065`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1066`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1067`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1068`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1069`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1070`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1071`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1072`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `data.ts`
+- **Thin community `Community 1073`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1074`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 1075`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1076`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1077`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1078`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1079`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1080`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1081`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1082`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1083`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1084`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1085`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `constants.ts`
+- **Thin community `Community 1086`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1087`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1089`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `data.ts`
+- **Thin community `Community 1090`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `types.ts`
+- **Thin community `Community 1091`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1092`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1093`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1094`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1095`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `index.tsx`
+- **Thin community `Community 1096`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1097`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `index.tsx`
+- **Thin community `Community 1098`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1099`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1100`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1101`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `button.tsx`
+- **Thin community `Community 1102`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1103`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `card.tsx`
+- **Thin community `Community 1104`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1105`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1106`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `command.tsx`
+- **Thin community `Community 1107`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1108`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1109`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1110`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `form.tsx`
+- **Thin community `Community 1111`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1112`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1113`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `input.tsx`
+- **Thin community `Community 1114`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1115`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1116`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1117`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1118`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1119`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `select.tsx`
+- **Thin community `Community 1120`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1121`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1122`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1123`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `table.tsx`
+- **Thin community `Community 1124`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1125`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1126`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1127`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1128`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1129`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1130`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1131`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1132`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `constants.ts`
+- **Thin community `Community 1133`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1134`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1135`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `data.ts`
+- **Thin community `Community 1137`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1138`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1139`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1140`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1141`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1142`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1143`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1144`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1145`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1146`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1147`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1148`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1149`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1150`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `index.ts`
+- **Thin community `Community 1151`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `config.ts`
+- **Thin community `Community 1152`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1153`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1154`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1155`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1156`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `aws.ts`
+- **Thin community `Community 1157`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `constants.ts`
+- **Thin community `Community 1158`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `countries.ts`
+- **Thin community `Community 1159`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1160`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1161`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1162`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1163`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1164`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `dto.ts`
+- **Thin community `Community 1165`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `ports.ts`
+- **Thin community `Community 1166`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `constants.ts`
+- **Thin community `Community 1167`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1168`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1169`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `index.ts`
+- **Thin community `Community 1170`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1171`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `types.ts`
+- **Thin community `Community 1172`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1173`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1174`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1175`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1176`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1177`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1178`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `category.ts`
+- **Thin community `Community 1179`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `product.ts`
+- **Thin community `Community 1180`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `store.ts`
+- **Thin community `Community 1181`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1182`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `user.ts`
+- **Thin community `Community 1183`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1185`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1187`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1188`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `index.tsx`
+- **Thin community `Community 1189`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1190`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1191`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1192`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1193`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1194`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1195`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1196`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `index.tsx`
+- **Thin community `Community 1197`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1198`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1199`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1200`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `home.tsx`
+- **Thin community `Community 1201`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1202`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1203`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1204`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `index.tsx`
+- **Thin community `Community 1205`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1206`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1207`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1208`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1209`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `index.tsx`
+- **Thin community `Community 1210`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1211`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1212`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1213`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1214`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1215`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1216`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1217`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `index.tsx`
+- **Thin community `Community 1218`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1219`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1220`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1221`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1222`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1223`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1224`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `index.tsx`
+- **Thin community `Community 1225`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1226`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `new.tsx`
+- **Thin community `Community 1227`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `index.tsx`
+- **Thin community `Community 1228`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `new.tsx`
+- **Thin community `Community 1229`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1230`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1231`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `new.tsx`
+- **Thin community `Community 1233`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `index.tsx`
+- **Thin community `Community 1234`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1235`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1236`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1237`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1238`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1239`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1240`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1241`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `index.tsx`
+- **Thin community `Community 1242`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1243`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1244`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1245`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1246`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1247`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1248`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1249`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1250`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1251`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1252`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1253`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1254`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1255`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1256`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1257`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1258`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1259`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1260`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `setup.ts`
+- **Thin community `Community 1261`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1262`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1263`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `types.ts`
+- **Thin community `Community 1264`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1265`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1266`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1267`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1268`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1269`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `types.ts`
+- **Thin community `Community 1270`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1271`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1272`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1273`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1274`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1275`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1276`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1278`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1279`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `schema.ts`
+- **Thin community `Community 1280`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1281`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1285`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1286`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1287`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1288`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1289`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `types.ts`
+- **Thin community `Community 1290`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1291`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1292`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1294`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1295`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1297`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `constants.ts`
+- **Thin community `Community 1298`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1299`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `About.tsx`
+- **Thin community `Community 1300`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1301`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1302`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1303`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1304`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1305`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1306`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1307`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1308`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1309`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `types.ts`
+- **Thin community `Community 1310`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1311`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1312`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1313`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1315`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1316`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1317`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1318`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1319`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1320`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `button.tsx`
+- **Thin community `Community 1321`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `card.tsx`
+- **Thin community `Community 1322`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1323`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `command.tsx`
+- **Thin community `Community 1324`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1325`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1326`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1327`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `form.tsx`
+- **Thin community `Community 1328`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1329`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1330`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1331`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1332`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `input.tsx`
+- **Thin community `Community 1333`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `label.tsx`
+- **Thin community `Community 1334`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1335`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1336`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1337`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `index.ts`
+- **Thin community `Community 1338`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `types.ts`
+- **Thin community `Community 1339`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1340`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1341`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1342`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1343`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `select.tsx`
+- **Thin community `Community 1344`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1345`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1346`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `table.tsx`
+- **Thin community `Community 1347`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1348`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1349`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1350`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1351`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1352`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `config.ts`
+- **Thin community `Community 1353`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1354`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1355`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1356`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `constants.ts`
+- **Thin community `Community 1357`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `countries.ts`
+- **Thin community `Community 1358`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1359`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1360`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1361`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `index.ts`
+- **Thin community `Community 1363`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `store.ts`
+- **Thin community `Community 1364`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `bag.ts`
+- **Thin community `Community 1365`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1366`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `category.ts`
+- **Thin community `Community 1367`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `organization.ts`
+- **Thin community `Community 1368`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `product.ts`
+- **Thin community `Community 1369`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `store.ts`
+- **Thin community `Community 1370`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1371`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `user.ts`
+- **Thin community `Community 1372`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `states.ts`
+- **Thin community `Community 1373`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1374`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1375`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1376`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1377`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1378`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1379`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1380`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `index.tsx`
+- **Thin community `Community 1381`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1382`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `index.tsx`
+- **Thin community `Community 1383`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1384`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1385`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1386`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1387`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1388`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `index.tsx`
+- **Thin community `Community 1389`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1390`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1391`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1392`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1393`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `index.js`
+- **Thin community `Community 1394`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1395`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1396`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1397`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1398`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1399`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1007,7 +1007,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L792",
+      "source_location": "L795",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1019,7 +1019,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L719",
+      "source_location": "L720",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1031,7 +1031,7 @@
       "relation": "calls",
       "source": "completetransaction_persistworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L778",
+      "source_location": "L779",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1043,7 +1043,7 @@
       "relation": "calls",
       "source": "completetransaction_recordpossaletracebesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L772",
+      "source_location": "L773",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1055,7 +1055,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L783",
+      "source_location": "L785",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1067,7 +1067,7 @@
       "relation": "calls",
       "source": "completetransaction_resolvesessionregistersessionid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L678",
+      "source_location": "L679",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -7751,7 +7751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L181",
+      "source_location": "L185",
       "target": "possessions_trace_test_buildsession",
       "weight": 1
     },
@@ -7763,7 +7763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L77",
+      "source_location": "L81",
       "target": "possessions_trace_test_createmutationctx",
       "weight": 1
     },
@@ -7775,7 +7775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L197",
+      "source_location": "L201",
       "target": "possessions_trace_test_gethandler",
       "weight": 1
     },
@@ -48835,7 +48835,7 @@
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L181"
+      "source_location": "L185"
     },
     {
       "community": 181,
@@ -48844,7 +48844,7 @@
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L77"
+      "source_location": "L81"
     },
     {
       "community": 181,
@@ -48853,7 +48853,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L197"
+      "source_location": "L201"
     },
     {
       "community": 182,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -947,7 +947,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L487",
+      "source_location": "L503",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -959,7 +959,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L417",
+      "source_location": "L433",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -971,7 +971,7 @@
       "relation": "calls",
       "source": "completetransaction_persistworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L471",
+      "source_location": "L487",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -983,7 +983,7 @@
       "relation": "calls",
       "source": "completetransaction_recordpossaletracebesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L465",
+      "source_location": "L481",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -995,7 +995,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L477",
+      "source_location": "L493",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1007,7 +1007,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L760",
+      "source_location": "L792",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1019,7 +1019,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L688",
+      "source_location": "L719",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1031,7 +1031,7 @@
       "relation": "calls",
       "source": "completetransaction_persistworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L746",
+      "source_location": "L778",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1043,7 +1043,7 @@
       "relation": "calls",
       "source": "completetransaction_recordpossaletracebesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L740",
+      "source_location": "L772",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1055,7 +1055,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L751",
+      "source_location": "L783",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1067,7 +1067,7 @@
       "relation": "calls",
       "source": "completetransaction_resolvesessionregistersessionid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L657",
+      "source_location": "L678",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1079,7 +1079,7 @@
       "relation": "calls",
       "source": "completetransaction_safetracewrite",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L238",
+      "source_location": "L239",
       "target": "completetransaction_persistworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -1091,7 +1091,7 @@
       "relation": "calls",
       "source": "completetransaction_buildpossaletraceevent",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L200",
+      "source_location": "L201",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -1103,7 +1103,7 @@
       "relation": "calls",
       "source": "completetransaction_buildpossaletracerecord",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L199",
+      "source_location": "L200",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -1115,7 +1115,7 @@
       "relation": "calls",
       "source": "completetransaction_normalizeregisternumber",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L90",
+      "source_location": "L91",
       "target": "completetransaction_registersessionmatchesidentity",
       "weight": 1
     },
@@ -1127,7 +1127,7 @@
       "relation": "calls",
       "source": "completetransaction_isusableregistersession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L272",
+      "source_location": "L279",
       "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
@@ -1139,7 +1139,7 @@
       "relation": "calls",
       "source": "completetransaction_registersessionmatchesidentity",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L273",
+      "source_location": "L280",
       "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
@@ -1151,7 +1151,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionvoid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L593",
+      "source_location": "L602",
       "target": "completetransaction_voidtransaction",
       "weight": 1
     },
@@ -1273,6 +1273,30 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
       "source_location": "L75",
       "target": "customerengagementevents_recordstorefrontcustomermilestone",
+      "weight": 1
+    },
+    {
+      "_src": "customerinfopanel_handlecreatecustomer",
+      "_tgt": "customerinfopanel_showcommanderror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "customerinfopanel_showcommanderror",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L100",
+      "target": "customerinfopanel_handlecreatecustomer",
+      "weight": 1
+    },
+    {
+      "_src": "customerinfopanel_handlesaveedit",
+      "_tgt": "customerinfopanel_showcommanderror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "customerinfopanel_showcommanderror",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L143",
+      "target": "customerinfopanel_handlesaveedit",
       "weight": 1
     },
     {
@@ -7708,6 +7732,18 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_convex_inventory_possessionitems_ts",
+      "_tgt": "possessionitems_usererrorfromsessionitemfailure",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_possessionitems_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
+      "source_location": "L22",
+      "target": "possessionitems_usererrorfromsessionitemfailure",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "_tgt": "possessions_trace_test_buildsession",
       "confidence": "EXTRACTED",
@@ -7751,7 +7787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L193",
+      "source_location": "L244",
       "target": "possessions_hascustomersnapshotvalue",
       "weight": 1
     },
@@ -7763,7 +7799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L65",
+      "source_location": "L116",
       "target": "possessions_listpossessionsbystatusbefore",
       "weight": 1
     },
@@ -7775,7 +7811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L91",
+      "source_location": "L142",
       "target": "possessions_listpossessionsforstorestatus",
       "weight": 1
     },
@@ -7787,7 +7823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L43",
+      "source_location": "L94",
       "target": "possessions_loadpossessionitems",
       "weight": 1
     },
@@ -7799,7 +7835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L178",
+      "source_location": "L229",
       "target": "possessions_normalizecustomersnapshot",
       "weight": 1
     },
@@ -7811,7 +7847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L117",
+      "source_location": "L168",
       "target": "possessions_persistsessionworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -7823,7 +7859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L138",
+      "source_location": "L189",
       "target": "possessions_recordsessionlifecycletracebesteffort",
       "weight": 1
     },
@@ -7835,8 +7871,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L202",
+      "source_location": "L253",
       "target": "possessions_resolvecustomertracestage",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "_tgt": "possessions_usererrorfromsessioncommandfailure",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L53",
+      "target": "possessions_usererrorfromsessioncommandfailure",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "_tgt": "possessions_usererrorfromvalidationmessage",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L80",
+      "target": "possessions_usererrorfromvalidationmessage",
       "weight": 1
     },
     {
@@ -8365,6 +8425,18 @@
       "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
       "source_location": "L100",
       "target": "athenauserauth_syncauthenticatedathenauserwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
+      "_tgt": "commandresultvalidators_commandresultvalidator",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
+      "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.ts",
+      "source_location": "L22",
+      "target": "commandresultvalidators_commandresultvalidator",
       "weight": 1
     },
     {
@@ -9971,7 +10043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L17",
+      "source_location": "L18",
       "target": "assigncustomer_createcustomer",
       "weight": 1
     },
@@ -9983,7 +10055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L150",
+      "source_location": "L176",
       "target": "assigncustomer_linktoguest",
       "weight": 1
     },
@@ -9995,7 +10067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111",
+      "source_location": "L133",
       "target": "assigncustomer_linktostorefrontuser",
       "weight": 1
     },
@@ -10007,7 +10079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L72",
+      "source_location": "L86",
       "target": "assigncustomer_updatecustomer",
       "weight": 1
     },
@@ -10019,7 +10091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L95",
+      "source_location": "L117",
       "target": "assigncustomer_updatecustomerstats",
       "weight": 1
     },
@@ -10031,7 +10103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L50",
+      "source_location": "L51",
       "target": "completetransaction_buildcompletetransactionresult",
       "weight": 1
     },
@@ -10043,7 +10115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L150",
+      "source_location": "L151",
       "target": "completetransaction_buildpossaletraceevent",
       "weight": 1
     },
@@ -10055,7 +10127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L129",
+      "source_location": "L130",
       "target": "completetransaction_buildpossaletracerecord",
       "weight": 1
     },
@@ -10067,7 +10139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L71",
+      "source_location": "L72",
       "target": "completetransaction_calculatetotalpaid",
       "weight": 1
     },
@@ -10079,7 +10151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L364",
+      "source_location": "L374",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -10091,7 +10163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L638",
+      "source_location": "L647",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -10103,7 +10175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L114",
+      "source_location": "L115",
       "target": "completetransaction_isusableregistersession",
       "weight": 1
     },
@@ -10115,7 +10187,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L75",
+      "source_location": "L76",
       "target": "completetransaction_normalizeregisternumber",
       "weight": 1
     },
@@ -10127,7 +10199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L226",
+      "source_location": "L227",
       "target": "completetransaction_persistworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -10139,7 +10211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L190",
+      "source_location": "L191",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -10151,7 +10223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L284",
+      "source_location": "L294",
       "target": "completetransaction_recordregistersessionsale",
       "weight": 1
     },
@@ -10163,7 +10235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L309",
+      "source_location": "L319",
       "target": "completetransaction_recordregistersessionvoid",
       "weight": 1
     },
@@ -10175,7 +10247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "target": "completetransaction_registersessionmatchesidentity",
       "weight": 1
     },
@@ -10187,7 +10259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L245",
+      "source_location": "L246",
       "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
@@ -10199,7 +10271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L118",
+      "source_location": "L119",
       "target": "completetransaction_safetracewrite",
       "weight": 1
     },
@@ -10211,7 +10283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L334",
+      "source_location": "L344",
       "target": "completetransaction_updateinventory",
       "weight": 1
     },
@@ -10223,7 +10295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L569",
+      "source_location": "L578",
       "target": "completetransaction_voidtransaction",
       "weight": 1
     },
@@ -17795,7 +17867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L164",
+      "source_location": "L167",
       "target": "customerinfopanel_clearcustomer",
       "weight": 1
     },
@@ -17807,7 +17879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L155",
+      "source_location": "L158",
       "target": "customerinfopanel_handlecanceledit",
       "weight": 1
     },
@@ -17819,7 +17891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L82",
+      "source_location": "L86",
       "target": "customerinfopanel_handlecreatecustomer",
       "weight": 1
     },
@@ -17831,7 +17903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L122",
+      "source_location": "L125",
       "target": "customerinfopanel_handlesaveedit",
       "weight": 1
     },
@@ -17843,7 +17915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L62",
+      "source_location": "L66",
       "target": "customerinfopanel_handleselectcustomer",
       "weight": 1
     },
@@ -17855,8 +17927,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L112",
+      "source_location": "L115",
       "target": "customerinfopanel_handlestartedit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
+      "_tgt": "customerinfopanel_showcommanderror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L62",
+      "target": "customerinfopanel_showcommanderror",
       "weight": 1
     },
     {
@@ -22535,7 +22619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L16",
+      "source_location": "L20",
       "target": "customergateway_useconvexposcustomercreate",
       "weight": 1
     },
@@ -22547,7 +22631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L6",
+      "source_location": "L10",
       "target": "customergateway_useconvexposcustomersearch",
       "weight": 1
     },
@@ -22655,7 +22739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L25",
+      "source_location": "L38",
       "target": "sessiongateway_useconvexactivesession",
       "weight": 1
     },
@@ -22667,7 +22751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L52",
+      "source_location": "L65",
       "target": "sessiongateway_useconvexheldsessions",
       "weight": 1
     },
@@ -22679,7 +22763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L78",
+      "source_location": "L91",
       "target": "sessiongateway_useconvexsessionactions",
       "weight": 1
     },
@@ -30359,7 +30443,7 @@
       "relation": "calls",
       "source": "possessions_persistsessionworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L160",
+      "source_location": "L211",
       "target": "possessions_recordsessionlifecycletracebesteffort",
       "weight": 1
     },
@@ -30371,7 +30455,7 @@
       "relation": "calls",
       "source": "possessions_hascustomersnapshotvalue",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L224",
+      "source_location": "L275",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -30383,7 +30467,7 @@
       "relation": "calls",
       "source": "possessions_normalizecustomersnapshot",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L211",
+      "source_location": "L262",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -39972,6 +40056,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -39979,7 +40072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -39988,7 +40081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -39997,7 +40090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -40006,7 +40099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -40015,7 +40108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -40024,7 +40117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -40033,7 +40126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -40042,21 +40135,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1"
     },
     {
@@ -40066,7 +40150,7 @@
       "label": "createCustomer()",
       "norm_label": "createcustomer()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L17"
+      "source_location": "L18"
     },
     {
       "community": 101,
@@ -40075,7 +40159,7 @@
       "label": "linkToGuest()",
       "norm_label": "linktoguest()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L150"
+      "source_location": "L176"
     },
     {
       "community": 101,
@@ -40084,7 +40168,7 @@
       "label": "linkToStoreFrontUser()",
       "norm_label": "linktostorefrontuser()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "source_location": "L133"
     },
     {
       "community": 101,
@@ -40093,7 +40177,7 @@
       "label": "updateCustomer()",
       "norm_label": "updatecustomer()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L72"
+      "source_location": "L86"
     },
     {
       "community": 101,
@@ -40102,7 +40186,7 @@
       "label": "updateCustomerStats()",
       "norm_label": "updatecustomerstats()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L95"
+      "source_location": "L117"
     },
     {
       "community": 101,
@@ -40116,6 +40200,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
       "norm_label": "returnexchangeview.test.tsx",
@@ -40123,7 +40216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -40132,7 +40225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -40141,7 +40234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -40150,7 +40243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -40159,7 +40252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -40168,7 +40261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -40177,7 +40270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -40186,21 +40279,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -40260,6 +40344,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -40267,7 +40360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -40276,7 +40369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -40285,7 +40378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -40294,7 +40387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -40303,7 +40396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -40312,7 +40405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -40321,7 +40414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -40330,21 +40423,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -40404,6 +40488,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
       "norm_label": "memberscolumns.tsx",
@@ -40411,7 +40504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -40420,7 +40513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -40429,7 +40522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -40438,7 +40531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -40447,7 +40540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -40456,7 +40549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -40465,7 +40558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -40474,21 +40567,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
       "norm_label": "searchresultssection.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
-      "label": "SessionManager.test.tsx",
-      "norm_label": "sessionmanager.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
       "source_location": "L1"
     },
     {
@@ -40548,6 +40632,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
+      "label": "SessionManager.test.tsx",
+      "norm_label": "sessionmanager.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
       "norm_label": "sessionmanager.tsx",
@@ -40555,7 +40648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -40564,7 +40657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -40573,7 +40666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -40582,7 +40675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -40591,7 +40684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -40600,7 +40693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -40609,7 +40702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -40618,21 +40711,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
       "norm_label": "heldsessionslist.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
-      "label": "TransactionView.test.tsx",
-      "norm_label": "transactionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -40692,6 +40776,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
+      "label": "TransactionView.test.tsx",
+      "norm_label": "transactionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
       "norm_label": "transactionview.tsx",
@@ -40699,7 +40792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -40708,7 +40801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_test_tsx",
       "label": "WorkflowTraceLink.test.tsx",
@@ -40717,7 +40810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -40726,7 +40819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -40735,7 +40828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -40744,7 +40837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -40753,7 +40846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -40762,21 +40855,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
       "norm_label": "detailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1"
     },
     {
@@ -40836,6 +40920,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
       "norm_label": "productstatus.tsx",
@@ -40843,7 +40936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -40852,7 +40945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -40861,7 +40954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -40870,7 +40963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -40879,7 +40972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -40888,7 +40981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -40897,7 +40990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -40906,21 +40999,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -40980,6 +41064,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -40987,7 +41080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -40996,7 +41089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -41005,7 +41098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -41014,7 +41107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -41023,7 +41116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -41032,7 +41125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -41041,7 +41134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -41050,21 +41143,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
       "norm_label": "captured-emails-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -41124,6 +41208,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
@@ -41131,7 +41224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -41140,7 +41233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -41149,7 +41242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -41158,7 +41251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -41167,7 +41260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -41176,7 +41269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -41185,7 +41278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -41194,21 +41287,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -41268,6 +41352,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -41275,7 +41368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -41284,7 +41377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -41293,7 +41386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -41302,7 +41395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -41311,7 +41404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -41320,7 +41413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -41329,7 +41422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -41338,21 +41431,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
-      "label": "WorkflowTraceView.test.tsx",
-      "norm_label": "workflowtraceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -41592,6 +41676,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
+      "label": "WorkflowTraceView.test.tsx",
+      "norm_label": "workflowtraceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
@@ -41599,7 +41692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -41608,7 +41701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -41617,7 +41710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -41626,7 +41719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -41635,7 +41728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -41644,7 +41737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -41653,7 +41746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -41662,21 +41755,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -41736,6 +41820,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
@@ -41743,7 +41836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -41752,7 +41845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -41761,7 +41854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -41770,7 +41863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -41779,7 +41872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -41788,7 +41881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -41797,7 +41890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -41806,7 +41899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -41815,160 +41908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 112,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1120,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -41977,7 +41917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -41986,7 +41926,7 @@
       "source_location": "L147"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -41995,7 +41935,7 @@
       "source_location": "L105"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -42004,7 +41944,7 @@
       "source_location": "L224"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -42013,7 +41953,7 @@
       "source_location": "L228"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -42022,97 +41962,97 @@
       "source_location": "L45"
     },
     {
-      "community": 1130,
+      "community": 1120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "label": "upload-button.tsx",
-      "norm_label": "upload-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "label": "BagView.tsx",
-      "norm_label": "bagview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "id": "packages_athena_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1122,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
+      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1123,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1124,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1125,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1127,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1128,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1139,
+      "community": 1129,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -42121,7 +42061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -42130,7 +42070,7 @@
       "source_location": "L56"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -42139,7 +42079,7 @@
       "source_location": "L87"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -42148,7 +42088,7 @@
       "source_location": "L101"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -42157,7 +42097,7 @@
       "source_location": "L158"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -42166,97 +42106,97 @@
       "source_location": "L139"
     },
     {
-      "community": 1140,
+      "community": 1130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_upload_button_tsx",
+      "label": "upload-button.tsx",
+      "norm_label": "upload-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
+      "label": "BagView.tsx",
+      "norm_label": "bagview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1137,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1145,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1138,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "label": "LinkedAccounts.tsx",
-      "norm_label": "linkedaccounts.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1139,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "label": "TimelineEventCard.test.tsx",
-      "norm_label": "timelineeventcard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -42265,7 +42205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -42274,7 +42214,7 @@
       "source_location": "L41"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -42283,7 +42223,7 @@
       "source_location": "L31"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -42292,7 +42232,7 @@
       "source_location": "L61"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -42301,7 +42241,7 @@
       "source_location": "L98"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -42310,97 +42250,97 @@
       "source_location": "L9"
     },
     {
-      "community": 1150,
+      "community": 1140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1144,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1145,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
-      "label": "useAuth.test.tsx",
-      "norm_label": "useauth.test.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1146,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1147,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
+      "label": "LinkedAccounts.tsx",
+      "norm_label": "linkedaccounts.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1148,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
+      "label": "TimelineEventCard.test.tsx",
+      "norm_label": "timelineeventcard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 1149,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/src/lib/countries.ts",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -42409,7 +42349,7 @@
       "source_location": "L173"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -42418,7 +42358,7 @@
       "source_location": "L71"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -42427,7 +42367,7 @@
       "source_location": "L251"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -42436,7 +42376,7 @@
       "source_location": "L36"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -42445,7 +42385,7 @@
       "source_location": "L277"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -42454,97 +42394,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1160,
+      "community": 1150,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
-      "label": "presentCommandToast.test.ts",
-      "norm_label": "presentcommandtoast.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1151,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
-      "label": "runCommand.test.ts",
-      "norm_label": "runcommand.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1153,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1154,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
-      "label": "bootstrapRegister.test.ts",
-      "norm_label": "bootstrapregister.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1155,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1156,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
+      "label": "useAuth.test.tsx",
+      "norm_label": "useauth.test.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1157,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1158,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
-      "label": "displayAmounts.test.ts",
-      "norm_label": "displayamounts.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
-      "label": "cart.test.ts",
-      "norm_label": "cart.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -42553,7 +42493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -42562,7 +42502,7 @@
       "source_location": "L107"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -42571,7 +42511,7 @@
       "source_location": "L63"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -42580,7 +42520,7 @@
       "source_location": "L80"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -42589,7 +42529,7 @@
       "source_location": "L46"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -42598,97 +42538,97 @@
       "source_location": "L97"
     },
     {
-      "community": 1170,
+      "community": 1160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
+      "id": "packages_athena_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/src/lib/countries.ts",
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1161,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
-      "label": "session.test.ts",
-      "norm_label": "session.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
+      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
+      "label": "presentCommandToast.test.ts",
+      "norm_label": "presentcommandtoast.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1162,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
+      "label": "runCommand.test.ts",
+      "norm_label": "runcommand.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1163,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1164,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
-      "label": "sessionGateway.test.ts",
-      "norm_label": "sessiongateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1165,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
-      "label": "loggerGateway.ts",
-      "norm_label": "loggergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "label": "bootstrapRegister.test.ts",
+      "norm_label": "bootstrapregister.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1166,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
-      "label": "registerUiState.ts",
-      "norm_label": "registeruistate.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1167,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1168,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1169,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -42697,7 +42637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -42706,7 +42646,7 @@
       "source_location": "L3"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -42715,7 +42655,7 @@
       "source_location": "L20"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -42724,7 +42664,7 @@
       "source_location": "L14"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -42733,7 +42673,7 @@
       "source_location": "L7"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -42742,97 +42682,97 @@
       "source_location": "L27"
     },
     {
-      "community": 1180,
+      "community": 1170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
+      "label": "cart.test.ts",
+      "norm_label": "cart.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1171,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1172,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
+      "label": "session.test.ts",
+      "norm_label": "session.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1173,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1174,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1175,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
+      "label": "sessionGateway.test.ts",
+      "norm_label": "sessiongateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1176,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
+      "label": "loggerGateway.ts",
+      "norm_label": "loggergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1177,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
+      "label": "registerUiState.ts",
+      "norm_label": "registeruistate.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1178,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 1179,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -42841,7 +42781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -42850,7 +42790,7 @@
       "source_location": "L27"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -42859,7 +42799,7 @@
       "source_location": "L36"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -42868,7 +42808,7 @@
       "source_location": "L11"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -42877,7 +42817,7 @@
       "source_location": "L5"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -42886,7 +42826,160 @@
       "source_location": "L48"
     },
     {
+      "community": 1180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1185,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1186,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "label": "useRegisterViewModel.ts",
+      "norm_label": "useregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "useregisterviewmodel_createpaymentid",
+      "label": "createPaymentId()",
+      "norm_label": "createpaymentid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "useregisterviewmodel_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "useregisterviewmodel_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "useregisterviewmodel_useregisterviewmodel",
+      "label": "useRegisterViewModel()",
+      "norm_label": "useregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L96"
+    },
+    {
       "community": 1190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -42895,7 +42988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -42904,7 +42997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -42913,7 +43006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -42922,7 +43015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -42931,7 +43024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -42940,7 +43033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -42949,7 +43042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -42958,21 +43051,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
       "norm_label": "checkout-sessions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1"
     },
     {
@@ -42982,7 +43066,7 @@
       "label": "buildCompleteTransactionResult()",
       "norm_label": "buildcompletetransactionresult()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L50"
+      "source_location": "L51"
     },
     {
       "community": 12,
@@ -42991,7 +43075,7 @@
       "label": "buildPosSaleTraceEvent()",
       "norm_label": "buildpossaletraceevent()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L150"
+      "source_location": "L151"
     },
     {
       "community": 12,
@@ -43000,7 +43084,7 @@
       "label": "buildPosSaleTraceRecord()",
       "norm_label": "buildpossaletracerecord()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L129"
+      "source_location": "L130"
     },
     {
       "community": 12,
@@ -43009,7 +43093,7 @@
       "label": "calculateTotalPaid()",
       "norm_label": "calculatetotalpaid()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L71"
+      "source_location": "L72"
     },
     {
       "community": 12,
@@ -43027,7 +43111,7 @@
       "label": "createTransactionFromSessionHandler()",
       "norm_label": "createtransactionfromsessionhandler()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L638"
+      "source_location": "L647"
     },
     {
       "community": 12,
@@ -43036,7 +43120,7 @@
       "label": "isUsableRegisterSession()",
       "norm_label": "isusableregistersession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L114"
+      "source_location": "L115"
     },
     {
       "community": 12,
@@ -43045,7 +43129,7 @@
       "label": "normalizeRegisterNumber()",
       "norm_label": "normalizeregisternumber()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L75"
+      "source_location": "L76"
     },
     {
       "community": 12,
@@ -43054,7 +43138,7 @@
       "label": "persistWorkflowTraceIdBestEffort()",
       "norm_label": "persistworkflowtraceidbesteffort()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L226"
+      "source_location": "L227"
     },
     {
       "community": 12,
@@ -43063,7 +43147,7 @@
       "label": "recordPosSaleTraceBestEffort()",
       "norm_label": "recordpossaletracebesteffort()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L190"
+      "source_location": "L191"
     },
     {
       "community": 12,
@@ -43072,7 +43156,7 @@
       "label": "recordRegisterSessionSale()",
       "norm_label": "recordregistersessionsale()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L284"
+      "source_location": "L294"
     },
     {
       "community": 12,
@@ -43081,7 +43165,7 @@
       "label": "recordRegisterSessionVoid()",
       "norm_label": "recordregistersessionvoid()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L309"
+      "source_location": "L319"
     },
     {
       "community": 12,
@@ -43090,7 +43174,7 @@
       "label": "registerSessionMatchesIdentity()",
       "norm_label": "registersessionmatchesidentity()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L80"
+      "source_location": "L81"
     },
     {
       "community": 12,
@@ -43099,7 +43183,7 @@
       "label": "resolveSessionRegisterSessionId()",
       "norm_label": "resolvesessionregistersessionid()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L245"
+      "source_location": "L246"
     },
     {
       "community": 12,
@@ -43108,7 +43192,7 @@
       "label": "safeTraceWrite()",
       "norm_label": "safetracewrite()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L118"
+      "source_location": "L119"
     },
     {
       "community": 12,
@@ -43117,7 +43201,7 @@
       "label": "updateInventory()",
       "norm_label": "updateinventory()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L334"
+      "source_location": "L344"
     },
     {
       "community": 12,
@@ -43126,7 +43210,7 @@
       "label": "voidTransaction()",
       "norm_label": "voidtransaction()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L569"
+      "source_location": "L578"
     },
     {
       "community": 12,
@@ -43149,150 +43233,6 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
-      "label": "useRegisterViewModel.ts",
-      "norm_label": "useregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "useregisterviewmodel_createpaymentid",
-      "label": "createPaymentId()",
-      "norm_label": "createpaymentid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "useregisterviewmodel_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "useregisterviewmodel_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "useregisterviewmodel_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "useregisterviewmodel_useregisterviewmodel",
-      "label": "useRegisterViewModel()",
-      "norm_label": "useregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 1200,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1201,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "label": "logs.$logId.tsx",
-      "norm_label": "logs.$logid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1203,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1204,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "label": "members.index.tsx",
-      "norm_label": "members.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1205,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1206,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1207,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "label": "all.index.tsx",
-      "norm_label": "all.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "label": "cancelled.index.tsx",
-      "norm_label": "cancelled.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
       "norm_label": "toastservice.ts",
@@ -43300,7 +43240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -43309,7 +43249,7 @@
       "source_location": "L171"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -43318,7 +43258,7 @@
       "source_location": "L302"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -43327,7 +43267,7 @@
       "source_location": "L319"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -43336,7 +43276,7 @@
       "source_location": "L312"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -43345,97 +43285,97 @@
       "source_location": "L293"
     },
     {
-      "community": 1210,
+      "community": 1200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1203,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
+      "label": "logs.$logId.tsx",
+      "norm_label": "logs.$logid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1205,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
+      "label": "members.index.tsx",
+      "norm_label": "members.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1206,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1207,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1212,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1213,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1214,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1215,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1216,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1217,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "label": "expense.index.tsx",
-      "norm_label": "expense.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 1208,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
+      "label": "all.index.tsx",
+      "norm_label": "all.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 122,
+      "community": 1209,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
+      "label": "cancelled.index.tsx",
+      "norm_label": "cancelled.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -43444,7 +43384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -43453,7 +43393,7 @@
       "source_location": "L12"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -43462,7 +43402,7 @@
       "source_location": "L21"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -43471,7 +43411,7 @@
       "source_location": "L101"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -43480,7 +43420,7 @@
       "source_location": "L35"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -43489,97 +43429,97 @@
       "source_location": "L66"
     },
     {
-      "community": 1220,
+      "community": 1210,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1211,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1222,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1223,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1224,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1225,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1212,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1213,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1214,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1215,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1216,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1217,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1218,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
+      "label": "expense.index.tsx",
+      "norm_label": "expense.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1219,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -43588,7 +43528,7 @@
       "source_location": "L156"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -43597,7 +43537,7 @@
       "source_location": "L198"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -43606,7 +43546,7 @@
       "source_location": "L105"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -43615,7 +43555,7 @@
       "source_location": "L24"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -43624,7 +43564,7 @@
       "source_location": "L71"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -43633,97 +43573,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1230,
+      "community": 1220,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1221,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1222,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1223,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1224,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1225,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1226,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1227,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1228,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1229,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1235,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "label": "new.index.tsx",
-      "norm_label": "new.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1236,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
-      "label": "active-cases.index.tsx",
-      "norm_label": "active-cases.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1237,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
-      "label": "appointments.index.tsx",
-      "norm_label": "appointments.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -43732,7 +43672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -43741,7 +43681,7 @@
       "source_location": "L232"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -43750,7 +43690,7 @@
       "source_location": "L167"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -43759,7 +43699,7 @@
       "source_location": "L116"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -43768,7 +43708,7 @@
       "source_location": "L82"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -43777,97 +43717,97 @@
       "source_location": "L28"
     },
     {
-      "community": 1240,
+      "community": 1230,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
-      "label": "$traceId.test.tsx",
-      "norm_label": "$traceid.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1231,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1232,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1233,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1234,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
-      "label": "_authed.test.tsx",
-      "norm_label": "_authed.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1235,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
-      "label": "join-team.index.tsx",
-      "norm_label": "join-team.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1236,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
-      "label": "_layout.index.test.tsx",
-      "norm_label": "_layout.index.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
+      "label": "new.index.tsx",
+      "norm_label": "new.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1237,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
-      "label": "_layout.test.tsx",
-      "norm_label": "_layout.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
+      "label": "active-cases.index.tsx",
+      "norm_label": "active-cases.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1238,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "label": "StoresSettingsAccordion.tsx",
-      "norm_label": "storessettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
+      "label": "appointments.index.tsx",
+      "norm_label": "appointments.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1239,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "label": "expenseStore.ts",
-      "norm_label": "expensestore.ts",
-      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -43876,7 +43816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -43885,7 +43825,7 @@
       "source_location": "L83"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -43894,7 +43834,7 @@
       "source_location": "L62"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -43903,7 +43843,7 @@
       "source_location": "L95"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -43912,7 +43852,7 @@
       "source_location": "L41"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -43921,97 +43861,97 @@
       "source_location": "L12"
     },
     {
-      "community": 1250,
+      "community": 1240,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1241,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
+      "label": "$traceId.test.tsx",
+      "norm_label": "$traceid.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1242,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1243,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1244,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
-      "label": "AdminShell.stories.tsx",
-      "norm_label": "adminshell.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
+      "label": "_authed.test.tsx",
+      "norm_label": "_authed.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1245,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
-      "label": "admin-shell-patterns.test.tsx",
-      "norm_label": "admin-shell-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
+      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
+      "label": "join-team.index.tsx",
+      "norm_label": "join-team.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1246,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
-      "label": "Surfaces.stories.tsx",
-      "norm_label": "surfaces.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
+      "label": "_layout.index.test.tsx",
+      "norm_label": "_layout.index.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1247,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
+      "label": "_layout.test.tsx",
+      "norm_label": "_layout.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1248,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
+      "label": "StoresSettingsAccordion.tsx",
+      "norm_label": "storessettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1249,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "id": "packages_athena_webapp_src_stores_expensestore_ts",
+      "label": "expenseStore.ts",
+      "norm_label": "expensestore.ts",
+      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -44020,7 +43960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -44029,7 +43969,7 @@
       "source_location": "L4"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -44038,7 +43978,7 @@
       "source_location": "L49"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -44047,7 +43987,7 @@
       "source_location": "L34"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -44056,7 +43996,7 @@
       "source_location": "L74"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -44065,97 +44005,97 @@
       "source_location": "L6"
     },
     {
-      "community": 1260,
+      "community": 1250,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
-      "label": "reference-fixtures.test.tsx",
-      "norm_label": "reference-fixtures.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1251,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_test_setup_ts",
-      "label": "setup.ts",
-      "norm_label": "setup.ts",
-      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1252,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "label": "usePrint.test.ts",
-      "norm_label": "useprint.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1253,
       "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1254,
       "file_type": "code",
-      "id": "packages_athena_webapp_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/types.ts",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1255,
       "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
+      "label": "AdminShell.stories.tsx",
+      "norm_label": "adminshell.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1256,
       "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1257,
       "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
+      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
+      "label": "Surfaces.stories.tsx",
+      "norm_label": "surfaces.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1258,
       "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 1259,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -44164,7 +44104,7 @@
       "source_location": "L173"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -44173,7 +44113,7 @@
       "source_location": "L102"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -44182,7 +44122,7 @@
       "source_location": "L201"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -44191,7 +44131,7 @@
       "source_location": "L150"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -44200,7 +44140,7 @@
       "source_location": "L155"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -44209,97 +44149,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1270,
+      "community": 1260,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_types_ts",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
+      "label": "reference-fixtures.test.tsx",
+      "norm_label": "reference-fixtures.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1262,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_test_setup_ts",
+      "label": "setup.ts",
+      "norm_label": "setup.ts",
+      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1263,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "label": "usePrint.test.ts",
+      "norm_label": "useprint.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1264,
+      "file_type": "code",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1265,
+      "file_type": "code",
+      "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/api/types.ts",
+      "source_file": "packages/athena-webapp/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1266,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "label": "HeartIconFilled.tsx",
-      "norm_label": "hearticonfilled.tsx",
-      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1267,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1268,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1269,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1275,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1276,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "label": "Upsell.tsx",
-      "norm_label": "upsell.tsx",
-      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1277,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
-      "label": "Checkout.test.tsx",
-      "norm_label": "checkout.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1278,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "label": "Checkout.tsx",
-      "norm_label": "checkout.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -44308,7 +44248,7 @@
       "source_location": "L9"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -44317,7 +44257,7 @@
       "source_location": "L73"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -44326,7 +44266,7 @@
       "source_location": "L54"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -44335,7 +44275,7 @@
       "source_location": "L98"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -44344,7 +44284,7 @@
       "source_location": "L33"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -44353,7 +44293,160 @@
       "source_location": "L1"
     },
     {
+      "community": 1270,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/api/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1272,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
+      "label": "HeartIconFilled.tsx",
+      "norm_label": "hearticonfilled.tsx",
+      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1273,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1274,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1275,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1276,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1277,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_upsell_tsx",
+      "label": "Upsell.tsx",
+      "norm_label": "upsell.tsx",
+      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1278,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
+      "label": "Checkout.test.tsx",
+      "norm_label": "checkout.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1279,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
+      "label": "Checkout.tsx",
+      "norm_label": "checkout.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 1280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -44362,7 +44455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -44371,7 +44464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -44380,7 +44473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -44389,7 +44482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -44398,7 +44491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -44407,7 +44500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -44416,7 +44509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -44425,21 +44518,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
       "norm_label": "deliverydetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
@@ -44499,6 +44583,15 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -44506,7 +44599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -44515,7 +44608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -44524,7 +44617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -44533,7 +44626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -44542,7 +44635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -44551,7 +44644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -44560,7 +44653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -44569,21 +44662,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
@@ -44814,6 +44898,15 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
       "norm_label": "about.tsx",
@@ -44821,7 +44914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -44830,7 +44923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -44839,7 +44932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -44848,7 +44941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -44857,7 +44950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -44866,7 +44959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -44875,7 +44968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -44884,21 +44977,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
       "norm_label": "reviewform.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "label": "SuccessMessage.tsx",
-      "norm_label": "successmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -44958,6 +45042,15 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
+      "label": "SuccessMessage.tsx",
+      "norm_label": "successmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -44965,7 +45058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -44974,7 +45067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -44983,7 +45076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -44992,7 +45085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -45001,7 +45094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -45010,7 +45103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -45019,7 +45112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -45028,21 +45121,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "label": "alert.tsx",
-      "norm_label": "alert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1"
     },
     {
@@ -45102,6 +45186,15 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
+      "label": "alert.tsx",
+      "norm_label": "alert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
       "norm_label": "breadcrumb.tsx",
@@ -45109,7 +45202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -45118,7 +45211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -45127,7 +45220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -45136,7 +45229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -45145,7 +45238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -45154,7 +45247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -45163,7 +45256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -45172,21 +45265,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
       "norm_label": "form.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1"
     },
     {
@@ -45237,6 +45321,15 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
       "norm_label": "image-with-fallback.tsx",
@@ -45244,7 +45337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -45253,7 +45346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -45262,7 +45355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -45271,7 +45364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -45280,7 +45373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -45289,7 +45382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -45298,7 +45391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -45307,21 +45400,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1"
     },
     {
@@ -45372,6 +45456,15 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
       "norm_label": "navigation-menu.tsx",
@@ -45379,7 +45472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -45388,7 +45481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -45397,7 +45490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -45406,7 +45499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -45415,7 +45508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -45424,7 +45517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -45433,7 +45526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -45442,21 +45535,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1"
     },
     {
@@ -45507,6 +45591,15 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
       "norm_label": "toggle-group.tsx",
@@ -45514,7 +45607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -45523,7 +45616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -45532,7 +45625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -45541,7 +45634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -45550,7 +45643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -45559,7 +45652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -45568,7 +45661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -45577,21 +45670,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
       "source_file": "packages/storefront-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
-      "label": "feeUtils.test.ts",
-      "norm_label": "feeutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1"
     },
     {
@@ -45642,6 +45726,15 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
+      "label": "feeUtils.test.ts",
+      "norm_label": "feeutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
@@ -45649,7 +45742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -45658,7 +45751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -45667,7 +45760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -45676,7 +45769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -45685,7 +45778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -45694,7 +45787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -45703,7 +45796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -45712,21 +45805,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1"
     },
     {
@@ -45777,6 +45861,15 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -45784,7 +45877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -45793,7 +45886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -45802,7 +45895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -45811,7 +45904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -45820,7 +45913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -45829,7 +45922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -45838,7 +45931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -45847,21 +45940,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
       "norm_label": "-homepageloader.test.ts",
       "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1"
     },
     {
@@ -45912,6 +45996,15 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
       "norm_label": "$orderitemid.review.tsx",
@@ -45919,7 +46012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -45928,7 +46021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -45937,7 +46030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -45946,7 +46039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -45955,7 +46048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -45964,7 +46057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -45973,7 +46066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -45982,21 +46075,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
       "norm_label": "incomplete.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
       "source_location": "L1"
     },
     {
@@ -46047,6 +46131,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
       "norm_label": "pending.tsx",
@@ -46054,7 +46147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -46063,7 +46156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -46072,7 +46165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -46081,7 +46174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -46090,7 +46183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -46099,7 +46192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -46108,7 +46201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -46117,7 +46210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -46569,6 +46662,51 @@
     {
       "community": 146,
       "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
       "norm_label": "getperiodrange()",
@@ -46576,7 +46714,7 @@
       "source_location": "L20"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -46585,7 +46723,7 @@
       "source_location": "L50"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -46594,7 +46732,7 @@
       "source_location": "L342"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -46603,7 +46741,7 @@
       "source_location": "L322"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -46612,7 +46750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -46621,7 +46759,7 @@
       "source_location": "L61"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -46630,7 +46768,7 @@
       "source_location": "L57"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -46639,7 +46777,7 @@
       "source_location": "L98"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -46648,7 +46786,7 @@
       "source_location": "L134"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -46657,7 +46795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -46666,7 +46804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -46675,7 +46813,7 @@
       "source_location": "L38"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -46684,7 +46822,7 @@
       "source_location": "L64"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -46693,58 +46831,13 @@
       "source_location": "L135"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
       "norm_label": "validatefile()",
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L43"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 15,
@@ -46911,6 +47004,51 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
       "norm_label": "fetchtransactions()",
@@ -46918,7 +47056,7 @@
       "source_location": "L138"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -46927,7 +47065,7 @@
       "source_location": "L175"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -46936,7 +47074,7 @@
       "source_location": "L189"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -46945,7 +47083,7 @@
       "source_location": "L43"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -46954,7 +47092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -46963,7 +47101,7 @@
       "source_location": "L77"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -46972,7 +47110,7 @@
       "source_location": "L295"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -46981,7 +47119,7 @@
       "source_location": "L61"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -46990,57 +47128,12 @@
       "source_location": "L47"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -50821,7 +50914,7 @@
       "label": "useConvexPosCustomerCreate()",
       "norm_label": "useconvexposcustomercreate()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L16"
+      "source_location": "L20"
     },
     {
       "community": 218,
@@ -50830,7 +50923,7 @@
       "label": "useConvexPosCustomerSearch()",
       "norm_label": "useconvexposcustomersearch()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
-      "source_location": "L6"
+      "source_location": "L10"
     },
     {
       "community": 218,
@@ -51055,7 +51148,7 @@
       "label": "useConvexActiveSession()",
       "norm_label": "useconvexactivesession()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L25"
+      "source_location": "L38"
     },
     {
       "community": 220,
@@ -51064,7 +51157,7 @@
       "label": "useConvexHeldSessions()",
       "norm_label": "useconvexheldsessions()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L52"
+      "source_location": "L65"
     },
     {
       "community": 220,
@@ -51073,7 +51166,7 @@
       "label": "useConvexSessionActions()",
       "norm_label": "useconvexsessionactions()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L78"
+      "source_location": "L91"
     },
     {
       "community": 221,
@@ -56937,101 +57030,101 @@
     {
       "community": 36,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L187"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L203"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L337"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_hascustomersnapshotvalue",
+      "label": "hasCustomerSnapshotValue()",
+      "norm_label": "hascustomersnapshotvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_normalizecustomersnapshot",
+      "label": "normalizeCustomerSnapshot()",
+      "norm_label": "normalizecustomersnapshot()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_persistsessionworkflowtraceidbesteffort",
+      "label": "persistSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistsessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_recordsessionlifecycletracebesteffort",
+      "label": "recordSessionLifecycleTraceBestEffort()",
+      "norm_label": "recordsessionlifecycletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_resolvecustomertracestage",
+      "label": "resolveCustomerTraceStage()",
+      "norm_label": "resolvecustomertracestage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_usererrorfromsessioncommandfailure",
+      "label": "userErrorFromSessionCommandFailure()",
+      "norm_label": "usererrorfromsessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "possessions_usererrorfromvalidationmessage",
+      "label": "userErrorFromValidationMessage()",
+      "norm_label": "usererrorfromvalidationmessage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L80"
     },
     {
       "community": 360,
@@ -57306,100 +57399,100 @@
     {
       "community": 37,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L139"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L63"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L93"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L197"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L187"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L79"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L83"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L203"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L337"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L58"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L1"
     },
     {
@@ -57666,100 +57759,100 @@
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -57909,6 +58002,24 @@
     {
       "community": 388,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
+      "label": "posSessionItems.ts",
+      "norm_label": "possessionitems.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 388,
+      "file_type": "code",
+      "id": "possessionitems_usererrorfromsessionitemfailure",
+      "label": "userErrorFromSessionItemFailure()",
+      "norm_label": "usererrorfromsessionitemfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 389,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
       "norm_label": "sessionqueryindexes.test.ts",
@@ -57916,7 +58027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -57925,7 +58036,106 @@
       "source_location": "L6"
     },
     {
-      "community": 389,
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -57934,7 +58144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 389,
+      "community": 390,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -57943,106 +58153,25 @@
       "source_location": "L27"
     },
     {
-      "community": 39,
+      "community": 391,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "commandresultvalidators_commandresultvalidator",
+      "label": "commandResultValidator()",
+      "norm_label": "commandresultvalidator()",
+      "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
+      "label": "commandResultValidators.ts",
+      "norm_label": "commandresultvalidators.ts",
+      "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.ts",
       "source_location": "L1"
     },
     {
-      "community": 39,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 390,
+      "community": 392,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -58051,7 +58180,7 @@
       "source_location": "L4"
     },
     {
-      "community": 390,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -58060,7 +58189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -58069,7 +58198,7 @@
       "source_location": "L3"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -58078,7 +58207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -58087,7 +58216,7 @@
       "source_location": "L3"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -58096,7 +58225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -58105,7 +58234,7 @@
       "source_location": "L6"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -58114,7 +58243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -58123,7 +58252,7 @@
       "source_location": "L3"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -58132,7 +58261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -58141,7 +58270,7 @@
       "source_location": "L18"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -58150,7 +58279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -58159,7 +58288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -58168,7 +58297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -58177,49 +58306,13 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "staffprofiles_test_createstaffprofilesmutationctx",
-      "label": "createStaffProfilesMutationCtx()",
-      "norm_label": "createstaffprofilesmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "emailotp_formatvalidtime",
-      "label": "formatValidTime()",
-      "norm_label": "formatvalidtime()",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
-      "label": "EmailOTP.ts",
-      "norm_label": "emailotp.ts",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -58476,104 +58569,140 @@
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getbanneranimationdelay",
-      "label": "getBannerAnimationDelay()",
-      "norm_label": "getbanneranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L152"
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getbannerbgclass",
-      "label": "getBannerBGClass()",
-      "norm_label": "getbannerbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L136"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getbannertextclass",
-      "label": "getBannerTextClass()",
-      "norm_label": "getbannertextclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L119"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_gethoverclass",
-      "label": "getHoverClass()",
-      "norm_label": "gethoverclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L76"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getmainwrapperclass",
-      "label": "getMainWrapperClass()",
-      "norm_label": "getmainwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L28"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getnavbaranimationdelay",
-      "label": "getNavBarAnimationDelay()",
-      "norm_label": "getnavbaranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L174"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getnavbarwrapperclass",
-      "label": "getNavBarWrapperClass()",
-      "norm_label": "getnavbarwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L163"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getnavbgclass",
-      "label": "getNavBGClass()",
-      "norm_label": "getnavbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L43"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getoverlayclass",
-      "label": "getOverlayClass()",
-      "norm_label": "getoverlayclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L184"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "navbarstyles_getsubmenubgclass",
-      "label": "getSubmenuBGClass()",
-      "norm_label": "getsubmenubgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L93"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
-      "label": "navBarStyles.ts",
-      "norm_label": "navbarstyles.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
       "source_location": "L1"
     },
     {
       "community": 400,
+      "file_type": "code",
+      "id": "staffprofiles_test_createstaffprofilesmutationctx",
+      "label": "createStaffProfilesMutationCtx()",
+      "norm_label": "createstaffprofilesmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "emailotp_formatvalidtime",
+      "label": "formatValidTime()",
+      "norm_label": "formatvalidtime()",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
+      "label": "EmailOTP.ts",
+      "norm_label": "emailotp.ts",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 402,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -58582,7 +58711,7 @@
       "source_location": "L31"
     },
     {
-      "community": 400,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -58591,7 +58720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -58600,7 +58729,7 @@
       "source_location": "L6"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -58609,7 +58738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -58618,7 +58747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -58627,7 +58756,7 @@
       "source_location": "L88"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -58636,7 +58765,7 @@
       "source_location": "L9"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -58645,7 +58774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -58654,7 +58783,7 @@
       "source_location": "L4"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -58663,7 +58792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -58672,7 +58801,7 @@
       "source_location": "L15"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -58681,7 +58810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -58690,7 +58819,7 @@
       "source_location": "L7"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -58699,7 +58828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -58708,7 +58837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -58717,7 +58846,106 @@
       "source_location": "L8"
     },
     {
-      "community": 408,
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getbanneranimationdelay",
+      "label": "getBannerAnimationDelay()",
+      "norm_label": "getbanneranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getbannerbgclass",
+      "label": "getBannerBGClass()",
+      "norm_label": "getbannerbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getbannertextclass",
+      "label": "getBannerTextClass()",
+      "norm_label": "getbannertextclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_gethoverclass",
+      "label": "getHoverClass()",
+      "norm_label": "gethoverclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getmainwrapperclass",
+      "label": "getMainWrapperClass()",
+      "norm_label": "getmainwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbaranimationdelay",
+      "label": "getNavBarAnimationDelay()",
+      "norm_label": "getnavbaranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbarwrapperclass",
+      "label": "getNavBarWrapperClass()",
+      "norm_label": "getnavbarwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbgclass",
+      "label": "getNavBGClass()",
+      "norm_label": "getnavbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getoverlayclass",
+      "label": "getOverlayClass()",
+      "norm_label": "getoverlayclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "navbarstyles_getsubmenubgclass",
+      "label": "getSubmenuBGClass()",
+      "norm_label": "getsubmenubgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
+      "label": "navBarStyles.ts",
+      "norm_label": "navbarstyles.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -58726,7 +58954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 410,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -58735,7 +58963,7 @@
       "source_location": "L13"
     },
     {
-      "community": 409,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -58744,7 +58972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 409,
+      "community": 411,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -58753,97 +58981,7 @@
       "source_location": "L5"
     },
     {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
-      "label": "resultTypes.ts",
-      "norm_label": "resulttypes.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_expenseitemsuccess",
-      "label": "expenseItemSuccess()",
-      "norm_label": "expenseitemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_expensesessionsuccess",
-      "label": "expenseSessionSuccess()",
-      "norm_label": "expensesessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_iserror",
-      "label": "isError()",
-      "norm_label": "iserror()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L176"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_issuccess",
-      "label": "isSuccess()",
-      "norm_label": "issuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_itemsuccess",
-      "label": "itemSuccess()",
-      "norm_label": "itemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_operationsuccess",
-      "label": "operationSuccess()",
-      "norm_label": "operationsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_sessionsuccess",
-      "label": "sessionSuccess()",
-      "norm_label": "sessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "resulttypes_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 410,
+      "community": 412,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -58852,7 +58990,7 @@
       "source_location": "L15"
     },
     {
-      "community": 410,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -58861,7 +58999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -58870,7 +59008,7 @@
       "source_location": "L8"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -58879,7 +59017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -58888,7 +59026,7 @@
       "source_location": "L17"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -58897,7 +59035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -58906,7 +59044,7 @@
       "source_location": "L6"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -58915,7 +59053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -58924,7 +59062,7 @@
       "source_location": "L5"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -58933,7 +59071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -58942,7 +59080,7 @@
       "source_location": "L25"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -58951,7 +59089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -58960,7 +59098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -58969,7 +59107,7 @@
       "source_location": "L17"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -58978,7 +59116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -58987,7 +59125,97 @@
       "source_location": "L7"
     },
     {
-      "community": 418,
+      "community": 42,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
+      "label": "resultTypes.ts",
+      "norm_label": "resulttypes.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_expenseitemsuccess",
+      "label": "expenseItemSuccess()",
+      "norm_label": "expenseitemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_expensesessionsuccess",
+      "label": "expenseSessionSuccess()",
+      "norm_label": "expensesessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_iserror",
+      "label": "isError()",
+      "norm_label": "iserror()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_issuccess",
+      "label": "isSuccess()",
+      "norm_label": "issuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_itemsuccess",
+      "label": "itemSuccess()",
+      "norm_label": "itemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_operationsuccess",
+      "label": "operationSuccess()",
+      "norm_label": "operationsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_sessionsuccess",
+      "label": "sessionSuccess()",
+      "norm_label": "sessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "resulttypes_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 420,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -58996,7 +59224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 420,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -59005,7 +59233,7 @@
       "source_location": "L14"
     },
     {
-      "community": 419,
+      "community": 421,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -59014,7 +59242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 419,
+      "community": 421,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -59023,97 +59251,7 @@
       "source_location": "L8"
     },
     {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
-      "label": "sessionValidation.ts",
-      "norm_label": "sessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_isvalidemail",
-      "label": "isValidEmail()",
-      "norm_label": "isvalidemail()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L303"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validatecartitems",
-      "label": "validateCartItems()",
-      "norm_label": "validatecartitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validatecustomerinfo",
-      "label": "validateCustomerInfo()",
-      "norm_label": "validatecustomerinfo()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validateitembelongstosession",
-      "label": "validateItemBelongsToSession()",
-      "norm_label": "validateitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validatepaymentdetails",
-      "label": "validatePaymentDetails()",
-      "norm_label": "validatepaymentdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionactive",
-      "label": "validateSessionActive()",
-      "norm_label": "validatesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionexists",
-      "label": "validateSessionExists()",
-      "norm_label": "validatesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionmodifiable",
-      "label": "validateSessionModifiable()",
-      "norm_label": "validatesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "sessionvalidation_validatesessionownership",
-      "label": "validateSessionOwnership()",
-      "norm_label": "validatesessionownership()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 420,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -59122,7 +59260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 422,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -59131,7 +59269,7 @@
       "source_location": "L3"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -59140,7 +59278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -59149,7 +59287,7 @@
       "source_location": "L5"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -59158,7 +59296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -59167,7 +59305,7 @@
       "source_location": "L16"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -59176,7 +59314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -59185,7 +59323,7 @@
       "source_location": "L30"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_ts",
       "label": "posSale.ts",
@@ -59194,7 +59332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "possale_buildpossaletraceseed",
       "label": "buildPosSaleTraceSeed()",
@@ -59203,7 +59341,7 @@
       "source_location": "L43"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -59212,7 +59350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -59221,7 +59359,7 @@
       "source_location": "L43"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -59230,7 +59368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -59239,7 +59377,7 @@
       "source_location": "L31"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -59248,7 +59386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -59257,7 +59395,97 @@
       "source_location": "L5"
     },
     {
-      "community": 428,
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
+      "label": "sessionValidation.ts",
+      "norm_label": "sessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_isvalidemail",
+      "label": "isValidEmail()",
+      "norm_label": "isvalidemail()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L303"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validatecartitems",
+      "label": "validateCartItems()",
+      "norm_label": "validatecartitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validatecustomerinfo",
+      "label": "validateCustomerInfo()",
+      "norm_label": "validatecustomerinfo()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L275"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validateitembelongstosession",
+      "label": "validateItemBelongsToSession()",
+      "norm_label": "validateitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validatepaymentdetails",
+      "label": "validatePaymentDetails()",
+      "norm_label": "validatepaymentdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionactive",
+      "label": "validateSessionActive()",
+      "norm_label": "validatesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionexists",
+      "label": "validateSessionExists()",
+      "norm_label": "validatesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionmodifiable",
+      "label": "validateSessionModifiable()",
+      "norm_label": "validatesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "sessionvalidation_validatesessionownership",
+      "label": "validateSessionOwnership()",
+      "norm_label": "validatesessionownership()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 430,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -59266,7 +59494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 430,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -59275,7 +59503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 429,
+      "community": 431,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -59284,7 +59512,7 @@
       "source_location": "L7"
     },
     {
-      "community": 429,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -59293,97 +59521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 430,
+      "community": 432,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -59392,7 +59530,7 @@
       "source_location": "L12"
     },
     {
-      "community": 430,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -59401,7 +59539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -59410,7 +59548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -59419,7 +59557,7 @@
       "source_location": "L11"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -59428,7 +59566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -59437,7 +59575,7 @@
       "source_location": "L11"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -59446,7 +59584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -59455,7 +59593,7 @@
       "source_location": "L3"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -59464,7 +59602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -59473,7 +59611,7 @@
       "source_location": "L12"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -59482,7 +59620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -59491,7 +59629,7 @@
       "source_location": "L42"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -59500,7 +59638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -59509,7 +59647,7 @@
       "source_location": "L13"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -59518,7 +59656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -59527,7 +59665,97 @@
       "source_location": "L42"
     },
     {
-      "community": 438,
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -59536,7 +59764,7 @@
       "source_location": "L31"
     },
     {
-      "community": 438,
+      "community": 440,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -59545,7 +59773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 439,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -59554,7 +59782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 439,
+      "community": 441,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -59563,97 +59791,7 @@
       "source_location": "L10"
     },
     {
-      "community": 44,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
-      "label": "receiving.ts",
-      "norm_label": "receiving.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_assertdistinctreceivinglineitems",
-      "label": "assertDistinctReceivingLineItems()",
-      "norm_label": "assertdistinctreceivinglineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_assertreceivablepurchaseorderstatus",
-      "label": "assertReceivablePurchaseOrderStatus()",
-      "norm_label": "assertreceivablepurchaseorderstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_assertreceivinglinequantities",
-      "label": "assertReceivingLineQuantities()",
-      "norm_label": "assertreceivinglinequantities()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_buildreceivingbatchsourceid",
-      "label": "buildReceivingBatchSourceId()",
-      "norm_label": "buildreceivingbatchsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_calculatepurchaseorderreceivingstatus",
-      "label": "calculatePurchaseOrderReceivingStatus()",
-      "norm_label": "calculatepurchaseorderreceivingstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_calculatereceivingbatchtotals",
-      "label": "calculateReceivingBatchTotals()",
-      "norm_label": "calculatereceivingbatchtotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_summarizereceivingskudeltas",
-      "label": "summarizeReceivingSkuDeltas()",
-      "norm_label": "summarizereceivingskudeltas()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "receiving_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 440,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -59662,7 +59800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 442,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -59671,7 +59809,7 @@
       "source_location": "L14"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -59680,7 +59818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -59689,7 +59827,7 @@
       "source_location": "L5"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -59698,7 +59836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -59707,7 +59845,7 @@
       "source_location": "L10"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -59716,7 +59854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -59725,7 +59863,7 @@
       "source_location": "L15"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -59734,7 +59872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -59743,7 +59881,7 @@
       "source_location": "L13"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -59752,7 +59890,7 @@
       "source_location": "L116"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -59761,7 +59899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -59770,7 +59908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -59779,7 +59917,7 @@
       "source_location": "L47"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -59788,7 +59926,7 @@
       "source_location": "L151"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -59797,7 +59935,97 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 45,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
+      "label": "receiving.ts",
+      "norm_label": "receiving.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_assertdistinctreceivinglineitems",
+      "label": "assertDistinctReceivingLineItems()",
+      "norm_label": "assertdistinctreceivinglineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_assertreceivablepurchaseorderstatus",
+      "label": "assertReceivablePurchaseOrderStatus()",
+      "norm_label": "assertreceivablepurchaseorderstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_assertreceivinglinequantities",
+      "label": "assertReceivingLineQuantities()",
+      "norm_label": "assertreceivinglinequantities()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_buildreceivingbatchsourceid",
+      "label": "buildReceivingBatchSourceId()",
+      "norm_label": "buildreceivingbatchsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_calculatepurchaseorderreceivingstatus",
+      "label": "calculatePurchaseOrderReceivingStatus()",
+      "norm_label": "calculatepurchaseorderreceivingstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_calculatereceivingbatchtotals",
+      "label": "calculateReceivingBatchTotals()",
+      "norm_label": "calculatereceivingbatchtotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_summarizereceivingskudeltas",
+      "label": "summarizeReceivingSkuDeltas()",
+      "norm_label": "summarizereceivingskudeltas()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "receiving_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 450,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -59806,7 +60034,7 @@
       "source_location": "L6"
     },
     {
-      "community": 448,
+      "community": 450,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -59815,7 +60043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 449,
+      "community": 451,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -59824,7 +60052,7 @@
       "source_location": "L19"
     },
     {
-      "community": 449,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -59833,97 +60061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 45,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
-      "label": "RegisterCloseoutView.tsx",
-      "norm_label": "registercloseoutview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_formatsessionname",
-      "label": "formatSessionName()",
-      "norm_label": "formatsessionname()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_getvariance",
-      "label": "getVariance()",
-      "norm_label": "getvariance()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_handlereviewcloseout",
-      "label": "handleReviewCloseout()",
-      "norm_label": "handlereviewcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_handlesubmitcloseout",
-      "label": "handleSubmitCloseout()",
-      "norm_label": "handlesubmitcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L108"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_onreviewcloseout",
-      "label": "onReviewCloseout()",
-      "norm_label": "onreviewcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L456"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_onsubmitcloseout",
-      "label": "onSubmitCloseout()",
-      "norm_label": "onsubmitcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L429"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercloseoutview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 450,
+      "community": 452,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -59932,7 +60070,7 @@
       "source_location": "L7"
     },
     {
-      "community": 450,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -59941,7 +60079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -59950,7 +60088,7 @@
       "source_location": "L42"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -59959,7 +60097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -59968,7 +60106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -59977,7 +60115,7 @@
       "source_location": "L66"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -59986,7 +60124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -59995,7 +60133,7 @@
       "source_location": "L18"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -60004,7 +60142,7 @@
       "source_location": "L6"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -60013,7 +60151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -60022,7 +60160,7 @@
       "source_location": "L10"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -60031,7 +60169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -60040,7 +60178,7 @@
       "source_location": "L27"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -60049,7 +60187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -60058,7 +60196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -60067,7 +60205,97 @@
       "source_location": "L12"
     },
     {
-      "community": 458,
+      "community": 46,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
+      "label": "RegisterCloseoutView.tsx",
+      "norm_label": "registercloseoutview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_formatsessionname",
+      "label": "formatSessionName()",
+      "norm_label": "formatsessionname()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_getvariance",
+      "label": "getVariance()",
+      "norm_label": "getvariance()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_handlereviewcloseout",
+      "label": "handleReviewCloseout()",
+      "norm_label": "handlereviewcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_handlesubmitcloseout",
+      "label": "handleSubmitCloseout()",
+      "norm_label": "handlesubmitcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L108"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_onreviewcloseout",
+      "label": "onReviewCloseout()",
+      "norm_label": "onreviewcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L456"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_onsubmitcloseout",
+      "label": "onSubmitCloseout()",
+      "norm_label": "onsubmitcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L429"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "registercloseoutview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 460,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -60076,7 +60304,7 @@
       "source_location": "L3"
     },
     {
-      "community": 458,
+      "community": 460,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -60085,7 +60313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 459,
+      "community": 461,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -60094,7 +60322,7 @@
       "source_location": "L5"
     },
     {
-      "community": 459,
+      "community": 461,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -60103,97 +60331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 46,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
-      "label": "RegisterSessionView.tsx",
-      "norm_label": "registersessionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_builddepositsubmissionkey",
-      "label": "buildDepositSubmissionKey()",
-      "norm_label": "builddepositsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L137"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L625"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L160"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L165"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_handlerecorddeposit",
-      "label": "handleRecordDeposit()",
-      "norm_label": "handlerecorddeposit()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L245"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "registersessionview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -60202,7 +60340,7 @@
       "source_location": "L49"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -60211,7 +60349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -60220,7 +60358,7 @@
       "source_location": "L23"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -60229,7 +60367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -60238,7 +60376,7 @@
       "source_location": "L50"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -60247,7 +60385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -60256,7 +60394,7 @@
       "source_location": "L13"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -60265,7 +60403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -60274,7 +60412,7 @@
       "source_location": "L11"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -60283,7 +60421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -60292,7 +60430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -60301,7 +60439,7 @@
       "source_location": "L7"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -60310,7 +60448,7 @@
       "source_location": "L32"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -60319,7 +60457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -60328,7 +60466,7 @@
       "source_location": "L29"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -60337,7 +60475,97 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 47,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "label": "RegisterSessionView.tsx",
+      "norm_label": "registersessionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_builddepositsubmissionkey",
+      "label": "buildDepositSubmissionKey()",
+      "norm_label": "builddepositsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L137"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L625"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L160"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L149"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L165"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_handlerecorddeposit",
+      "label": "handleRecordDeposit()",
+      "norm_label": "handlerecorddeposit()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L245"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "registersessionview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 470,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -60346,7 +60574,7 @@
       "source_location": "L37"
     },
     {
-      "community": 468,
+      "community": 470,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -60355,7 +60583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 469,
+      "community": 471,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -60364,7 +60592,7 @@
       "source_location": "L25"
     },
     {
-      "community": 469,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -60373,97 +60601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_editmodebuttons",
-      "label": "EditModeButtons()",
-      "norm_label": "editmodebuttons()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L179"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handleeditclick",
-      "label": "handleEditClick()",
-      "norm_label": "handleeditclick()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L108"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handlerevert",
-      "label": "handleRevert()",
-      "norm_label": "handlerevert()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_reseteditstate",
-      "label": "resetEditState()",
-      "norm_label": "reseteditstate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_uploadimage",
-      "label": "uploadImage()",
-      "norm_label": "uploadimage()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_viewmodebutton",
-      "label": "ViewModeButton()",
-      "norm_label": "viewmodebutton()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L205"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
-      "label": "HeroHeaderImageUploader.tsx",
-      "norm_label": "heroheaderimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -60472,7 +60610,7 @@
       "source_location": "L83"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -60481,7 +60619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -60490,7 +60628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -60499,7 +60637,7 @@
       "source_location": "L35"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -60508,7 +60646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -60517,7 +60655,7 @@
       "source_location": "L28"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -60526,7 +60664,7 @@
       "source_location": "L11"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -60535,7 +60673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -60544,7 +60682,7 @@
       "source_location": "L13"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -60553,7 +60691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -60562,7 +60700,7 @@
       "source_location": "L41"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -60571,7 +60709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -60580,7 +60718,7 @@
       "source_location": "L33"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -60589,7 +60727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -60598,7 +60736,7 @@
       "source_location": "L68"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -60607,7 +60745,97 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_editmodebuttons",
+      "label": "EditModeButtons()",
+      "norm_label": "editmodebuttons()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L179"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_handleeditclick",
+      "label": "handleEditClick()",
+      "norm_label": "handleeditclick()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L108"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_handlerevert",
+      "label": "handleRevert()",
+      "norm_label": "handlerevert()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_reseteditstate",
+      "label": "resetEditState()",
+      "norm_label": "reseteditstate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_uploadimage",
+      "label": "uploadImage()",
+      "norm_label": "uploadimage()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_viewmodebutton",
+      "label": "ViewModeButton()",
+      "norm_label": "viewmodebutton()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L205"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
+      "label": "HeroHeaderImageUploader.tsx",
+      "norm_label": "heroheaderimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -60616,7 +60844,7 @@
       "source_location": "L35"
     },
     {
-      "community": 478,
+      "community": 480,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -60625,7 +60853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 479,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -60634,7 +60862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 479,
+      "community": 481,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -60643,97 +60871,7 @@
       "source_location": "L79"
     },
     {
-      "community": 48,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
-      "label": "StaffManagement.tsx",
-      "norm_label": "staffmanagement.tsx",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_buildusername",
-      "label": "buildUsername()",
-      "norm_label": "buildusername()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_credentialpindialog",
-      "label": "CredentialPinDialog()",
-      "norm_label": "credentialpindialog()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L538"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_credentialstatusbadge",
-      "label": "CredentialStatusBadge()",
-      "norm_label": "credentialstatusbadge()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_formatcredentialstatuslabel",
-      "label": "formatCredentialStatusLabel()",
-      "norm_label": "formatcredentialstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_formatrolelabel",
-      "label": "formatRoleLabel()",
-      "norm_label": "formatrolelabel()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_formatstartdate",
-      "label": "formatStartDate()",
-      "norm_label": "formatstartdate()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L126"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_handledeactivate",
-      "label": "handleDeactivate()",
-      "norm_label": "handledeactivate()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L730"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_normalizenamesegment",
-      "label": "normalizeNameSegment()",
-      "norm_label": "normalizenamesegment()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_staffprovisionform",
-      "label": "StaffProvisionForm()",
-      "norm_label": "staffprovisionform()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -60742,7 +60880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -60751,7 +60889,7 @@
       "source_location": "L6"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -60760,7 +60898,7 @@
       "source_location": "L34"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -60769,7 +60907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -60778,7 +60916,7 @@
       "source_location": "L89"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -60787,7 +60925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -60796,7 +60934,7 @@
       "source_location": "L8"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -60805,7 +60943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -60814,7 +60952,7 @@
       "source_location": "L5"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -60823,7 +60961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -60832,7 +60970,7 @@
       "source_location": "L7"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -60841,7 +60979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -60850,7 +60988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -60859,7 +60997,7 @@
       "source_location": "L13"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -60868,7 +61006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -60877,7 +61015,97 @@
       "source_location": "L35"
     },
     {
-      "community": 488,
+      "community": 49,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
+      "label": "StaffManagement.tsx",
+      "norm_label": "staffmanagement.tsx",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_buildusername",
+      "label": "buildUsername()",
+      "norm_label": "buildusername()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_credentialpindialog",
+      "label": "CredentialPinDialog()",
+      "norm_label": "credentialpindialog()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L538"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_credentialstatusbadge",
+      "label": "CredentialStatusBadge()",
+      "norm_label": "credentialstatusbadge()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_formatcredentialstatuslabel",
+      "label": "formatCredentialStatusLabel()",
+      "norm_label": "formatcredentialstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_formatrolelabel",
+      "label": "formatRoleLabel()",
+      "norm_label": "formatrolelabel()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_formatstartdate",
+      "label": "formatStartDate()",
+      "norm_label": "formatstartdate()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L126"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_handledeactivate",
+      "label": "handleDeactivate()",
+      "norm_label": "handledeactivate()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L730"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_normalizenamesegment",
+      "label": "normalizeNameSegment()",
+      "norm_label": "normalizenamesegment()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "staffmanagement_staffprovisionform",
+      "label": "StaffProvisionForm()",
+      "norm_label": "staffprovisionform()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 490,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -60886,7 +61114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 490,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -60895,7 +61123,7 @@
       "source_location": "L3"
     },
     {
-      "community": 489,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -60904,7 +61132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 489,
+      "community": 491,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -60913,97 +61141,7 @@
       "source_location": "L14"
     },
     {
-      "community": 49,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "label": "simple.test.ts",
-      "norm_label": "simple.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_addtocart",
-      "label": "addToCart()",
-      "norm_label": "addtocart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_formatreceiptdate",
-      "label": "formatReceiptDate()",
-      "norm_label": "formatreceiptdate()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_removefromcart",
-      "label": "removeFromCart()",
-      "norm_label": "removefromcart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_updatequantity",
-      "label": "updateQuantity()",
-      "norm_label": "updatequantity()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "simple_test_validateinventorywithaggregation",
-      "label": "validateInventoryWithAggregation()",
-      "norm_label": "validateinventorywithaggregation()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -61012,7 +61150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -61021,7 +61159,7 @@
       "source_location": "L86"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -61030,7 +61168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -61039,7 +61177,7 @@
       "source_location": "L15"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -61048,7 +61186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -61057,7 +61195,7 @@
       "source_location": "L14"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -61066,7 +61204,7 @@
       "source_location": "L18"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -61075,7 +61213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -61084,7 +61222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -61093,7 +61231,7 @@
       "source_location": "L8"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -61102,7 +61240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "registerdrawergate_registerdrawergate",
       "label": "RegisterDrawerGate()",
@@ -61111,7 +61249,7 @@
       "source_location": "L8"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -61120,7 +61258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -61129,7 +61267,7 @@
       "source_location": "L8"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -61138,49 +61276,13 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
       "norm_label": "rendertransactioncell()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
       "source_location": "L46"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "barcodeview_barcodeview",
-      "label": "BarcodeView()",
-      "norm_label": "barcodeview()",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "label": "BarcodeView.tsx",
-      "norm_label": "barcodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 5,
@@ -61437,95 +61539,131 @@
     {
       "community": 50,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
+      "label": "simple.test.ts",
+      "norm_label": "simple.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_awardpointsforguestorders",
-      "label": "awardPointsForGuestOrders()",
-      "norm_label": "awardpointsforguestorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L198"
+      "id": "simple_test_addtocart",
+      "label": "addToCart()",
+      "norm_label": "addtocart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L249"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_awardpointsforpastorder",
-      "label": "awardPointsForPastOrder()",
-      "norm_label": "awardpointsforpastorder()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L151"
+      "id": "simple_test_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L173"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L3"
+      "id": "simple_test_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L201"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_geteligiblepastorders",
-      "label": "getEligiblePastOrders()",
-      "norm_label": "geteligiblepastorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L129"
+      "id": "simple_test_formatreceiptdate",
+      "label": "formatReceiptDate()",
+      "norm_label": "formatreceiptdate()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L225"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_getorderrewardpoints",
-      "label": "getOrderRewardPoints()",
-      "norm_label": "getorderrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L175"
+      "id": "simple_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_getpointhistory",
-      "label": "getPointHistory()",
-      "norm_label": "getpointhistory()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L71"
+      "id": "simple_test_removefromcart",
+      "label": "removeFromCart()",
+      "norm_label": "removefromcart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L288"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_getrewardtiers",
-      "label": "getRewardTiers()",
-      "norm_label": "getrewardtiers()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L90"
+      "id": "simple_test_updatequantity",
+      "label": "updateQuantity()",
+      "norm_label": "updatequantity()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L311"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_getuserpoints",
-      "label": "getUserPoints()",
-      "norm_label": "getuserpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L54"
+      "id": "simple_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L77"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "rewards_redeemrewardpoints",
-      "label": "redeemRewardPoints()",
-      "norm_label": "redeemrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L107"
+      "id": "simple_test_validateinventorywithaggregation",
+      "label": "validateInventoryWithAggregation()",
+      "norm_label": "validateinventorywithaggregation()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L130"
     },
     {
       "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "barcodeview_barcodeview",
+      "label": "BarcodeView()",
+      "norm_label": "barcodeview()",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
+      "label": "BarcodeView.tsx",
+      "norm_label": "barcodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -61534,7 +61672,7 @@
       "source_location": "L6"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -61543,7 +61681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -61552,7 +61690,7 @@
       "source_location": "L38"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -61561,7 +61699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -61570,7 +61708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -61579,7 +61717,7 @@
       "source_location": "L10"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -61588,7 +61726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -61597,7 +61735,7 @@
       "source_location": "L6"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -61606,7 +61744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -61615,7 +61753,7 @@
       "source_location": "L5"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -61624,7 +61762,7 @@
       "source_location": "L17"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -61633,7 +61771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -61642,7 +61780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -61651,7 +61789,7 @@
       "source_location": "L4"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -61660,7 +61798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -61669,7 +61807,97 @@
       "source_location": "L84"
     },
     {
-      "community": 508,
+      "community": 51,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_awardpointsforguestorders",
+      "label": "awardPointsForGuestOrders()",
+      "norm_label": "awardpointsforguestorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_awardpointsforpastorder",
+      "label": "awardPointsForPastOrder()",
+      "norm_label": "awardpointsforpastorder()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_geteligiblepastorders",
+      "label": "getEligiblePastOrders()",
+      "norm_label": "geteligiblepastorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_getorderrewardpoints",
+      "label": "getOrderRewardPoints()",
+      "norm_label": "getorderrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_getpointhistory",
+      "label": "getPointHistory()",
+      "norm_label": "getpointhistory()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_getrewardtiers",
+      "label": "getRewardTiers()",
+      "norm_label": "getrewardtiers()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_getuserpoints",
+      "label": "getUserPoints()",
+      "norm_label": "getuserpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "rewards_redeemrewardpoints",
+      "label": "redeemRewardPoints()",
+      "norm_label": "redeemrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 510,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -61678,7 +61906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 510,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -61687,7 +61915,7 @@
       "source_location": "L22"
     },
     {
-      "community": 509,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -61696,7 +61924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 509,
+      "community": 511,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -61705,97 +61933,7 @@
       "source_location": "L9"
     },
     {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_comparedeterministically",
-      "label": "compareDeterministically()",
-      "norm_label": "comparedeterministically()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_isjsonobject",
-      "label": "isJsonObject()",
-      "norm_label": "isjsonobject()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsonartifact",
-      "label": "normalizeGraphJsonArtifact()",
-      "norm_label": "normalizegraphjsonartifact()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsoncontents",
-      "label": "normalizeGraphJsonContents()",
-      "norm_label": "normalizegraphjsoncontents()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_resolvegraphifypython",
-      "label": "resolveGraphifyPython()",
-      "norm_label": "resolvegraphifypython()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_rungraphifyrebuild",
-      "label": "runGraphifyRebuild()",
-      "norm_label": "rungraphifyrebuild()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_sortjsonarray",
-      "label": "sortJsonArray()",
-      "norm_label": "sortjsonarray()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "graphify_rebuild_sortjsonvalue",
-      "label": "sortJsonValue()",
-      "norm_label": "sortjsonvalue()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_ts",
-      "label": "graphify-rebuild.ts",
-      "norm_label": "graphify-rebuild.ts",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -61804,7 +61942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -61813,7 +61951,7 @@
       "source_location": "L23"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -61822,7 +61960,7 @@
       "source_location": "L5"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -61831,7 +61969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -61840,7 +61978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -61849,7 +61987,7 @@
       "source_location": "L4"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -61858,7 +61996,7 @@
       "source_location": "L13"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -61867,7 +62005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -61876,7 +62014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -61885,7 +62023,7 @@
       "source_location": "L29"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -61894,7 +62032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -61903,7 +62041,7 @@
       "source_location": "L20"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -61912,7 +62050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -61921,7 +62059,7 @@
       "source_location": "L62"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -61930,7 +62068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -61939,7 +62077,97 @@
       "source_location": "L178"
     },
     {
-      "community": 518,
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_comparedeterministically",
+      "label": "compareDeterministically()",
+      "norm_label": "comparedeterministically()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_isjsonobject",
+      "label": "isJsonObject()",
+      "norm_label": "isjsonobject()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_normalizegraphjsonartifact",
+      "label": "normalizeGraphJsonArtifact()",
+      "norm_label": "normalizegraphjsonartifact()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_normalizegraphjsoncontents",
+      "label": "normalizeGraphJsonContents()",
+      "norm_label": "normalizegraphjsoncontents()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_resolvegraphifypython",
+      "label": "resolveGraphifyPython()",
+      "norm_label": "resolvegraphifypython()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_rungraphifyrebuild",
+      "label": "runGraphifyRebuild()",
+      "norm_label": "rungraphifyrebuild()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L194"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_sortjsonarray",
+      "label": "sortJsonArray()",
+      "norm_label": "sortjsonarray()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "graphify_rebuild_sortjsonvalue",
+      "label": "sortJsonValue()",
+      "norm_label": "sortjsonvalue()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_ts",
+      "label": "graphify-rebuild.ts",
+      "norm_label": "graphify-rebuild.ts",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -61948,7 +62176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 520,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -61957,7 +62185,7 @@
       "source_location": "L29"
     },
     {
-      "community": 519,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -61966,7 +62194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 519,
+      "community": 521,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -61975,88 +62203,7 @@
       "source_location": "L59"
     },
     {
-      "community": 52,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_hascustomersnapshotvalue",
-      "label": "hasCustomerSnapshotValue()",
-      "norm_label": "hascustomersnapshotvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_normalizecustomersnapshot",
-      "label": "normalizeCustomerSnapshot()",
-      "norm_label": "normalizecustomersnapshot()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_persistsessionworkflowtraceidbesteffort",
-      "label": "persistSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistsessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_recordsessionlifecycletracebesteffort",
-      "label": "recordSessionLifecycleTraceBestEffort()",
-      "norm_label": "recordsessionlifecycletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "possessions_resolvecustomertracestage",
-      "label": "resolveCustomerTraceStage()",
-      "norm_label": "resolvecustomertracestage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -62065,7 +62212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -62074,7 +62221,7 @@
       "source_location": "L45"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -62083,7 +62230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -62092,7 +62239,7 @@
       "source_location": "L47"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -62101,7 +62248,7 @@
       "source_location": "L29"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -62110,7 +62257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -62119,7 +62266,7 @@
       "source_location": "L3"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -62128,7 +62275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -62137,7 +62284,7 @@
       "source_location": "L4"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -62146,7 +62293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -62155,7 +62302,7 @@
       "source_location": "L4"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -62164,7 +62311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -62173,7 +62320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -62182,7 +62329,7 @@
       "source_location": "L9"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -62191,48 +62338,12 @@
       "source_location": "L9"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
       "norm_label": "contactview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "maintenanceview_maintenanceview",
-      "label": "MaintenanceView()",
-      "norm_label": "maintenanceview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "label": "MaintenanceView.tsx",
-      "norm_label": "maintenanceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L1"
     },
     {
@@ -62319,6 +62430,42 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "maintenanceview_maintenanceview",
+      "label": "MaintenanceView()",
+      "norm_label": "maintenanceview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
+      "label": "MaintenanceView.tsx",
+      "norm_label": "maintenanceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
       "norm_label": "taxview.tsx",
@@ -62326,7 +62473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -62335,7 +62482,7 @@
       "source_location": "L25"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -62344,7 +62491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -62353,7 +62500,7 @@
       "source_location": "L19"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -62362,7 +62509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -62371,7 +62518,7 @@
       "source_location": "L63"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -62380,7 +62527,7 @@
       "source_location": "L7"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -62389,7 +62536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -62398,7 +62545,7 @@
       "source_location": "L25"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -62407,7 +62554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -62416,7 +62563,7 @@
       "source_location": "L15"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -62425,7 +62572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -62434,7 +62581,7 @@
       "source_location": "L21"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -62443,7 +62590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -62452,48 +62599,12 @@
       "source_location": "L6"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
       "norm_label": "label.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "organization_modal_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
-      "label": "organization-modal.tsx",
-      "norm_label": "organization-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -62580,6 +62691,42 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "organization_modal_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
+      "label": "organization-modal.tsx",
+      "norm_label": "organization-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
       "norm_label": "store-modal.tsx",
@@ -62587,7 +62734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -62596,7 +62743,7 @@
       "source_location": "L63"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -62605,7 +62752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -62614,7 +62761,7 @@
       "source_location": "L5"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -62623,7 +62770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -62632,7 +62779,7 @@
       "source_location": "L12"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -62641,7 +62788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -62650,7 +62797,7 @@
       "source_location": "L15"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -62659,7 +62806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -62668,7 +62815,7 @@
       "source_location": "L3"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -62677,7 +62824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -62686,7 +62833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -62695,7 +62842,7 @@
       "source_location": "L5"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -62704,7 +62851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -62713,48 +62860,12 @@
       "source_location": "L11"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
       "norm_label": "bagitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_string",
-      "label": "String()",
-      "norm_label": "string()",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
-      "label": "CustomerBehaviorTimeline.tsx",
-      "norm_label": "customerbehaviortimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1"
     },
     {
@@ -62841,6 +62952,42 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_string",
+      "label": "String()",
+      "norm_label": "string()",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
+      "label": "CustomerBehaviorTimeline.tsx",
+      "norm_label": "customerbehaviortimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
       "norm_label": "useranalyticsname.tsx",
@@ -62848,7 +62995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -62857,7 +63004,7 @@
       "source_location": "L13"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -62866,7 +63013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -62875,7 +63022,7 @@
       "source_location": "L7"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -62884,7 +63031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -62893,7 +63040,7 @@
       "source_location": "L11"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -62902,7 +63049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -62911,7 +63058,7 @@
       "source_location": "L7"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -62920,7 +63067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -62929,7 +63076,7 @@
       "source_location": "L45"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -62938,7 +63085,7 @@
       "source_location": "L13"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -62947,7 +63094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -62956,7 +63103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -62965,7 +63112,7 @@
       "source_location": "L7"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -62974,49 +63121,13 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
       "norm_label": "useismobile()",
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
-      "label": "use-navigation-keyboard-shortcuts.ts",
-      "norm_label": "use-navigation-keyboard-shortcuts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "label": "useNavigationKeyboardShortcuts()",
-      "norm_label": "usenavigationkeyboardshortcuts()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
-      "source_location": "L7"
     },
     {
       "community": 56,
@@ -63102,6 +63213,42 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
+      "label": "use-navigation-keyboard-shortcuts.ts",
+      "norm_label": "use-navigation-keyboard-shortcuts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
+      "label": "useNavigationKeyboardShortcuts()",
+      "norm_label": "usenavigationkeyboardshortcuts()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
       "norm_label": "use-pagination-persistence.ts",
@@ -63109,7 +63256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -63118,7 +63265,7 @@
       "source_location": "L9"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -63127,7 +63274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -63136,7 +63283,7 @@
       "source_location": "L6"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -63145,7 +63292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -63154,7 +63301,7 @@
       "source_location": "L168"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -63163,7 +63310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -63172,7 +63319,7 @@
       "source_location": "L5"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -63181,7 +63328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -63190,7 +63337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -63199,7 +63346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -63208,7 +63355,7 @@
       "source_location": "L6"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -63217,7 +63364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -63226,7 +63373,7 @@
       "source_location": "L12"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -63235,49 +63382,13 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
       "norm_label": "useexpenseoperations()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L23"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
-      "label": "useGetAuthedUser.ts",
-      "norm_label": "usegetautheduser.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "usegetautheduser_usegetautheduser",
-      "label": "useGetAuthedUser()",
-      "norm_label": "usegetautheduser()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L4"
     },
     {
       "community": 57,
@@ -63363,6 +63474,42 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
+      "label": "useGetAuthedUser.ts",
+      "norm_label": "usegetautheduser.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "usegetautheduser_usegetautheduser",
+      "label": "useGetAuthedUser()",
+      "norm_label": "usegetautheduser()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
       "norm_label": "usegetcategories.ts",
@@ -63370,7 +63517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 572,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -63379,7 +63526,7 @@
       "source_location": "L5"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -63388,7 +63535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -63397,7 +63544,7 @@
       "source_location": "L5"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -63406,7 +63553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -63415,7 +63562,7 @@
       "source_location": "L4"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -63424,7 +63571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -63433,7 +63580,7 @@
       "source_location": "L5"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -63442,7 +63589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -63451,7 +63598,7 @@
       "source_location": "L5"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -63460,7 +63607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -63469,7 +63616,7 @@
       "source_location": "L8"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -63478,7 +63625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -63487,7 +63634,7 @@
       "source_location": "L13"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -63496,49 +63643,13 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
       "norm_label": "useprint()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
-      "label": "useProductWithNoImagesNotification.tsx",
-      "norm_label": "useproductwithnoimagesnotification.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "label": "useProductWithNoImagesNotification()",
-      "norm_label": "useproductwithnoimagesnotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L7"
     },
     {
       "community": 58,
@@ -63624,6 +63735,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
+      "label": "useProductWithNoImagesNotification.tsx",
+      "norm_label": "useproductwithnoimagesnotification.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
+      "label": "useProductWithNoImagesNotification()",
+      "norm_label": "useproductwithnoimagesnotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
       "norm_label": "useprotectedadminpagestate.ts",
@@ -63631,7 +63778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 582,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -63640,7 +63787,7 @@
       "source_location": "L5"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -63649,7 +63796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -63658,7 +63805,7 @@
       "source_location": "L19"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -63667,7 +63814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -63676,7 +63823,7 @@
       "source_location": "L12"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -63685,7 +63832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -63694,7 +63841,7 @@
       "source_location": "L12"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -63703,7 +63850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -63712,7 +63859,7 @@
       "source_location": "L5"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -63721,7 +63868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -63730,7 +63877,7 @@
       "source_location": "L5"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -63739,7 +63886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -63748,7 +63895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -63757,48 +63904,12 @@
       "source_location": "L5"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
       "norm_label": "additem.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "bootstrapregister_bootstrapregister",
-      "label": "bootstrapRegister()",
-      "norm_label": "bootstrapregister()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
-      "label": "bootstrapRegister.ts",
-      "norm_label": "bootstrapregister.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "holdsession_holdsession",
-      "label": "holdSession()",
-      "norm_label": "holdsession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
-      "label": "holdSession.ts",
-      "norm_label": "holdsession.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
       "source_location": "L1"
     },
     {
@@ -63885,6 +63996,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "bootstrapregister_bootstrapregister",
+      "label": "bootstrapRegister()",
+      "norm_label": "bootstrapregister()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
+      "label": "bootstrapRegister.ts",
+      "norm_label": "bootstrapregister.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "holdsession_holdsession",
+      "label": "holdSession()",
+      "norm_label": "holdsession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
+      "label": "holdSession.ts",
+      "norm_label": "holdsession.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
       "norm_label": "opendrawer()",
@@ -63892,7 +64039,7 @@
       "source_location": "L5"
     },
     {
-      "community": 590,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -63901,7 +64048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -63910,7 +64057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -63919,7 +64066,7 @@
       "source_location": "L5"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -63928,7 +64075,7 @@
       "source_location": "L10"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -63937,7 +64084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -63946,7 +64093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -63955,7 +64102,7 @@
       "source_location": "L12"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -63964,7 +64111,7 @@
       "source_location": "L10"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -63973,7 +64120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -63982,7 +64129,7 @@
       "source_location": "L6"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -63991,7 +64138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -64000,7 +64147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -64009,7 +64156,7 @@
       "source_location": "L6"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -64018,49 +64165,13 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
       "norm_label": "hasorgnotfoundpayload()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "label": "published.index.tsx",
-      "norm_label": "published.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "published_index_routecomponent",
-      "label": "RouteComponent()",
-      "norm_label": "routecomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L9"
     },
     {
       "community": 6,
@@ -64380,6 +64491,42 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
+      "label": "published.index.tsx",
+      "norm_label": "published.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "published_index_routecomponent",
+      "label": "RouteComponent()",
+      "norm_label": "routecomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
       "id": "index_index",
       "label": "Index()",
       "norm_label": "index()",
@@ -64387,7 +64534,7 @@
       "source_location": "L13"
     },
     {
-      "community": 600,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -64396,7 +64543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -64405,7 +64552,7 @@
       "source_location": "L4"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -64414,7 +64561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -64423,7 +64570,7 @@
       "source_location": "L13"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -64432,7 +64579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -64441,7 +64588,7 @@
       "source_location": "L5"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -64450,7 +64597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -64459,7 +64606,7 @@
       "source_location": "L17"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -64468,7 +64615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -64477,7 +64624,7 @@
       "source_location": "L15"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -64486,7 +64633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -64495,7 +64642,7 @@
       "source_location": "L12"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -64504,7 +64651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -64513,49 +64660,13 @@
       "source_location": "L5"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
-      "label": "Popover.stories.tsx",
-      "norm_label": "popover.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "popover_stories_popovershowcase",
-      "label": "PopoverShowcase()",
-      "norm_label": "popovershowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
-      "label": "Sheet.stories.tsx",
-      "norm_label": "sheet.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "sheet_stories_sheetshowcase",
-      "label": "SheetShowcase()",
-      "norm_label": "sheetshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L14"
     },
     {
       "community": 61,
@@ -64641,6 +64752,42 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
+      "label": "Popover.stories.tsx",
+      "norm_label": "popover.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "popover_stories_popovershowcase",
+      "label": "PopoverShowcase()",
+      "norm_label": "popovershowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
+      "label": "Sheet.stories.tsx",
+      "norm_label": "sheet.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "sheet_stories_sheetshowcase",
+      "label": "SheetShowcase()",
+      "norm_label": "sheetshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
       "norm_label": "tooltip.stories.tsx",
@@ -64648,7 +64795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 612,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -64657,7 +64804,7 @@
       "source_location": "L13"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -64666,7 +64813,7 @@
       "source_location": "L5"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -64675,7 +64822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -64684,7 +64831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -64693,7 +64840,7 @@
       "source_location": "L17"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -64702,7 +64849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -64711,7 +64858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -64720,7 +64867,7 @@
       "source_location": "L4"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -64729,7 +64876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -64738,7 +64885,7 @@
       "source_location": "L27"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -64747,7 +64894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -64756,7 +64903,7 @@
       "source_location": "L4"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -64765,7 +64912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -64774,49 +64921,13 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "entitypage_entitypage",
-      "label": "EntityPage()",
-      "norm_label": "entitypage()",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "label": "EntityPage.tsx",
-      "norm_label": "entitypage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productspage_tsx",
-      "label": "ProductsPage.tsx",
-      "norm_label": "productspage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "productspage_productcardloadingskeleton",
-      "label": "ProductCardLoadingSkeleton()",
-      "norm_label": "productcardloadingskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L10"
     },
     {
       "community": 62,
@@ -64893,6 +65004,42 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "entitypage_entitypage",
+      "label": "EntityPage()",
+      "norm_label": "entitypage()",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
+      "label": "EntityPage.tsx",
+      "norm_label": "entitypage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productspage_tsx",
+      "label": "ProductsPage.tsx",
+      "norm_label": "productspage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "productspage_productcardloadingskeleton",
+      "label": "ProductCardLoadingSkeleton()",
+      "norm_label": "productcardloadingskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
       "norm_label": "authcomponent()",
@@ -64900,7 +65047,7 @@
       "source_location": "L4"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -64909,7 +65056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -64918,7 +65065,7 @@
       "source_location": "L39"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -64927,7 +65074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -64936,7 +65083,7 @@
       "source_location": "L18"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -64945,7 +65092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -64954,7 +65101,7 @@
       "source_location": "L71"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -64963,7 +65110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -64972,7 +65119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -64981,7 +65128,7 @@
       "source_location": "L12"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -64990,7 +65137,7 @@
       "source_location": "L6"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -64999,7 +65146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -65008,7 +65155,7 @@
       "source_location": "L18"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -65017,7 +65164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -65026,7 +65173,7 @@
       "source_location": "L10"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -65035,799 +65182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "label": "PaymentMethodSection.tsx",
-      "norm_label": "paymentmethodsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "paymentmethodsection_paymentmethodsection",
-      "label": "PaymentMethodSection()",
-      "norm_label": "paymentmethodsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "label": "PaymentSection.tsx",
-      "norm_label": "paymentsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "paymentsection_paymentsection",
-      "label": "PaymentSection()",
-      "norm_label": "paymentsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L27"
-    },
-    {
       "community": 63,
-      "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "deliveryfees_calculatedeliveryfee",
-      "label": "calculateDeliveryFee()",
-      "norm_label": "calculatedeliveryfee()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "label": "deliveryFees.ts",
-      "norm_label": "deliveryfees.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 631,
-      "file_type": "code",
-      "id": "derivecheckoutstate_derivecheckoutstate",
-      "label": "deriveCheckoutState()",
-      "norm_label": "derivecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 631,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "label": "deriveCheckoutState.ts",
-      "norm_label": "derivecheckoutstate.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 632,
-      "file_type": "code",
-      "id": "checkoutschemas_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 632,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
-      "label": "checkoutSchemas.test.ts",
-      "norm_label": "checkoutschemas.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 633,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
-      "label": "webOrderSchema.test.ts",
-      "norm_label": "weborderschema.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 633,
-      "file_type": "code",
-      "id": "weborderschema_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 634,
-      "file_type": "code",
-      "id": "customerdetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 634,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
-      "label": "CustomerDetailsForm.tsx",
-      "norm_label": "customerdetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 635,
-      "file_type": "code",
-      "id": "deliverydetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 635,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "label": "DeliveryDetailsForm.tsx",
-      "norm_label": "deliverydetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 636,
-      "file_type": "code",
-      "id": "hooks_usecountdown",
-      "label": "useCountdown()",
-      "norm_label": "usecountdown()",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 636,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "label": "TrustSignals.tsx",
-      "norm_label": "trustsignals.tsx",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "trustsignals_trustsignals",
-      "label": "TrustSignals()",
-      "norm_label": "trustsignals()",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "label": "ProductFilter.tsx",
-      "norm_label": "productfilter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "productfilter_productfilter",
-      "label": "ProductFilter()",
-      "norm_label": "productfilter()",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "filter_handlecheckboxchange",
-      "label": "handleCheckboxChange()",
-      "norm_label": "handlecheckboxchange()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "label": "Filter.tsx",
-      "norm_label": "filter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "bestsellerssection_bestsellerssection",
-      "label": "BestSellersSection()",
-      "norm_label": "bestsellerssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "label": "BestSellersSection.tsx",
-      "norm_label": "bestsellerssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 641,
-      "file_type": "code",
-      "id": "homepagecontent_resolvehomepagecontent",
-      "label": "resolveHomepageContent()",
-      "norm_label": "resolvehomepagecontent()",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 641,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
-      "label": "homePageContent.ts",
-      "norm_label": "homepagecontent.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 642,
-      "file_type": "code",
-      "id": "bagmenu_handleonlinkclick",
-      "label": "handleOnLinkClick()",
-      "norm_label": "handleonlinkclick()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 642,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "label": "BagMenu.tsx",
-      "norm_label": "bagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 643,
-      "file_type": "code",
-      "id": "mobilebagmenu_mobilebagmenu",
-      "label": "MobileBagMenu()",
-      "norm_label": "mobilebagmenu()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 643,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
-      "label": "MobileBagMenu.tsx",
-      "norm_label": "mobilebagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 644,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
-      "label": "SiteBanner.tsx",
-      "norm_label": "sitebanner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 644,
-      "file_type": "code",
-      "id": "sitebanner_sitebanner",
-      "label": "SiteBanner()",
-      "norm_label": "sitebanner()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 645,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 645,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 646,
-      "file_type": "code",
-      "id": "dimensionbar_mapvaluetolabelindex",
-      "label": "mapValueToLabelIndex()",
-      "norm_label": "mapvaluetolabelindex()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 646,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "label": "DimensionBar.tsx",
-      "norm_label": "dimensionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "discountbadge_discountbadge",
-      "label": "DiscountBadge()",
-      "norm_label": "discountbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "label": "DiscountBadge.tsx",
-      "norm_label": "discountbadge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "galleryviewer_handleclickonpreview",
-      "label": "handleClickOnPreview()",
-      "norm_label": "handleclickonpreview()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "label": "GalleryViewer.tsx",
-      "norm_label": "galleryviewer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "onsaleproduct_onsaleproduct",
-      "label": "OnsaleProduct()",
-      "norm_label": "onsaleproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "label": "OnSaleProduct.tsx",
-      "norm_label": "onsaleproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L880"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L874"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L870"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L890"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L650"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L727"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L632"
-    },
-    {
-      "community": 650,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "label": "ProductActions.tsx",
-      "norm_label": "productactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 650,
-      "file_type": "code",
-      "id": "productactions_productactions",
-      "label": "ProductActions()",
-      "norm_label": "productactions()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 651,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 651,
-      "file_type": "code",
-      "id": "productattributes_productattributes",
-      "label": "ProductAttributes()",
-      "norm_label": "productattributes()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 652,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
-      "label": "ProductPage.tsx",
-      "norm_label": "productpage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 652,
-      "file_type": "code",
-      "id": "productpage_showshippingpolicy",
-      "label": "showShippingPolicy()",
-      "norm_label": "showshippingpolicy()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L78"
-    },
-    {
-      "community": 653,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
-      "label": "ProductReview.tsx",
-      "norm_label": "productreview.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 653,
-      "file_type": "code",
-      "id": "productreview_handlehelpful",
-      "label": "handleHelpful()",
-      "norm_label": "handlehelpful()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 654,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "label": "ReviewSummary.tsx",
-      "norm_label": "reviewsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 654,
-      "file_type": "code",
-      "id": "reviewsummary_reviewsummary",
-      "label": "ReviewSummary()",
-      "norm_label": "reviewsummary()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "label": "RatingSelector.tsx",
-      "norm_label": "ratingselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
-      "id": "ratingselector_ratingselector",
-      "label": "RatingSelector()",
-      "norm_label": "ratingselector()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "guestrewardsprompt_guestrewardsprompt",
-      "label": "GuestRewardsPrompt()",
-      "norm_label": "guestrewardsprompt()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "label": "GuestRewardsPrompt.tsx",
-      "norm_label": "guestrewardsprompt.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "orderpointsdisplay_orderpointsdisplay",
-      "label": "OrderPointsDisplay()",
-      "norm_label": "orderpointsdisplay()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "label": "OrderPointsDisplay.tsx",
-      "norm_label": "orderpointsdisplay.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "label": "PastOrdersRewards.tsx",
-      "norm_label": "pastordersrewards.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "pastordersrewards_handleclaimpoints",
-      "label": "handleClaimPoints()",
-      "norm_label": "handleclaimpoints()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 66,
       "file_type": "code",
       "id": "index_senddiscountcodeemail",
       "label": "sendDiscountCodeEmail()",
@@ -65836,7 +65191,7 @@
       "source_location": "L255"
     },
     {
-      "community": 66,
+      "community": 63,
       "file_type": "code",
       "id": "index_senddiscountreminderemail",
       "label": "sendDiscountReminderEmail()",
@@ -65845,7 +65200,7 @@
       "source_location": "L334"
     },
     {
-      "community": 66,
+      "community": 63,
       "file_type": "code",
       "id": "index_sendfeedbackrequestemail",
       "label": "sendFeedbackRequestEmail()",
@@ -65854,7 +65209,7 @@
       "source_location": "L167"
     },
     {
-      "community": 66,
+      "community": 63,
       "file_type": "code",
       "id": "index_sendneworderemail",
       "label": "sendNewOrderEmail()",
@@ -65863,7 +65218,7 @@
       "source_location": "L117"
     },
     {
-      "community": 66,
+      "community": 63,
       "file_type": "code",
       "id": "index_sendorderemail",
       "label": "sendOrderEmail()",
@@ -65872,7 +65227,7 @@
       "source_location": "L43"
     },
     {
-      "community": 66,
+      "community": 63,
       "file_type": "code",
       "id": "index_sendverificationcode",
       "label": "sendVerificationCode()",
@@ -65881,7 +65236,7 @@
       "source_location": "L3"
     },
     {
-      "community": 66,
+      "community": 63,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mailersend_index_tsx",
       "label": "index.tsx",
@@ -65890,7 +65245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 66,
+      "community": 63,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
       "label": "index.tsx",
@@ -65899,7 +65254,799 @@
       "source_location": "L1"
     },
     {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
+      "label": "PaymentMethodSection.tsx",
+      "norm_label": "paymentmethodsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "paymentmethodsection_paymentmethodsection",
+      "label": "PaymentMethodSection()",
+      "norm_label": "paymentmethodsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
+      "label": "PaymentSection.tsx",
+      "norm_label": "paymentsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "paymentsection_paymentsection",
+      "label": "PaymentSection()",
+      "norm_label": "paymentsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "deliveryfees_calculatedeliveryfee",
+      "label": "calculateDeliveryFee()",
+      "norm_label": "calculatedeliveryfee()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
+      "label": "deliveryFees.ts",
+      "norm_label": "deliveryfees.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
+      "id": "derivecheckoutstate_derivecheckoutstate",
+      "label": "deriveCheckoutState()",
+      "norm_label": "derivecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
+      "label": "deriveCheckoutState.ts",
+      "norm_label": "derivecheckoutstate.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 634,
+      "file_type": "code",
+      "id": "checkoutschemas_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 634,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
+      "label": "checkoutSchemas.test.ts",
+      "norm_label": "checkoutschemas.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 635,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
+      "label": "webOrderSchema.test.ts",
+      "norm_label": "weborderschema.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 635,
+      "file_type": "code",
+      "id": "weborderschema_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 636,
+      "file_type": "code",
+      "id": "customerdetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 636,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
+      "label": "CustomerDetailsForm.tsx",
+      "norm_label": "customerdetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 637,
+      "file_type": "code",
+      "id": "deliverydetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 637,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
+      "label": "DeliveryDetailsForm.tsx",
+      "norm_label": "deliverydetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 638,
+      "file_type": "code",
+      "id": "hooks_usecountdown",
+      "label": "useCountdown()",
+      "norm_label": "usecountdown()",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 638,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 639,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
+      "label": "TrustSignals.tsx",
+      "norm_label": "trustsignals.tsx",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 639,
+      "file_type": "code",
+      "id": "trustsignals_trustsignals",
+      "label": "TrustSignals()",
+      "norm_label": "trustsignals()",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
+      "label": "ProductFilter.tsx",
+      "norm_label": "productfilter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "productfilter_productfilter",
+      "label": "ProductFilter()",
+      "norm_label": "productfilter()",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "filter_handlecheckboxchange",
+      "label": "handleCheckboxChange()",
+      "norm_label": "handlecheckboxchange()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
+      "label": "Filter.tsx",
+      "norm_label": "filter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "bestsellerssection_bestsellerssection",
+      "label": "BestSellersSection()",
+      "norm_label": "bestsellerssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
+      "label": "BestSellersSection.tsx",
+      "norm_label": "bestsellerssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
+      "id": "homepagecontent_resolvehomepagecontent",
+      "label": "resolveHomepageContent()",
+      "norm_label": "resolvehomepagecontent()",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
+      "label": "homePageContent.ts",
+      "norm_label": "homepagecontent.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "bagmenu_handleonlinkclick",
+      "label": "handleOnLinkClick()",
+      "norm_label": "handleonlinkclick()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
+      "label": "BagMenu.tsx",
+      "norm_label": "bagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "mobilebagmenu_mobilebagmenu",
+      "label": "MobileBagMenu()",
+      "norm_label": "mobilebagmenu()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
+      "label": "MobileBagMenu.tsx",
+      "norm_label": "mobilebagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 646,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
+      "label": "SiteBanner.tsx",
+      "norm_label": "sitebanner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 646,
+      "file_type": "code",
+      "id": "sitebanner_sitebanner",
+      "label": "SiteBanner()",
+      "norm_label": "sitebanner()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 647,
+      "file_type": "code",
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 647,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 648,
+      "file_type": "code",
+      "id": "dimensionbar_mapvaluetolabelindex",
+      "label": "mapValueToLabelIndex()",
+      "norm_label": "mapvaluetolabelindex()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 648,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
+      "label": "DimensionBar.tsx",
+      "norm_label": "dimensionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 649,
+      "file_type": "code",
+      "id": "discountbadge_discountbadge",
+      "label": "DiscountBadge()",
+      "norm_label": "discountbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 649,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
+      "label": "DiscountBadge.tsx",
+      "norm_label": "discountbadge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "galleryviewer_handleclickonpreview",
+      "label": "handleClickOnPreview()",
+      "norm_label": "handleclickonpreview()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
+      "label": "GalleryViewer.tsx",
+      "norm_label": "galleryviewer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "onsaleproduct_onsaleproduct",
+      "label": "OnsaleProduct()",
+      "norm_label": "onsaleproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
+      "label": "OnSaleProduct.tsx",
+      "norm_label": "onsaleproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
+      "label": "ProductActions.tsx",
+      "norm_label": "productactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "productactions_productactions",
+      "label": "ProductActions()",
+      "norm_label": "productactions()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
+      "id": "productattributes_productattributes",
+      "label": "ProductAttributes()",
+      "norm_label": "productattributes()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 654,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
+      "label": "ProductPage.tsx",
+      "norm_label": "productpage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 654,
+      "file_type": "code",
+      "id": "productpage_showshippingpolicy",
+      "label": "showShippingPolicy()",
+      "norm_label": "showshippingpolicy()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L78"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
+      "label": "ProductReview.tsx",
+      "norm_label": "productreview.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "productreview_handlehelpful",
+      "label": "handleHelpful()",
+      "norm_label": "handlehelpful()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 656,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
+      "label": "ReviewSummary.tsx",
+      "norm_label": "reviewsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 656,
+      "file_type": "code",
+      "id": "reviewsummary_reviewsummary",
+      "label": "ReviewSummary()",
+      "norm_label": "reviewsummary()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 657,
+      "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 657,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 658,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
+      "label": "RatingSelector.tsx",
+      "norm_label": "ratingselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 658,
+      "file_type": "code",
+      "id": "ratingselector_ratingselector",
+      "label": "RatingSelector()",
+      "norm_label": "ratingselector()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "guestrewardsprompt_guestrewardsprompt",
+      "label": "GuestRewardsPrompt()",
+      "norm_label": "guestrewardsprompt()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
+      "label": "GuestRewardsPrompt.tsx",
+      "norm_label": "guestrewardsprompt.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L880"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L874"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L870"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L890"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L650"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L727"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L632"
+    },
+    {
       "community": 660,
+      "file_type": "code",
+      "id": "orderpointsdisplay_orderpointsdisplay",
+      "label": "OrderPointsDisplay()",
+      "norm_label": "orderpointsdisplay()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
+      "label": "OrderPointsDisplay.tsx",
+      "norm_label": "orderpointsdisplay.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
+      "label": "PastOrdersRewards.tsx",
+      "norm_label": "pastordersrewards.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "pastordersrewards_handleclaimpoints",
+      "label": "handleClaimPoints()",
+      "norm_label": "handleclaimpoints()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -65908,7 +66055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 662,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -65917,7 +66064,7 @@
       "source_location": "L33"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -65926,7 +66073,7 @@
       "source_location": "L19"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -65935,7 +66082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -65944,7 +66091,7 @@
       "source_location": "L4"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -65953,7 +66100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -65962,7 +66109,7 @@
       "source_location": "L22"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -65971,7 +66118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -65980,7 +66127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -65989,7 +66136,7 @@
       "source_location": "L11"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -65998,7 +66145,7 @@
       "source_location": "L3"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -66007,7 +66154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -66016,7 +66163,7 @@
       "source_location": "L3"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -66025,7 +66172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -66034,49 +66181,13 @@
       "source_location": "L9"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
       "norm_label": "ghost-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "leaveareviewmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "label": "LeaveAReviewModal.tsx",
-      "norm_label": "leaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "label": "UpsellModalSuccess.tsx",
-      "norm_label": "upsellmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "label": "UpsellModalSuccess()",
-      "norm_label": "upsellmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L19"
     },
     {
       "community": 67,
@@ -66153,6 +66264,42 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "leaveareviewmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
+      "label": "LeaveAReviewModal.tsx",
+      "norm_label": "leaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
+      "label": "UpsellModalSuccess.tsx",
+      "norm_label": "upsellmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "upsellmodalsuccess_upsellmodalsuccess",
+      "label": "UpsellModalSuccess()",
+      "norm_label": "upsellmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
       "norm_label": "welcomebackmodalsuccess.tsx",
@@ -66160,7 +66307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 672,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -66169,7 +66316,7 @@
       "source_location": "L13"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -66178,7 +66325,7 @@
       "source_location": "L46"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -66187,7 +66334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -66196,7 +66343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -66205,7 +66352,7 @@
       "source_location": "L46"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -66214,7 +66361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -66223,7 +66370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -66232,7 +66379,7 @@
       "source_location": "L15"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -66241,7 +66388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -66250,7 +66397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -66259,7 +66406,7 @@
       "source_location": "L5"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -66268,7 +66415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -66277,7 +66424,7 @@
       "source_location": "L14"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -66286,49 +66433,13 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
       "norm_label": "useenhancedtracking()",
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "label": "useGetActiveCheckoutSession.tsx",
-      "norm_label": "usegetactivecheckoutsession.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "label": "useGetActiveCheckoutSession()",
-      "norm_label": "usegetactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "label": "useGetProduct.tsx",
-      "norm_label": "usegetproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "usegetproduct_usegetproductquery",
-      "label": "useGetProductQuery()",
-      "norm_label": "usegetproductquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L5"
     },
     {
       "community": 68,
@@ -66405,6 +66516,42 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
+      "label": "useGetActiveCheckoutSession.tsx",
+      "norm_label": "usegetactivecheckoutsession.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
+      "label": "useGetActiveCheckoutSession()",
+      "norm_label": "usegetactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
+      "label": "useGetProduct.tsx",
+      "norm_label": "usegetproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "usegetproduct_usegetproductquery",
+      "label": "useGetProductQuery()",
+      "norm_label": "usegetproductquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
       "norm_label": "usegetproductfilters.ts",
@@ -66412,7 +66559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 682,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -66421,7 +66568,7 @@
       "source_location": "L3"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -66430,7 +66577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -66439,7 +66586,7 @@
       "source_location": "L4"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -66448,7 +66595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -66457,7 +66604,7 @@
       "source_location": "L4"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -66466,7 +66613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -66475,7 +66622,7 @@
       "source_location": "L9"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -66484,7 +66631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -66493,7 +66640,7 @@
       "source_location": "L17"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -66502,7 +66649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -66511,7 +66658,7 @@
       "source_location": "L5"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -66520,7 +66667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -66529,7 +66676,7 @@
       "source_location": "L15"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -66538,7 +66685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -66547,7 +66694,79 @@
       "source_location": "L18"
     },
     {
-      "community": 688,
+      "community": 69,
+      "file_type": "code",
+      "id": "customerinfopanel_clearcustomer",
+      "label": "clearCustomer()",
+      "norm_label": "clearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L158"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecreatecustomer",
+      "label": "handleCreateCustomer()",
+      "norm_label": "handlecreatecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "customerinfopanel_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L125"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "customerinfopanel_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "customerinfopanel_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "customerinfopanel_showcommanderror",
+      "label": "showCommandError()",
+      "norm_label": "showcommanderror()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
+      "label": "CustomerInfoPanel.tsx",
+      "norm_label": "customerinfopanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -66556,7 +66775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 690,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -66565,7 +66784,7 @@
       "source_location": "L9"
     },
     {
-      "community": 689,
+      "community": 691,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -66574,7 +66793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 689,
+      "community": 691,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -66583,79 +66802,7 @@
       "source_location": "L16"
     },
     {
-      "community": 69,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
-      "label": "welcome-offer-modal.tsx",
-      "norm_label": "welcome-offer-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlecolorchange",
-      "label": "handleColorChange()",
-      "norm_label": "handlecolorchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlenumberchange",
-      "label": "handleNumberChange()",
-      "norm_label": "handlenumberchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleselectchange",
-      "label": "handleSelectChange()",
-      "norm_label": "handleselectchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleswitchchange",
-      "label": "handleSwitchChange()",
-      "norm_label": "handleswitchchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "welcome_offer_modal_updateimages",
-      "label": "updateImages()",
-      "norm_label": "updateimages()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 690,
+      "community": 692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -66664,7 +66811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 690,
+      "community": 692,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -66673,7 +66820,7 @@
       "source_location": "L4"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -66682,7 +66829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -66691,7 +66838,7 @@
       "source_location": "L11"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -66700,7 +66847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -66709,7 +66856,7 @@
       "source_location": "L3"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -66718,7 +66865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -66727,7 +66874,7 @@
       "source_location": "L7"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -66736,7 +66883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -66745,7 +66892,7 @@
       "source_location": "L4"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -66754,7 +66901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -66763,7 +66910,7 @@
       "source_location": "L14"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -66772,7 +66919,7 @@
       "source_location": "L4"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -66781,7 +66928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -66790,48 +66937,12 @@
       "source_location": "L7"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "bannermessage_usebannermessagequeries",
-      "label": "useBannerMessageQueries()",
-      "norm_label": "usebannermessagequeries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "checkout_usecheckoutsessionqueries",
-      "label": "useCheckoutSessionQueries()",
-      "norm_label": "usecheckoutsessionqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1"
     },
     {
@@ -67062,77 +67173,113 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L317"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L193"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L221"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
+      "label": "welcome-offer-modal.tsx",
+      "norm_label": "welcome-offer-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1"
     },
     {
+      "community": 70,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlecolorchange",
+      "label": "handleColorChange()",
+      "norm_label": "handlecolorchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlenumberchange",
+      "label": "handleNumberChange()",
+      "norm_label": "handlenumberchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleselectchange",
+      "label": "handleSelectChange()",
+      "norm_label": "handleselectchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleswitchchange",
+      "label": "handleSwitchChange()",
+      "norm_label": "handleswitchchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "welcome_offer_modal_updateimages",
+      "label": "updateImages()",
+      "norm_label": "updateimages()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L100"
+    },
+    {
       "community": 700,
+      "file_type": "code",
+      "id": "bannermessage_usebannermessagequeries",
+      "label": "useBannerMessageQueries()",
+      "norm_label": "usebannermessagequeries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "checkout_usecheckoutsessionqueries",
+      "label": "useCheckoutSessionQueries()",
+      "norm_label": "usecheckoutsessionqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -67141,7 +67288,7 @@
       "source_location": "L6"
     },
     {
-      "community": 700,
+      "community": 702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -67150,7 +67297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -67159,7 +67306,7 @@
       "source_location": "L5"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -67168,7 +67315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -67177,7 +67324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -67186,7 +67333,7 @@
       "source_location": "L14"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -67195,7 +67342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -67204,7 +67351,7 @@
       "source_location": "L9"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -67213,7 +67360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -67222,7 +67369,7 @@
       "source_location": "L10"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -67231,7 +67378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -67240,7 +67387,7 @@
       "source_location": "L11"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -67249,7 +67396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -67258,7 +67405,7 @@
       "source_location": "L6"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -67267,7 +67414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -67276,7 +67423,79 @@
       "source_location": "L5"
     },
     {
-      "community": 708,
+      "community": 71,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L258"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L189"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L317"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L193"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L221"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -67285,7 +67504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 710,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -67294,7 +67513,7 @@
       "source_location": "L6"
     },
     {
-      "community": 709,
+      "community": 711,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -67303,7 +67522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 709,
+      "community": 711,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -67312,79 +67531,7 @@
       "source_location": "L10"
     },
     {
-      "community": 71,
-      "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 710,
+      "community": 712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -67393,7 +67540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 712,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -67402,7 +67549,7 @@
       "source_location": "L15"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -67411,7 +67558,7 @@
       "source_location": "L14"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -67420,7 +67567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -67429,7 +67576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -67438,7 +67585,7 @@
       "source_location": "L6"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -67447,7 +67594,7 @@
       "source_location": "L13"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -67456,7 +67603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -67465,7 +67612,7 @@
       "source_location": "L8"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -67474,7 +67621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -67483,7 +67630,7 @@
       "source_location": "L14"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -67492,7 +67639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -67501,7 +67648,7 @@
       "source_location": "L13"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -67510,7 +67657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -67519,7 +67666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -67528,7 +67675,79 @@
       "source_location": "L9"
     },
     {
-      "community": 718,
+      "community": 72,
+      "file_type": "code",
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "bag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -67537,7 +67756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 720,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -67546,7 +67765,7 @@
       "source_location": "L15"
     },
     {
-      "community": 719,
+      "community": 721,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -67555,7 +67774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 719,
+      "community": 721,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -67564,79 +67783,7 @@
       "source_location": "L16"
     },
     {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "product_buildquerystring",
-      "label": "buildQueryString()",
-      "norm_label": "buildquerystring()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "product_getallproducts",
-      "label": "getAllProducts()",
-      "norm_label": "getallproducts()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "product_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "product_getbestsellers",
-      "label": "getBestSellers()",
-      "norm_label": "getbestsellers()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "product_getfeatured",
-      "label": "getFeatured()",
-      "norm_label": "getfeatured()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "product_getinventorybyskuids",
-      "label": "getInventoryBySkuIds()",
-      "norm_label": "getinventorybyskuids()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "product_getproduct",
-      "label": "getProduct()",
-      "norm_label": "getproduct()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 720,
+      "community": 722,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -67645,7 +67792,7 @@
       "source_location": "L6"
     },
     {
-      "community": 720,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -67654,7 +67801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -67663,7 +67810,7 @@
       "source_location": "L10"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -67672,7 +67819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -67681,7 +67828,7 @@
       "source_location": "L21"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -67690,7 +67837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -67699,7 +67846,7 @@
       "source_location": "L33"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -67708,7 +67855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -67717,7 +67864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -67726,7 +67873,7 @@
       "source_location": "L193"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -67735,7 +67882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -67744,7 +67891,7 @@
       "source_location": "L7"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -67753,7 +67900,7 @@
       "source_location": "L10"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -67762,7 +67909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -67771,7 +67918,7 @@
       "source_location": "L32"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -67780,7 +67927,79 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 73,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "product_buildquerystring",
+      "label": "buildQueryString()",
+      "norm_label": "buildquerystring()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "product_getallproducts",
+      "label": "getAllProducts()",
+      "norm_label": "getallproducts()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "product_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "product_getbestsellers",
+      "label": "getBestSellers()",
+      "norm_label": "getbestsellers()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "product_getfeatured",
+      "label": "getFeatured()",
+      "norm_label": "getfeatured()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "product_getinventorybyskuids",
+      "label": "getInventoryBySkuIds()",
+      "norm_label": "getinventorybyskuids()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "product_getproduct",
+      "label": "getProduct()",
+      "norm_label": "getproduct()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 730,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -67789,7 +68008,7 @@
       "source_location": "L211"
     },
     {
-      "community": 728,
+      "community": 730,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -67798,7 +68017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 729,
+      "community": 731,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -67807,7 +68026,7 @@
       "source_location": "L85"
     },
     {
-      "community": 729,
+      "community": 731,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -67816,79 +68035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 73,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L553"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L594"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L580"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L504"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L565"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 730,
+      "community": 732,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -67897,7 +68044,7 @@
       "source_location": "L15"
     },
     {
-      "community": 730,
+      "community": 732,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -67906,7 +68053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -67915,7 +68062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -67924,7 +68071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -67933,7 +68080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -67942,7 +68089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -67951,7 +68098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -67960,7 +68107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -67969,7 +68116,79 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L553"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L594"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L580"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L504"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L565"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 740,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -67978,7 +68197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 739,
+      "community": 741,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -67987,79 +68206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 74,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L200"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 740,
+      "community": 742,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -68068,7 +68215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -68077,7 +68224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -68086,7 +68233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -68095,7 +68242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -68104,7 +68251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -68113,7 +68260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -68122,7 +68269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -68131,7 +68278,79 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 750,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -68140,7 +68359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 749,
+      "community": 751,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -68149,70 +68368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 75,
-      "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 750,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -68221,7 +68377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -68230,7 +68386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -68239,7 +68395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -68248,7 +68404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -68257,7 +68413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -68266,7 +68422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -68275,7 +68431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -68284,7 +68440,70 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 76,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -68293,7 +68512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 761,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -68302,70 +68521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "client_buildheaders",
-      "label": "buildHeaders()",
-      "norm_label": "buildheaders()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "client_createcollectionsaccesstoken",
-      "label": "createCollectionsAccessToken()",
-      "norm_label": "createcollectionsaccesstoken()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "client_encodebasicauth",
-      "label": "encodeBasicAuth()",
-      "norm_label": "encodebasicauth()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "client_getrequesttopaystatus",
-      "label": "getRequestToPayStatus()",
-      "norm_label": "getrequesttopaystatus()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "client_requesttopay",
-      "label": "requestToPay()",
-      "norm_label": "requesttopay()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "client_toerror",
-      "label": "toError()",
-      "norm_label": "toerror()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "label": "client.ts",
-      "norm_label": "client.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 760,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -68374,7 +68530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -68383,7 +68539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -68392,7 +68548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -68401,7 +68557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -68410,7 +68566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -68419,7 +68575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -68428,7 +68584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -68437,7 +68593,70 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 77,
+      "file_type": "code",
+      "id": "client_buildheaders",
+      "label": "buildHeaders()",
+      "norm_label": "buildheaders()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "client_createcollectionsaccesstoken",
+      "label": "createCollectionsAccessToken()",
+      "norm_label": "createcollectionsaccesstoken()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "client_encodebasicauth",
+      "label": "encodeBasicAuth()",
+      "norm_label": "encodebasicauth()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "client_getrequesttopaystatus",
+      "label": "getRequestToPayStatus()",
+      "norm_label": "getrequesttopaystatus()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "client_requesttopay",
+      "label": "requestToPay()",
+      "norm_label": "requesttopay()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "client_toerror",
+      "label": "toError()",
+      "norm_label": "toerror()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_client_ts",
+      "label": "client.ts",
+      "norm_label": "client.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -68446,7 +68665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 771,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -68455,70 +68674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "linking_buildcustomerprofiledraft",
-      "label": "buildCustomerProfileDraft()",
-      "norm_label": "buildcustomerprofiledraft()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "linking_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "linking_findmatchingcustomerprofile",
-      "label": "findMatchingCustomerProfile()",
-      "norm_label": "findmatchingcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "linking_normalizelookupvalue",
-      "label": "normalizeLookupValue()",
-      "norm_label": "normalizelookupvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "linking_normalizephonenumber",
-      "label": "normalizePhoneNumber()",
-      "norm_label": "normalizephonenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "linking_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
-      "label": "linking.ts",
-      "norm_label": "linking.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 770,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -68527,7 +68683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -68536,7 +68692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -68545,7 +68701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -68554,7 +68710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -68563,7 +68719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -68572,7 +68728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -68581,7 +68737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -68590,7 +68746,70 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 78,
+      "file_type": "code",
+      "id": "linking_buildcustomerprofiledraft",
+      "label": "buildCustomerProfileDraft()",
+      "norm_label": "buildcustomerprofiledraft()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "linking_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "linking_findmatchingcustomerprofile",
+      "label": "findMatchingCustomerProfile()",
+      "norm_label": "findmatchingcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "linking_normalizelookupvalue",
+      "label": "normalizeLookupValue()",
+      "norm_label": "normalizelookupvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "linking_normalizephonenumber",
+      "label": "normalizePhoneNumber()",
+      "norm_label": "normalizephonenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "linking_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
+      "label": "linking.ts",
+      "norm_label": "linking.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -68599,7 +68818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -68608,70 +68827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 780,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -68680,7 +68836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -68689,7 +68845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -68698,7 +68854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -68707,7 +68863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -68716,7 +68872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -68725,7 +68881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -68734,7 +68890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -68743,7 +68899,70 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -68752,7 +68971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -68761,70 +68980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
-      "label": "sessionRepository.ts",
-      "norm_label": "sessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "sessionrepository_getactivesessionforregisterstate",
-      "label": "getActiveSessionForRegisterState()",
-      "norm_label": "getactivesessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "sessionrepository_listheldsessionsforregisterstate",
-      "label": "listHeldSessionsForRegisterState()",
-      "norm_label": "listheldsessionsforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "sessionrepository_matchesregisteridentity",
-      "label": "matchesRegisterIdentity()",
-      "norm_label": "matchesregisteridentity()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "sessionrepository_querysessionsbystatus",
-      "label": "querySessionsByStatus()",
-      "norm_label": "querysessionsbystatus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "sessionrepository_selectregisterstatelookupstrategy",
-      "label": "selectRegisterStateLookupStrategy()",
-      "norm_label": "selectregisterstatelookupstrategy()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "sessionrepository_summarizeregisterstatesessions",
-      "label": "summarizeRegisterStateSessions()",
-      "norm_label": "summarizeregisterstatesessions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 790,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -68833,7 +68989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -68842,7 +68998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -68851,16 +69007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
-      "label": "posSessionItems.ts",
-      "norm_label": "possessionitems.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -68869,7 +69016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -68878,7 +69025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -68887,7 +69034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -68896,21 +69043,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
       "norm_label": "stockvalidation.ts",
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "label": "storeConfigV2.test.ts",
-      "norm_label": "storeconfigv2.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1"
     },
     {
@@ -69114,68 +69252,77 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "label": "getCustomerAnalyticsQuery()",
-      "norm_label": "getcustomeranalyticsquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
-      "label": "getCustomerOperationalTimelineEvents()",
-      "norm_label": "getcustomeroperationaltimelineevents()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getproductinfomaps",
-      "label": "getProductInfoMaps()",
-      "norm_label": "getproductinfomaps()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimefilterforrange",
-      "label": "getTimeFilterForRange()",
-      "norm_label": "gettimefilterforrange()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimelineuserdata",
-      "label": "getTimelineUserData()",
-      "norm_label": "gettimelineuserdata()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
-      "label": "resolveCustomerProfileIdForTimeline()",
-      "norm_label": "resolvecustomerprofileidfortimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "label": "customerBehaviorTimeline.ts",
-      "norm_label": "customerbehaviortimeline.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
+      "label": "sessionRepository.ts",
+      "norm_label": "sessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
       "source_location": "L1"
     },
     {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessionrepository_getactivesessionforregisterstate",
+      "label": "getActiveSessionForRegisterState()",
+      "norm_label": "getactivesessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessionrepository_listheldsessionsforregisterstate",
+      "label": "listHeldSessionsForRegisterState()",
+      "norm_label": "listheldsessionsforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessionrepository_matchesregisteridentity",
+      "label": "matchesRegisterIdentity()",
+      "norm_label": "matchesregisteridentity()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessionrepository_querysessionsbystatus",
+      "label": "querySessionsByStatus()",
+      "norm_label": "querysessionsbystatus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessionrepository_selectregisterstatelookupstrategy",
+      "label": "selectRegisterStateLookupStrategy()",
+      "norm_label": "selectregisterstatelookupstrategy()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "sessionrepository_summarizeregisterstatesessions",
+      "label": "summarizeRegisterStateSessions()",
+      "norm_label": "summarizeregisterstatesessions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L97"
+    },
+    {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
+      "label": "storeConfigV2.test.ts",
+      "norm_label": "storeconfigv2.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -69184,7 +69331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -69193,7 +69340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -69202,7 +69349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -69211,7 +69358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -69220,7 +69367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -69229,7 +69376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -69238,7 +69385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -69247,7 +69394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -69256,7 +69403,70 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 81,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
+      "label": "getCustomerAnalyticsQuery()",
+      "norm_label": "getcustomeranalyticsquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
+      "label": "getCustomerOperationalTimelineEvents()",
+      "norm_label": "getcustomeroperationaltimelineevents()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_getproductinfomaps",
+      "label": "getProductInfoMaps()",
+      "norm_label": "getproductinfomaps()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_gettimefilterforrange",
+      "label": "getTimeFilterForRange()",
+      "norm_label": "gettimefilterforrange()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_gettimelineuserdata",
+      "label": "getTimelineUserData()",
+      "norm_label": "gettimelineuserdata()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
+      "label": "resolveCustomerProfileIdForTimeline()",
+      "norm_label": "resolvecustomerprofileidfortimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
+      "label": "customerBehaviorTimeline.ts",
+      "norm_label": "customerbehaviortimeline.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -69265,70 +69475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
-      "file_type": "code",
-      "id": "onlineorder_clearbagitems",
-      "label": "clearBagItems()",
-      "norm_label": "clearbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "onlineorder_createorderfromcheckoutsession",
-      "label": "createOrderFromCheckoutSession()",
-      "norm_label": "createorderfromcheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "onlineorder_findorderbyexternalreference",
-      "label": "findOrderByExternalReference()",
-      "norm_label": "findorderbyexternalreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "onlineorder_findorderbyexternaltransactionid",
-      "label": "findOrderByExternalTransactionId()",
-      "norm_label": "findorderbyexternaltransactionid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "onlineorder_generateordernumber",
-      "label": "generateOrderNumber()",
-      "norm_label": "generateordernumber()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "onlineorder_returnorderitemstostock",
-      "label": "returnOrderItemsToStock()",
-      "norm_label": "returnorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 810,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -69337,7 +69484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -69346,7 +69493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -69355,7 +69502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -69364,7 +69511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -69373,7 +69520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -69382,7 +69529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -69391,7 +69538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -69400,7 +69547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -69409,7 +69556,70 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 82,
+      "file_type": "code",
+      "id": "onlineorder_clearbagitems",
+      "label": "clearBagItems()",
+      "norm_label": "clearbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "onlineorder_createorderfromcheckoutsession",
+      "label": "createOrderFromCheckoutSession()",
+      "norm_label": "createorderfromcheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "onlineorder_findorderbyexternalreference",
+      "label": "findOrderByExternalReference()",
+      "norm_label": "findorderbyexternalreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "onlineorder_findorderbyexternaltransactionid",
+      "label": "findOrderByExternalTransactionId()",
+      "norm_label": "findorderbyexternaltransactionid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "onlineorder_generateordernumber",
+      "label": "generateOrderNumber()",
+      "norm_label": "generateordernumber()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "onlineorder_returnorderitemstostock",
+      "label": "returnOrderItemsToStock()",
+      "norm_label": "returnorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 820,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -69418,70 +69628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 82,
-      "file_type": "code",
-      "id": "orderupdateemails_formatorderitems",
-      "label": "formatOrderItems()",
-      "norm_label": "formatorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "orderupdateemails_getdeliveryaddress",
-      "label": "getDeliveryAddress()",
-      "norm_label": "getdeliveryaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "orderupdateemails_getlocationdetails",
-      "label": "getLocationDetails()",
-      "norm_label": "getlocationdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "orderupdateemails_getpickuplocation",
-      "label": "getPickupLocation()",
-      "norm_label": "getpickuplocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "orderupdateemails_handleorderstatusupdate",
-      "label": "handleOrderStatusUpdate()",
-      "norm_label": "handleorderstatusupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "orderupdateemails_processorderupdateemail",
-      "label": "processOrderUpdateEmail()",
-      "norm_label": "processorderupdateemail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "label": "orderUpdateEmails.ts",
-      "norm_label": "orderupdateemails.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 820,
+      "community": 821,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -69490,7 +69637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -69499,7 +69646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -69508,7 +69655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -69517,7 +69664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -69526,7 +69673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -69535,7 +69682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -69544,7 +69691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -69553,7 +69700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -69562,7 +69709,70 @@
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 83,
+      "file_type": "code",
+      "id": "orderupdateemails_formatorderitems",
+      "label": "formatOrderItems()",
+      "norm_label": "formatorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "orderupdateemails_getdeliveryaddress",
+      "label": "getDeliveryAddress()",
+      "norm_label": "getdeliveryaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "orderupdateemails_getlocationdetails",
+      "label": "getLocationDetails()",
+      "norm_label": "getlocationdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "orderupdateemails_getpickuplocation",
+      "label": "getPickupLocation()",
+      "norm_label": "getpickuplocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "orderupdateemails_handleorderstatusupdate",
+      "label": "handleOrderStatusUpdate()",
+      "norm_label": "handleorderstatusupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "orderupdateemails_processorderupdateemail",
+      "label": "processOrderUpdateEmail()",
+      "norm_label": "processorderupdateemail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
+      "label": "orderUpdateEmails.ts",
+      "norm_label": "orderupdateemails.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 830,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -69571,70 +69781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 830,
+      "community": 831,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -69643,7 +69790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -69652,7 +69799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -69661,7 +69808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -69670,7 +69817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -69679,7 +69826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -69688,7 +69835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -69697,7 +69844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -69706,7 +69853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -69715,7 +69862,70 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 840,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -69724,70 +69934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
-      "file_type": "code",
-      "id": "core_appendworkflowtraceeventwithctx",
-      "label": "appendWorkflowTraceEventWithCtx()",
-      "norm_label": "appendworkflowtraceeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "core_createworkflowtracewithctx",
-      "label": "createWorkflowTraceWithCtx()",
-      "norm_label": "createworkflowtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "core_getworkflowtracebyidwithctx",
-      "label": "getWorkflowTraceByIdWithCtx()",
-      "norm_label": "getworkflowtracebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "core_getworkflowtracebylookupwithctx",
-      "label": "getWorkflowTraceByLookupWithCtx()",
-      "norm_label": "getworkflowtracebylookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "core_listworkflowtraceeventswithctx",
-      "label": "listWorkflowTraceEventsWithCtx()",
-      "norm_label": "listworkflowtraceeventswithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "core_registerworkflowtracelookupwithctx",
-      "label": "registerWorkflowTraceLookupWithCtx()",
-      "norm_label": "registerworkflowtracelookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
-      "label": "core.ts",
-      "norm_label": "core.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 840,
+      "community": 841,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -69796,7 +69943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -69805,7 +69952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -69814,7 +69961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -69823,7 +69970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -69832,7 +69979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -69841,7 +69988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -69850,7 +69997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -69859,7 +70006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -69868,7 +70015,70 @@
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 85,
+      "file_type": "code",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 850,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -69877,70 +70087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L108"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_summarystrip",
-      "label": "SummaryStrip()",
-      "norm_label": "summarystrip()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 850,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -69949,7 +70096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -69958,7 +70105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -69967,7 +70114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -69976,7 +70123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -69985,7 +70132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -69994,7 +70141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -70003,7 +70150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -70012,7 +70159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -70021,7 +70168,70 @@
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 86,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L108"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_summarystrip",
+      "label": "SummaryStrip()",
+      "norm_label": "summarystrip()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L128"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 860,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -70030,70 +70240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handlemodechange",
-      "label": "handleModeChange()",
-      "norm_label": "handlemodechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L166"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 860,
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -70102,7 +70249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -70111,7 +70258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -70120,7 +70267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -70129,7 +70276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -70138,7 +70285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -70147,7 +70294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -70156,7 +70303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -70165,7 +70312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -70174,7 +70321,70 @@
       "source_location": "L1"
     },
     {
-      "community": 869,
+      "community": 87,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handlemodechange",
+      "label": "handleModeChange()",
+      "norm_label": "handlemodechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L166"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 870,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -70183,70 +70393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 87,
-      "file_type": "code",
-      "id": "customerinfopanel_clearcustomer",
-      "label": "clearCustomer()",
-      "norm_label": "clearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L164"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "customerinfopanel_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "customerinfopanel_handlecreatecustomer",
-      "label": "handleCreateCustomer()",
-      "norm_label": "handlecreatecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "customerinfopanel_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "customerinfopanel_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "customerinfopanel_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L112"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
-      "label": "CustomerInfoPanel.tsx",
-      "norm_label": "customerinfopanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 870,
+      "community": 871,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -70255,7 +70402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -70264,7 +70411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -70273,7 +70420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -70282,7 +70429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -70291,7 +70438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -70300,7 +70447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -70309,7 +70456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -70318,21 +70465,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
       "norm_label": "purchaseorder.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
-      "label": "purchaseOrderLineItem.ts",
-      "norm_label": "purchaseorderlineitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
       "source_location": "L1"
     },
     {
@@ -70401,6 +70539,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
+      "label": "purchaseOrderLineItem.ts",
+      "norm_label": "purchaseorderlineitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
       "norm_label": "receivingbatch.ts",
@@ -70408,7 +70555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -70417,7 +70564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -70426,7 +70573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -70435,7 +70582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -70444,7 +70591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -70453,7 +70600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -70462,7 +70609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -70471,21 +70618,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
       "source_location": "L1"
     },
     {
@@ -70554,6 +70692,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -70561,7 +70708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -70570,7 +70717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -70579,7 +70726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -70588,7 +70735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -70597,7 +70744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -70606,7 +70753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -70615,7 +70762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -70624,21 +70771,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
       "norm_label": "storefrontsession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
       "source_location": "L1"
     },
     {
@@ -70896,6 +71034,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
       "norm_label": "storefrontverificationcode.ts",
@@ -70903,7 +71050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -70912,7 +71059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -70921,7 +71068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -70930,7 +71077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -70939,7 +71086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -70948,7 +71095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -70957,7 +71104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -70966,21 +71113,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
       "norm_label": "orderoperations.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
       "source_location": "L1"
     },
     {
@@ -71049,6 +71187,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
       "norm_label": "paystackactions.ts",
@@ -71056,7 +71203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -71065,7 +71212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -71074,7 +71221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -71083,7 +71230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -71092,7 +71239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_test_ts",
       "label": "posSale.test.ts",
@@ -71101,7 +71248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -71110,7 +71257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -71119,7 +71266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -71128,169 +71275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/athena-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
       "community": 92,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 920,
-      "file_type": "code",
-      "id": "packages_athena_webapp_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 921,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 922,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/shared/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 923,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_test_ts",
-      "label": "commandResult.test.ts",
-      "norm_label": "commandresult.test.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 924,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
-      "label": "GenericComboBox.tsx",
-      "norm_label": "genericcombobox.tsx",
-      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 925,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
-      "label": "StoreAccordion.tsx",
-      "norm_label": "storeaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 926,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
-      "label": "StoresAccordion.tsx",
-      "norm_label": "storesaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 927,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
-      "label": "ThemeToggle.tsx",
-      "norm_label": "themetoggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
-      "label": "DefaultAttributesToggleGroup.tsx",
-      "norm_label": "defaultattributestogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
-      "label": "ProductAttributesView.tsx",
-      "norm_label": "productattributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 93,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
       "label": "reference-fixtures.tsx",
@@ -71299,7 +71284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 93,
+      "community": 92,
       "file_type": "code",
       "id": "reference_fixtures_compacttable",
       "label": "CompactTable()",
@@ -71308,7 +71293,7 @@
       "source_location": "L263"
     },
     {
-      "community": 93,
+      "community": 92,
       "file_type": "code",
       "id": "reference_fixtures_framecard",
       "label": "FrameCard()",
@@ -71317,7 +71302,7 @@
       "source_location": "L163"
     },
     {
-      "community": 93,
+      "community": 92,
       "file_type": "code",
       "id": "reference_fixtures_lanecard",
       "label": "LaneCard()",
@@ -71326,7 +71311,7 @@
       "source_location": "L213"
     },
     {
-      "community": 93,
+      "community": 92,
       "file_type": "code",
       "id": "reference_fixtures_metrictile",
       "label": "MetricTile()",
@@ -71335,7 +71320,7 @@
       "source_location": "L194"
     },
     {
-      "community": 93,
+      "community": 92,
       "file_type": "code",
       "id": "reference_fixtures_minitrendchart",
       "label": "MiniTrendChart()",
@@ -71344,7 +71329,7 @@
       "source_location": "L240"
     },
     {
-      "community": 93,
+      "community": 92,
       "file_type": "code",
       "id": "reference_fixtures_referencepageshell",
       "label": "ReferencePageShell()",
@@ -71353,97 +71338,97 @@
       "source_location": "L145"
     },
     {
-      "community": 930,
+      "community": 920,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
+      "id": "packages_athena_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/athena-webapp/eslint.config.js",
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 921,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 922,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 923,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "id": "packages_athena_webapp_shared_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/shared/auth.ts",
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 924,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
+      "id": "packages_athena_webapp_shared_commandresult_test_ts",
+      "label": "commandResult.test.ts",
+      "norm_label": "commandresult.test.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 925,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
-      "label": "ConversionFunnelChart.tsx",
-      "norm_label": "conversionfunnelchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
+      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
+      "label": "GenericComboBox.tsx",
+      "norm_label": "genericcombobox.tsx",
+      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 926,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
-      "label": "RevenueChart.tsx",
-      "norm_label": "revenuechart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
+      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
+      "label": "StoreAccordion.tsx",
+      "norm_label": "storeaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 927,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
+      "label": "StoresAccordion.tsx",
+      "norm_label": "storesaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 928,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
+      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
+      "label": "ThemeToggle.tsx",
+      "norm_label": "themetoggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
       "source_location": "L1"
     },
     {
-      "community": 939,
+      "community": 929,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
+      "label": "DefaultAttributesToggleGroup.tsx",
+      "norm_label": "defaultattributestogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1"
     },
     {
-      "community": 94,
+      "community": 93,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
       "label": "savedBag.ts",
@@ -71452,7 +71437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 94,
+      "community": 93,
       "file_type": "code",
       "id": "savedbag_additemtosavedbag",
       "label": "addItemToSavedBag()",
@@ -71461,7 +71446,7 @@
       "source_location": "L25"
     },
     {
-      "community": 94,
+      "community": 93,
       "file_type": "code",
       "id": "savedbag_getactivesavedbag",
       "label": "getActiveSavedBag()",
@@ -71470,7 +71455,7 @@
       "source_location": "L10"
     },
     {
-      "community": 94,
+      "community": 93,
       "file_type": "code",
       "id": "savedbag_getbaseurl",
       "label": "getBaseUrl()",
@@ -71479,7 +71464,7 @@
       "source_location": "L8"
     },
     {
-      "community": 94,
+      "community": 93,
       "file_type": "code",
       "id": "savedbag_removeitemfromsavedbag",
       "label": "removeItemFromSavedBag()",
@@ -71488,7 +71473,7 @@
       "source_location": "L91"
     },
     {
-      "community": 94,
+      "community": 93,
       "file_type": "code",
       "id": "savedbag_updatesavedbagitem",
       "label": "updateSavedBagItem()",
@@ -71497,7 +71482,7 @@
       "source_location": "L61"
     },
     {
-      "community": 94,
+      "community": 93,
       "file_type": "code",
       "id": "savedbag_updatesavedbagowner",
       "label": "updateSavedBagOwner()",
@@ -71506,7 +71491,169 @@
       "source_location": "L109"
     },
     {
+      "community": 930,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
+      "label": "ProductAttributesView.tsx",
+      "norm_label": "productattributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 933,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 934,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 935,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 936,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
+      "label": "ConversionFunnelChart.tsx",
+      "norm_label": "conversionfunnelchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 937,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
+      "label": "RevenueChart.tsx",
+      "norm_label": "revenuechart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 938,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 939,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
       "community": 940,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -71515,7 +71662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -71524,7 +71671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -71533,7 +71680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -71542,7 +71689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -71551,7 +71698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -71560,7 +71707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -71569,7 +71716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -71578,21 +71725,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -71661,6 +71799,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -71668,7 +71815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -71677,7 +71824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -71686,7 +71833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -71695,7 +71842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -71704,7 +71851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -71713,7 +71860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -71722,7 +71869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -71731,21 +71878,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -71814,6 +71952,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -71821,7 +71968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -71830,7 +71977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -71839,7 +71986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -71848,7 +71995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -71857,7 +72004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -71866,7 +72013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -71875,7 +72022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -71884,21 +72031,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -71967,6 +72105,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
       "norm_label": "app-sidebar.tsx",
@@ -71974,7 +72121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -71983,7 +72130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -71992,7 +72139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -72001,7 +72148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -72010,7 +72157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -72019,7 +72166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -72028,7 +72175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -72037,21 +72184,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
       "norm_label": "defaultcatchboundary.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
-      "label": "InputOTP.test.tsx",
-      "norm_label": "inputotp.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
       "source_location": "L1"
     },
     {
@@ -72111,6 +72249,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
+      "label": "InputOTP.test.tsx",
+      "norm_label": "inputotp.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
       "norm_label": "loginform.test.tsx",
@@ -72118,7 +72265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -72127,7 +72274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -72136,7 +72283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -72145,7 +72292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -72154,7 +72301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -72163,7 +72310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -72172,7 +72319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -72181,21 +72328,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -72255,6 +72393,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -72262,7 +72409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -72271,7 +72418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -72280,7 +72427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -72289,7 +72436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -72298,7 +72445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -72307,7 +72454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -72316,7 +72463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -72325,21 +72472,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
       "norm_label": "registersessionview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1484
-- Graph nodes: 3716
-- Graph edges: 3241
-- Communities: 1399
+- Code files discovered: 1485
+- Graph nodes: 3722
+- Graph edges: 3248
+- Communities: 1400
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/convex/inventory/pos.ts
+++ b/packages/athena-webapp/convex/inventory/pos.ts
@@ -14,4 +14,7 @@ export {
   getRecentTransactionsWithCustomers,
   getTodaySummary,
 } from "../pos/public/transactions";
-export { createTransactionFromSessionHandler } from "../pos/application/commands/completeTransaction";
+export {
+  createTransactionFromSessionHandler,
+  recordRegisterSessionSale,
+} from "../pos/application/commands/completeTransaction";

--- a/packages/athena-webapp/convex/inventory/posSessionItems.ts
+++ b/packages/athena-webapp/convex/inventory/posSessionItems.ts
@@ -1,17 +1,48 @@
 import { v } from "convex/values";
 import { mutation, query } from "../_generated/server";
 import {
-  itemResultValidator,
-  operationSuccessValidator,
-  error,
-} from "./helpers/resultTypes";
-import {
   runRemoveSessionItemCommand,
   runUpsertSessionItemCommand,
 } from "../pos/application/commands/sessionCommands";
 import { collectSessionItemsFromPages } from "../pos/infrastructure/repositories/sessionCommandRepository";
+import { commandResultValidator } from "../lib/commandResultValidators";
+import { ok, userError } from "../../shared/commandResult";
 
 const SESSION_ITEMS_PAGE_SIZE = 200;
+
+const itemOperationDataValidator = v.object({
+  itemId: v.id("posSessionItem"),
+  expiresAt: v.number(),
+});
+
+const operationDataValidator = v.object({
+  expiresAt: v.number(),
+});
+
+function userErrorFromSessionItemFailure(result: { status: string; message: string }) {
+  switch (result.status) {
+    case "notFound":
+      return userError({
+        code: "not_found",
+        message: result.message,
+      });
+    case "inventoryUnavailable":
+      return userError({
+        code: "conflict",
+        message: result.message,
+      });
+    case "validationFailed":
+      return userError({
+        code: "validation_failed",
+        message: result.message,
+      });
+    default:
+      return userError({
+        code: "precondition_failed",
+        message: result.message,
+      });
+  }
+}
 
 // Get all items for a session
 export const getSessionItems = query({
@@ -71,18 +102,15 @@ export const addOrUpdateItem = mutation({
     color: v.optional(v.string()),
     areProcessingFeesAbsorbed: v.optional(v.boolean()),
   },
-  returns: itemResultValidator,
+  returns: commandResultValidator(itemOperationDataValidator),
   handler: async (ctx, args) => {
     const result = await runUpsertSessionItemCommand(ctx, args);
 
     if (result.status === "ok") {
-      return {
-        success: true as const,
-        data: result.data,
-      };
+      return ok(result.data);
     }
 
-    return error(result.message);
+    return userErrorFromSessionItemFailure(result);
   },
 });
 
@@ -93,17 +121,14 @@ export const removeItem = mutation({
     staffProfileId: v.id("staffProfile"),
     itemId: v.id("posSessionItem"),
   },
-  returns: operationSuccessValidator,
+  returns: commandResultValidator(operationDataValidator),
   handler: async (ctx, args) => {
     const result = await runRemoveSessionItemCommand(ctx, args);
 
     if (result.status === "ok") {
-      return {
-        success: true as const,
-        data: result.data,
-      };
+      return ok(result.data);
     }
 
-    return error(result.message);
+    return userErrorFromSessionItemFailure(result);
   },
 });

--- a/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ok } from "../../shared/commandResult";
 
 const mocks = vi.hoisted(() => ({
   createTransactionFromSessionHandler: vi.fn(),
+  recordRegisterSessionSale: vi.fn(),
   releaseInventoryHoldsBatch: vi.fn(),
   traceRecord: vi.fn(),
 }));
 
 vi.mock("./pos", () => ({
   createTransactionFromSessionHandler: mocks.createTransactionFromSessionHandler,
+  recordRegisterSessionSale: mocks.recordRegisterSessionSale,
 }));
 
 vi.mock("./helpers/inventoryHolds", () => ({
@@ -42,6 +45,7 @@ type SessionRecord = {
   expiresAt: number;
   staffProfileId?: string;
   customerId?: string;
+  registerSessionId?: string;
   customerInfo?: {
     name?: string;
     email?: string;
@@ -212,6 +216,7 @@ describe("pos session lifecycle trace handlers", () => {
       sessions: [
         buildSession({
           _id: "session-1",
+          registerSessionId: "drawer-1",
           subtotal: 100,
           tax: 15,
           total: 115,
@@ -219,11 +224,13 @@ describe("pos session lifecycle trace handlers", () => {
       ],
     });
 
-    mocks.createTransactionFromSessionHandler.mockResolvedValue({
-      success: true,
-      transactionId: "txn-1",
-      transactionNumber: "POS-1001",
-    });
+    mocks.createTransactionFromSessionHandler.mockResolvedValue(
+      ok({
+        transactionId: "txn-1",
+        transactionNumber: "POS-1001",
+        transactionItems: ["txn-item-1"],
+      }),
+    );
 
     const result = await getHandler(completeSession)(ctx as never, {
       sessionId: "session-1",
@@ -235,12 +242,19 @@ describe("pos session lifecycle trace handlers", () => {
     });
 
     expect(result).toEqual({
-      success: true,
+      kind: "ok",
       data: {
         sessionId: "session-1",
         transactionNumber: "POS-1001",
       },
     });
+    expect(mocks.createTransactionFromSessionHandler).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        sessionId: "session-1",
+        recordRegisterSale: false,
+      }),
+    );
     expect(mocks.traceRecord).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -289,7 +303,7 @@ describe("pos session lifecycle trace handlers", () => {
     });
 
     expect(result).toEqual({
-      success: true,
+      kind: "ok",
       data: {
         sessionId: "session-2",
       },
@@ -335,8 +349,11 @@ describe("pos session lifecycle trace handlers", () => {
     });
 
     expect(result).toEqual({
-      sessionId: "session-customer",
-      expiresAt: expect.any(Number),
+      kind: "ok",
+      data: {
+        sessionId: "session-customer",
+        expiresAt: expect.any(Number),
+      },
     });
     expect(mocks.traceRecord).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -379,8 +396,11 @@ describe("pos session lifecycle trace handlers", () => {
     });
 
     expect(result).toEqual({
-      sessionId: "session-customer-cleared",
-      expiresAt: expect.any(Number),
+      kind: "ok",
+      data: {
+        sessionId: "session-customer-cleared",
+        expiresAt: expect.any(Number),
+      },
     });
     expect(mocks.traceRecord).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -393,6 +413,43 @@ describe("pos session lifecycle trace handlers", () => {
         }),
       }),
     );
+  });
+
+  it("treats stale completed sessions as a no-op metadata update", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "session-completed",
+          status: "completed",
+        }),
+      ],
+    });
+
+    const result = await getHandler(updateSession)(ctx as never, {
+      sessionId: "session-completed",
+      staffProfileId: "cashier-1",
+      customerId: "customer-1",
+      customerInfo: {
+        name: "Ama Serwa",
+      },
+      subtotal: 100,
+      tax: 15,
+      total: 115,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        sessionId: "session-completed",
+        expiresAt: 4_102_444_800_000,
+      },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "posSession",
+      "session-completed",
+      expect.anything(),
+    );
+    expect(mocks.traceRecord).not.toHaveBeenCalled();
   });
 
   it("records a cart-cleared milestone and clears pending payments", async () => {
@@ -429,7 +486,7 @@ describe("pos session lifecycle trace handlers", () => {
     );
 
     expect(result).toEqual({
-      success: true,
+      kind: "ok",
       data: {
         sessionId: "session-clear",
       },
@@ -537,7 +594,7 @@ describe("pos session lifecycle trace handlers", () => {
     );
 
     expect(result).toEqual({
-      success: true,
+      kind: "ok",
       data: {
         sessionId: "session-stale-clear",
       },
@@ -575,7 +632,7 @@ describe("pos session lifecycle trace handlers", () => {
     });
 
     expect(paymentResult).toEqual({
-      success: true,
+      kind: "ok",
       data: {
         sessionId: "session-checkout",
         expiresAt: expect.any(Number),
@@ -737,7 +794,7 @@ describe("pos session lifecycle trace handlers", () => {
     });
 
     expect(result).toEqual({
-      success: true,
+      kind: "ok",
       data: {
         sessionId: "session-trace-failure",
         expiresAt: expect.any(Number),

--- a/packages/athena-webapp/convex/inventory/posSessions.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.ts
@@ -22,7 +22,7 @@ import {
   runResumeSessionCommand,
   runStartSessionCommand,
 } from "../pos/application/commands/sessionCommands";
-import { createTransactionFromSessionHandler } from "./pos";
+import { createTransactionFromSessionHandler, recordRegisterSessionSale } from "./pos";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import { ok, userError } from "../../shared/commandResult";
 import {
@@ -469,6 +469,25 @@ export const updateSession = mutation({
         }
       : null;
 
+    const isStaleCompletedSession =
+      currentSession?.status === "completed" || currentSession?.status === "void";
+    const isExpiredSession = Boolean(
+      currentSession?.expiresAt && currentSession.expiresAt < now,
+    );
+
+    // Metadata persistence is best-effort in the register UI, so treat stale
+    // completed/voided/expired sessions as an idempotent no-op instead of
+    // surfacing a new hard failure during sign-out or navigation races.
+    if (
+      currentSession?.staffProfileId === args.staffProfileId &&
+      (isStaleCompletedSession || isExpiredSession)
+    ) {
+      return ok({
+        sessionId,
+        expiresAt: currentSession.expiresAt,
+      });
+    }
+
     // Validate session can be modified (not completed or void)
     const validation = await validateSessionModifiable(
       ctx.db,
@@ -598,6 +617,7 @@ export const completeSession = mutation({
     const transactionResult = await createTransactionFromSessionHandler(ctx, {
       sessionId: args.sessionId,
       payments: args.payments,
+      recordRegisterSale: false,
       notes: args.notes,
     });
 
@@ -607,6 +627,12 @@ export const completeSession = mutation({
 
     const { transactionId, transactionNumber } = transactionResult.data;
     const sessionTransactionId = transactionId as Id<"posTransaction">;
+    const registerSessionId = session.registerSessionId;
+    const totalPaid = args.payments.reduce((sum, payment) => sum + payment.amount, 0);
+
+    if (!registerSessionId) {
+      throw new Error("Session lost its drawer binding during completion.");
+    }
 
     await recordSessionLifecycleTraceBestEffort(ctx, {
       stage: "checkoutSubmitted",
@@ -632,6 +658,15 @@ export const completeSession = mutation({
       subtotal: args.subtotal,
       tax: args.tax,
       total: args.total,
+    });
+
+    await recordRegisterSessionSale(ctx, {
+      payments: args.payments,
+      changeGiven: totalPaid > args.total ? totalPaid - args.total : undefined,
+      registerSessionId,
+      registerNumber: session.registerNumber,
+      storeId: session.storeId,
+      terminalId: session.terminalId,
     });
 
     await recordSessionLifecycleTraceBestEffort(ctx, {

--- a/packages/athena-webapp/convex/inventory/posSessions.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.ts
@@ -16,12 +16,6 @@ import {
   validateSessionActive,
   validateSessionModifiable,
 } from "./helpers/sessionValidation";
-import {
-  sessionOperationResultValidator,
-  sessionResultValidator,
-  error,
-  createSessionResultValidator,
-} from "./helpers/resultTypes";
 import { calculateSessionExpiration } from "./helpers/sessionExpiration";
 import {
   runHoldSessionCommand,
@@ -29,6 +23,8 @@ import {
   runStartSessionCommand,
 } from "../pos/application/commands/sessionCommands";
 import { createTransactionFromSessionHandler } from "./pos";
+import { commandResultValidator } from "../lib/commandResultValidators";
+import { ok, userError } from "../../shared/commandResult";
 import {
   createPosSessionTraceRecorder,
   type PosSessionTraceStage,
@@ -39,6 +35,61 @@ const MAX_SESSION_ITEMS = 200;
 const SESSION_QUERY_CANDIDATE_LIMIT = 200;
 const ACTIVE_SESSION_CANDIDATE_LIMIT = 100;
 const SESSION_CLEANUP_BATCH_SIZE = 100;
+
+const sessionOperationDataValidator = v.object({
+  sessionId: v.id("posSession"),
+  expiresAt: v.number(),
+});
+
+const sessionIdOnlyValidator = v.object({
+  sessionId: v.id("posSession"),
+});
+
+const completeSessionDataValidator = v.object({
+  sessionId: v.id("posSession"),
+  transactionNumber: v.string(),
+});
+
+function userErrorFromSessionCommandFailure(
+  result: { status: string; message: string },
+) {
+  switch (result.status) {
+    case "notFound":
+      return userError({
+        code: "not_found",
+        message: result.message,
+      });
+    case "inventoryUnavailable":
+      return userError({
+        code: "conflict",
+        message: result.message,
+      });
+    case "validationFailed":
+      return userError({
+        code: "validation_failed",
+        message: result.message,
+      });
+    default:
+      return userError({
+        code: "precondition_failed",
+        message: result.message,
+      });
+  }
+}
+
+function userErrorFromValidationMessage(message: string) {
+  if (message.toLowerCase().includes("not found")) {
+    return userError({
+      code: "not_found",
+      message,
+    });
+  }
+
+  return userError({
+    code: "precondition_failed",
+    message,
+  });
+}
 
 async function loadPosSessionItems(ctx: QueryCtx, sessionId: Id<"posSession">) {
   const cartItemsRaw = await ctx.db
@@ -374,18 +425,15 @@ export const createSession = mutation({
     registerNumber: v.optional(v.string()),
     registerSessionId: v.optional(v.id("registerSession")),
   },
-  returns: createSessionResultValidator,
+  returns: commandResultValidator(sessionOperationDataValidator),
   handler: async (ctx, args) => {
     const result = await runStartSessionCommand(ctx, args);
 
     if (result.status === "ok") {
-      return {
-        success: true as const,
-        data: result.data,
-      };
+      return ok(result.data);
     }
 
-    return error(result.message);
+    return userErrorFromSessionCommandFailure(result);
   },
 });
 
@@ -407,7 +455,7 @@ export const updateSession = mutation({
     tax: v.optional(v.number()),
     total: v.optional(v.number()),
   },
-  returns: sessionOperationResultValidator,
+  returns: commandResultValidator(sessionOperationDataValidator),
   handler: async (ctx, args) => {
     const { sessionId, ...updates } = args;
     const now = Date.now();
@@ -428,14 +476,9 @@ export const updateSession = mutation({
       args.staffProfileId
     );
     if (!validation.success) {
-      // For completed/void sessions, return current state without update
-      console.warn(
-        `Attempted to update ${currentSession?.status} session ${sessionId}. Ignoring update.`
+      return userErrorFromValidationMessage(
+        validation.message || "Cannot update this session.",
       );
-      return {
-        sessionId,
-        expiresAt: currentSession?.expiresAt || now,
-      };
     }
 
     // Extend session expiration time
@@ -467,7 +510,7 @@ export const updateSession = mutation({
       }
     }
 
-    return { sessionId, expiresAt };
+    return ok({ sessionId, expiresAt });
   },
 });
 
@@ -478,18 +521,15 @@ export const holdSession = mutation({
     staffProfileId: v.id("staffProfile"),
     holdReason: v.optional(v.string()),
   },
-  returns: sessionResultValidator,
+  returns: commandResultValidator(sessionOperationDataValidator),
   handler: async (ctx, args) => {
     const result = await runHoldSessionCommand(ctx, args);
 
     if (result.status === "ok") {
-      return {
-        success: true as const,
-        data: result.data,
-      };
+      return ok(result.data);
     }
 
-    return error(result.message);
+    return userErrorFromSessionCommandFailure(result);
   },
 });
 
@@ -500,18 +540,15 @@ export const resumeSession = mutation({
     staffProfileId: v.id("staffProfile"),
     terminalId: v.id("posTerminal"),
   },
-  returns: sessionResultValidator,
+  returns: commandResultValidator(sessionOperationDataValidator),
   handler: async (ctx, args) => {
     const result = await runResumeSessionCommand(ctx, args);
 
     if (result.status === "ok") {
-      return {
-        success: true as const,
-        data: result.data,
-      };
+      return ok(result.data);
     }
 
-    return error(result.message);
+    return userErrorFromSessionCommandFailure(result);
   },
 });
 
@@ -532,37 +569,45 @@ export const completeSession = mutation({
     tax: v.number(),
     total: v.number(),
   },
-  returns: v.union(
-    v.object({
-      success: v.literal(true),
-      data: v.object({
-        sessionId: v.id("posSession"),
-        transactionNumber: v.string(),
-      }),
-    }),
-    v.object({
-      success: v.literal(false),
-      message: v.string(),
-    })
-  ),
+  returns: commandResultValidator(completeSessionDataValidator),
   handler: async (ctx, args) => {
     const session = await ctx.db.get("posSession", args.sessionId);
     if (!session) {
-      return error("Session not found");
+      return userError({
+        code: "not_found",
+        message: "Session not found.",
+      });
     }
 
     // Check if session has expired before completing
     const now = Date.now();
     if (session.expiresAt && session.expiresAt < now) {
-      return error("This session has expired. Start a new one to proceed.");
+      return userError({
+        code: "precondition_failed",
+        message: "This session has expired. Start a new one to proceed.",
+      });
     }
 
     if (session.status !== "active") {
-      return error("Can only complete active sessions");
+      return userError({
+        code: "precondition_failed",
+        message: "Can only complete active sessions.",
+      });
     }
 
-    // Mark session as completed and lock in final transaction totals
-    // This ensures audit integrity by capturing exact values at completion time
+    const transactionResult = await createTransactionFromSessionHandler(ctx, {
+      sessionId: args.sessionId,
+      payments: args.payments,
+      notes: args.notes,
+    });
+
+    if (transactionResult.kind === "user_error") {
+      return transactionResult;
+    }
+
+    const { transactionId, transactionNumber } = transactionResult.data;
+    const sessionTransactionId = transactionId as Id<"posTransaction">;
+
     await recordSessionLifecycleTraceBestEffort(ctx, {
       stage: "checkoutSubmitted",
       session: {
@@ -584,19 +629,10 @@ export const completeSession = mutation({
       updatedAt: now,
       notes: args.notes,
       payments: args.payments,
-      // Save final transaction totals for audit trail
       subtotal: args.subtotal,
       tax: args.tax,
       total: args.total,
     });
-
-    const { transactionId, transactionNumber } =
-      await createTransactionFromSessionHandler(ctx, {
-      sessionId: args.sessionId,
-      payments: args.payments,
-      notes: args.notes,
-    });
-    const sessionTransactionId = transactionId as Id<"posTransaction">;
 
     await recordSessionLifecycleTraceBestEffort(ctx, {
       stage: "completed",
@@ -617,13 +653,10 @@ export const completeSession = mutation({
     });
 
     // Return the session ID since the transaction will be created asynchronously
-    return {
-      success: true as const,
-      data: {
-        sessionId: args.sessionId,
-        transactionNumber,
-      },
-    };
+    return ok({
+      sessionId: args.sessionId,
+      transactionNumber,
+    });
   },
 });
 
@@ -633,25 +666,17 @@ export const voidSession = mutation({
     sessionId: v.id("posSession"),
     voidReason: v.optional(v.string()),
   },
-  returns: v.union(
-    v.object({
-      success: v.literal(true),
-      data: v.object({
-        sessionId: v.id("posSession"),
-      }),
-    }),
-    v.object({
-      success: v.literal(false),
-      message: v.string(),
-    })
-  ),
+  returns: commandResultValidator(sessionIdOnlyValidator),
   handler: async (ctx, args) => {
     const now = Date.now();
 
     // Get the session
     const session = await ctx.db.get("posSession", args.sessionId);
     if (!session) {
-      return error("Session not found");
+      return userError({
+        code: "not_found",
+        message: "Session not found.",
+      });
     }
 
     // Query all items for this session
@@ -699,7 +724,7 @@ export const voidSession = mutation({
       voidReason: args.voidReason,
     });
 
-    return { success: true as const, data: { sessionId: args.sessionId } };
+    return ok({ sessionId: args.sessionId });
   },
 });
 
@@ -708,31 +733,20 @@ export const releaseSessionInventoryHoldsAndDeleteItems = mutation({
     sessionId: v.id("posSession"),
     checkoutStateVersion: v.number(),
   },
-  returns: v.union(
-    v.object({
-      success: v.literal(true),
-      data: v.object({
-        sessionId: v.id("posSession"),
-      }),
-    }),
-    v.object({
-      success: v.literal(false),
-      message: v.string(),
-    })
-  ),
+  returns: commandResultValidator(sessionIdOnlyValidator),
   handler: async (ctx, args) => {
     const now = Date.now();
     // Get the session
     const session = await ctx.db.get("posSession", args.sessionId);
     if (!session) {
-      return error("Session not found");
+      return userError({
+        code: "not_found",
+        message: "Session not found.",
+      });
     }
 
     if (args.checkoutStateVersion <= (session.checkoutStateVersion ?? 0)) {
-      return {
-        success: true as const,
-        data: { sessionId: args.sessionId },
-      };
+      return ok({ sessionId: args.sessionId });
     }
 
     // Query all items for this session
@@ -787,7 +801,7 @@ export const releaseSessionInventoryHoldsAndDeleteItems = mutation({
       });
     }
 
-    return { success: true as const, data: { sessionId: args.sessionId } };
+    return ok({ sessionId: args.sessionId });
   },
 });
 
@@ -813,7 +827,7 @@ export const syncSessionCheckoutState = mutation({
     amount: v.optional(v.number()),
     previousAmount: v.optional(v.number()),
   },
-  returns: sessionResultValidator,
+  returns: commandResultValidator(sessionOperationDataValidator),
   handler: async (ctx, args) => {
     const validation = await validateSessionActive(
       ctx.db,
@@ -822,23 +836,25 @@ export const syncSessionCheckoutState = mutation({
     );
 
     if (!validation.success) {
-      return error(validation.message || "Session is not active.");
+      return userErrorFromValidationMessage(
+        validation.message || "Session is not active.",
+      );
     }
 
     const session = await ctx.db.get("posSession", args.sessionId);
     if (!session) {
-      return error("Session not found");
+      return userError({
+        code: "not_found",
+        message: "Session not found.",
+      });
     }
 
     const currentCheckoutStateVersion = session.checkoutStateVersion ?? 0;
     if (args.checkoutStateVersion <= currentCheckoutStateVersion) {
-      return {
-        success: true as const,
-        data: {
-          sessionId: args.sessionId,
-          expiresAt: session.expiresAt,
-        },
-      };
+      return ok({
+        sessionId: args.sessionId,
+        expiresAt: session.expiresAt,
+      });
     }
 
     const now = Date.now();
@@ -866,13 +882,10 @@ export const syncSessionCheckoutState = mutation({
       paymentCount: args.payments.length,
     });
 
-    return {
-      success: true as const,
-      data: {
-        sessionId: args.sessionId,
-        expiresAt,
-      },
-    };
+    return ok({
+      sessionId: args.sessionId,
+      expiresAt,
+    });
   },
 });
 

--- a/packages/athena-webapp/convex/lib/commandResultValidators.ts
+++ b/packages/athena-webapp/convex/lib/commandResultValidators.ts
@@ -1,0 +1,33 @@
+import { v } from "convex/values";
+
+export const userErrorValidator = v.object({
+  code: v.union(
+    v.literal("validation_failed"),
+    v.literal("authentication_failed"),
+    v.literal("authorization_failed"),
+    v.literal("not_found"),
+    v.literal("conflict"),
+    v.literal("precondition_failed"),
+    v.literal("rate_limited"),
+    v.literal("unavailable"),
+  ),
+  title: v.optional(v.string()),
+  message: v.string(),
+  fields: v.optional(v.record(v.string(), v.array(v.string()))),
+  retryable: v.optional(v.boolean()),
+  traceId: v.optional(v.string()),
+  metadata: v.optional(v.record(v.string(), v.any())),
+});
+
+export function commandResultValidator(dataValidator: any) {
+  return v.union(
+    v.object({
+      kind: v.literal("ok"),
+      data: dataValidator,
+    }),
+    v.object({
+      kind: v.literal("user_error"),
+      error: userErrorValidator,
+    }),
+  );
+}

--- a/packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts
@@ -1,5 +1,6 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
+import { ok, userError, type CommandResult } from "../../../../shared/commandResult";
 
 import {
   createPosCustomer,
@@ -24,7 +25,14 @@ export async function createCustomer(
     address?: Doc<"posCustomer">["address"];
     notes?: string;
   },
-) {
+): Promise<
+  CommandResult<{
+    _id: Id<"posCustomer">;
+    name: string;
+    email?: string;
+    phone?: string;
+  }>
+> {
   if (args.email) {
     const existingByEmail = await findCustomerByEmail(ctx, {
       storeId: args.storeId,
@@ -32,7 +40,10 @@ export async function createCustomer(
     });
 
     if (existingByEmail) {
-      throw new Error("Customer with this email already exists");
+      return userError({
+        code: "conflict",
+        message: "Customer with this email already exists.",
+      });
     }
   }
 
@@ -43,7 +54,10 @@ export async function createCustomer(
     });
 
     if (existingByPhone) {
-      throw new Error("Customer with this phone number already exists");
+      return userError({
+        code: "conflict",
+        message: "Customer with this phone number already exists.",
+      });
     }
   }
 
@@ -61,12 +75,12 @@ export async function createCustomer(
   });
   const customer = await getPosCustomerById(ctx, customerId);
 
-  return {
+  return ok({
     _id: customer!._id,
     name: customer!.name,
     email: customer!.email,
     phone: customer!.phone,
-  };
+  });
 }
 
 export async function updateCustomer(
@@ -79,7 +93,15 @@ export async function updateCustomer(
     address?: Doc<"posCustomer">["address"];
     notes?: string;
   },
-) {
+): Promise<CommandResult<null>> {
+  const customer = await getPosCustomerById(ctx, args.customerId);
+  if (!customer) {
+    return userError({
+      code: "not_found",
+      message: "Customer not found.",
+    });
+  }
+
   const updates: Partial<Doc<"posCustomer">> = {};
 
   if (args.name) updates.name = args.name;
@@ -89,7 +111,7 @@ export async function updateCustomer(
   if (args.notes) updates.notes = args.notes;
 
   await patchPosCustomer(ctx, args.customerId, updates);
-  return null;
+  return ok(null);
 }
 
 export async function updateCustomerStats(
@@ -114,12 +136,15 @@ export async function linkToStoreFrontUser(
     posCustomerId: Id<"posCustomer">;
     storeFrontUserId: Id<"storeFrontUser">;
   },
-) {
+): Promise<CommandResult<null>> {
   const posCustomer = await getPosCustomerById(ctx, args.posCustomerId);
   const storeFrontUser = await getStoreFrontUserById(ctx, args.storeFrontUserId);
 
   if (!posCustomer || !storeFrontUser) {
-    throw new Error("Customer or storefront user not found");
+    return userError({
+      code: "not_found",
+      message: "Customer or storefront user not found.",
+    });
   }
 
   const existingLink = await findPosCustomerByStoreFrontUser(
@@ -127,9 +152,10 @@ export async function linkToStoreFrontUser(
     args.storeFrontUserId,
   );
   if (existingLink && existingLink._id !== args.posCustomerId) {
-    throw new Error(
-      "This storefront user is already linked to another POS customer",
-    );
+    return userError({
+      code: "conflict",
+      message: "This storefront user is already linked to another POS customer.",
+    });
   }
 
   await patchPosCustomer(ctx, args.posCustomerId, {
@@ -144,7 +170,7 @@ export async function linkToStoreFrontUser(
     fallbackStoreId: posCustomer.storeId,
   });
 
-  return null;
+  return ok(null);
 }
 
 export async function linkToGuest(
@@ -153,12 +179,15 @@ export async function linkToGuest(
     posCustomerId: Id<"posCustomer">;
     guestId: Id<"guest">;
   },
-) {
+): Promise<CommandResult<null>> {
   const posCustomer = await getPosCustomerById(ctx, args.posCustomerId);
   const guest = await getGuestById(ctx, args.guestId);
 
   if (!posCustomer || !guest) {
-    throw new Error("Customer or guest not found");
+    return userError({
+      code: "not_found",
+      message: "Customer or guest not found.",
+    });
   }
 
   await patchPosCustomer(ctx, args.posCustomerId, {
@@ -173,5 +202,5 @@ export async function linkToGuest(
     fallbackStoreId: posCustomer.storeId,
   });
 
-  return null;
+  return ok(null);
 }

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -30,6 +30,7 @@ import {
   buildPosSaleTraceSeed,
   type PosSaleTraceSeed,
 } from "../../../workflowTraces/adapters/posSale";
+import { ok, userError, type CommandResult } from "../../../../shared/commandResult";
 
 type PosPaymentInput = {
   method: string;
@@ -48,7 +49,7 @@ type DirectTransactionItemInput = {
 };
 
 export function buildCompleteTransactionResult(input: {
-  transactionId: string | null;
+  transactionId: Id<"posTransaction"> | null;
   transactionNumber: string | null;
   paymentAllocated: boolean;
 }) {
@@ -248,12 +249,15 @@ async function resolveSessionRegisterSessionId(
     session: NonNullable<Awaited<ReturnType<typeof getPosSessionById>>>;
     providedRegisterSessionId?: Id<"registerSession">;
   },
-) {
+): Promise<CommandResult<Id<"registerSession">>> {
   const resolvedRegisterSessionId =
     args.session.registerSessionId ?? args.providedRegisterSessionId;
 
   if (!resolvedRegisterSessionId) {
-    throw new Error("Open the cash drawer before completing this sale.");
+    return userError({
+      code: "precondition_failed",
+      message: "Open the cash drawer before completing this sale.",
+    });
   }
 
   if (
@@ -261,7 +265,10 @@ async function resolveSessionRegisterSessionId(
     args.providedRegisterSessionId &&
     args.session.registerSessionId !== args.providedRegisterSessionId
   ) {
-    throw new Error("Open the cash drawer before completing this sale.");
+    return userError({
+      code: "precondition_failed",
+      message: "Open the cash drawer before completing this sale.",
+    });
   }
 
   const registerSession = await getRegisterSessionById(ctx, resolvedRegisterSessionId);
@@ -275,10 +282,13 @@ async function resolveSessionRegisterSessionId(
       terminalId: args.session.terminalId,
     })
   ) {
-    throw new Error("Open the cash drawer before completing this sale.");
+    return userError({
+      code: "precondition_failed",
+      message: "Open the cash drawer before completing this sale.",
+    });
   }
 
-  return resolvedRegisterSessionId;
+  return ok(resolvedRegisterSessionId);
 }
 
 async function recordRegisterSessionSale(
@@ -381,7 +391,13 @@ export async function completeTransaction(
     staffProfileId?: Id<"staffProfile">;
     registerSessionId?: Id<"registerSession">;
   },
-) {
+): Promise<
+  CommandResult<{
+    transactionId: Id<"posTransaction">;
+    transactionNumber: string;
+    transactionItems: Array<Id<"posTransactionItem">>;
+  }>
+> {
   const skuQuantityMap = new Map<Id<"productSku">, number>();
 
   for (const item of args.items) {
@@ -391,35 +407,35 @@ export async function completeTransaction(
   for (const [skuId, totalQuantity] of skuQuantityMap) {
     const sku = await getProductSkuById(ctx, skuId);
     if (!sku) {
-      return {
-        success: false,
-        error: `Product SKU ${skuId} not found`,
-      };
+      return userError({
+        code: "not_found",
+        message: `Product SKU ${skuId} not found.`,
+      });
     }
 
     if (sku.quantityAvailable < totalQuantity) {
       const itemName =
         args.items.find((item) => item.skuId === skuId)?.name || "Unknown Product";
-      return {
-        success: false,
-        error: `Insufficient inventory for ${capitalizeWords(itemName)} (${sku.sku}). Available: ${sku.quantityAvailable}, Total Requested: ${totalQuantity}`,
-      };
+      return userError({
+        code: "conflict",
+        message: `Insufficient inventory for ${capitalizeWords(itemName)} (${sku.sku}). Available: ${sku.quantityAvailable}, Total Requested: ${totalQuantity}`,
+      });
     }
   }
 
   if (args.payments.length === 0) {
-    return {
-      success: false,
-      error: "At least one payment is required",
-    };
+    return userError({
+      code: "validation_failed",
+      message: "At least one payment is required.",
+    });
   }
 
   const totalPaid = calculateTotalPaid(args.payments);
   if (totalPaid < args.total) {
-    return {
-      success: false,
-      error: `Insufficient payment. Total: ${args.total.toFixed(2)}, Paid: ${totalPaid.toFixed(2)}`,
-    };
+    return userError({
+      code: "validation_failed",
+      message: `Insufficient payment. Total: ${args.total.toFixed(2)}, Paid: ${totalPaid.toFixed(2)}`,
+    });
   }
 
   const changeGiven = totalPaid > args.total ? totalPaid - args.total : undefined;
@@ -499,10 +515,7 @@ export async function completeTransaction(
   });
 
   if (completionResult.status !== "ok") {
-    return {
-      success: false,
-      error: completionResult.message,
-    };
+    throw new Error(completionResult.message);
   }
 
   if (args.customerId) {
@@ -517,10 +530,7 @@ export async function completeTransaction(
     args.items.map(async (item) => {
       const sku = await getProductSkuById(ctx, item.skuId);
       if (!sku) {
-        return {
-          success: false,
-          error: `SKU ${item.skuId} not found during transaction processing`,
-        };
+        throw new Error(`SKU ${item.skuId} not found during transaction processing`);
       }
 
       const image = item.image ?? sku.images?.[0];
@@ -558,12 +568,11 @@ export async function completeTransaction(
     transactionId,
   });
 
-  return {
-    success: true,
+  return ok({
     transactionId: completionResult.data.transactionId,
     transactionNumber: completionResult.data.transactionNumber,
     transactionItems,
-  };
+  });
 }
 
 export async function voidTransaction(
@@ -643,21 +652,36 @@ export async function createTransactionFromSessionHandler(
     registerSessionId?: Id<"registerSession">;
     notes?: string;
   },
-) {
+): Promise<
+  CommandResult<{
+    transactionId: Id<"posTransaction">;
+    transactionNumber: string;
+    transactionItems: Array<Id<"posTransactionItem">>;
+  }>
+> {
   const session = await getPosSessionById(ctx, args.sessionId);
   if (!session) {
-    throw new Error("Session not found");
+    return userError({
+      code: "not_found",
+      message: "Session not found.",
+    });
   }
 
   const items = await listSessionItems(ctx, args.sessionId);
   if (items.length === 0) {
-    throw new Error("Cannot complete session with no items");
+    return userError({
+      code: "precondition_failed",
+      message: "Cannot complete session with no items.",
+    });
   }
 
   const resolvedRegisterSessionId = await resolveSessionRegisterSessionId(ctx, {
     session,
     providedRegisterSessionId: args.registerSessionId,
   });
+  if (resolvedRegisterSessionId.kind === "user_error") {
+    return resolvedRegisterSessionId;
+  }
 
   const skuQuantityMap = new Map<Id<"productSku">, number>();
   for (const item of items) {
@@ -670,19 +694,26 @@ export async function createTransactionFromSessionHandler(
   for (const [skuId, totalQuantity] of skuQuantityMap) {
     const sku = await getProductSkuById(ctx, skuId);
     if (!sku) {
-      throw new Error(`Product SKU ${skuId} not found`);
+      return userError({
+        code: "not_found",
+        message: `Product SKU ${skuId} not found.`,
+      });
     }
 
     if (sku.inventoryCount < totalQuantity) {
       const item = items.find((sessionItem) => sessionItem.productSkuId === skuId);
-      throw new Error(
-        `Insufficient inventory for ${capitalizeWords(item?.productName || "Unknown Product")} (${sku.sku}). In Stock: ${sku.inventoryCount}, Needed: ${totalQuantity}`,
-      );
+      return userError({
+        code: "conflict",
+        message: `Insufficient inventory for ${capitalizeWords(item?.productName || "Unknown Product")} (${sku.sku}). In Stock: ${sku.inventoryCount}, Needed: ${totalQuantity}`,
+      });
     }
   }
 
   if (args.payments.length === 0) {
-    throw new Error("At least one payment is required");
+    return userError({
+      code: "validation_failed",
+      message: "At least one payment is required.",
+    });
   }
 
   const totalPaid = calculateTotalPaid(args.payments);
@@ -691,9 +722,10 @@ export async function createTransactionFromSessionHandler(
   const total = session.total || 0;
 
   if (totalPaid < total) {
-    throw new Error(
-      `Insufficient payment. Total: ${total.toFixed(2)}, Paid: ${totalPaid.toFixed(2)}`,
-    );
+    return userError({
+      code: "validation_failed",
+      message: `Insufficient payment. Total: ${total.toFixed(2)}, Paid: ${totalPaid.toFixed(2)}`,
+    });
   }
 
   const changeGiven = totalPaid > total ? totalPaid - total : undefined;
@@ -706,7 +738,7 @@ export async function createTransactionFromSessionHandler(
     transactionNumber,
     storeId: session.storeId,
     sessionId: args.sessionId,
-    registerSessionId: resolvedRegisterSessionId,
+    registerSessionId: resolvedRegisterSessionId.data,
     customerId: session.customerId,
     staffProfileId: session.staffProfileId,
     registerNumber: session.registerNumber,
@@ -731,7 +763,7 @@ export async function createTransactionFromSessionHandler(
     startedAt: traceStartedAt,
     transactionNumber,
     posTransactionId: transactionId,
-    registerSessionId: resolvedRegisterSessionId,
+    registerSessionId: resolvedRegisterSessionId.data,
     staffProfileId: session.staffProfileId,
     terminalId: session.terminalId,
     customerId: session.customerId,
@@ -751,7 +783,7 @@ export async function createTransactionFromSessionHandler(
   await recordRegisterSessionSale(ctx, {
     changeGiven,
     payments: args.payments,
-    registerSessionId: resolvedRegisterSessionId,
+    registerSessionId: resolvedRegisterSessionId.data,
     registerNumber: session.registerNumber,
     storeId: session.storeId,
     terminalId: session.terminalId,
@@ -765,7 +797,7 @@ export async function createTransactionFromSessionHandler(
       organizationId: store?.organizationId,
       payments: args.payments,
       posTransactionId: transactionId,
-      registerSessionId: resolvedRegisterSessionId,
+      registerSessionId: resolvedRegisterSessionId.data,
       storeId: session.storeId,
       transactionNumber,
     }),
@@ -816,7 +848,7 @@ export async function createTransactionFromSessionHandler(
 
   await patchPosSession(ctx, args.sessionId, {
     transactionId,
-    registerSessionId: resolvedRegisterSessionId,
+    registerSessionId: resolvedRegisterSessionId.data,
   });
 
   const finalizedTrace = await recordPosSaleTraceBestEffort(ctx, {
@@ -831,10 +863,9 @@ export async function createTransactionFromSessionHandler(
     transactionId,
   });
 
-  return {
-    success: true,
+  return ok({
     transactionId: completionResult.data.transactionId,
     transactionNumber: completionResult.data.transactionNumber,
     transactionItems,
-  };
+  });
 }

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -291,7 +291,7 @@ async function resolveSessionRegisterSessionId(
   return ok(resolvedRegisterSessionId);
 }
 
-async function recordRegisterSessionSale(
+export async function recordRegisterSessionSale(
   ctx: MutationCtx,
   args: {
     changeGiven?: number;
@@ -650,6 +650,7 @@ export async function createTransactionFromSessionHandler(
     sessionId: Id<"posSession">;
     payments: PosPaymentInput[];
     registerSessionId?: Id<"registerSession">;
+    recordRegisterSale?: boolean;
     notes?: string;
   },
 ): Promise<
@@ -780,14 +781,16 @@ export async function createTransactionFromSessionHandler(
     transactionId,
   });
 
-  await recordRegisterSessionSale(ctx, {
-    changeGiven,
-    payments: args.payments,
-    registerSessionId: resolvedRegisterSessionId.data,
-    registerNumber: session.registerNumber,
-    storeId: session.storeId,
-    terminalId: session.terminalId,
-  });
+  if (args.recordRegisterSale !== false) {
+    await recordRegisterSessionSale(ctx, {
+      changeGiven,
+      payments: args.payments,
+      registerSessionId: resolvedRegisterSessionId.data,
+      registerNumber: session.registerNumber,
+      storeId: session.storeId,
+      terminalId: session.terminalId,
+    });
+  }
 
   const completionResult = buildCompleteTransactionResult({
     transactionId,

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
 describe("buildCompleteTransactionResult", () => {
   it("returns ok with transaction data when completion succeeds", () => {
     const result = buildCompleteTransactionResult({
-      transactionId: "txn-1",
+      transactionId: "txn-1" as Id<"posTransaction">,
       transactionNumber: "POS-TXN-001",
       paymentAllocated: true,
     });
@@ -79,7 +79,7 @@ describe("buildCompleteTransactionResult", () => {
 
   it("does not fail completion when no payment allocations are recorded", () => {
     const result = buildCompleteTransactionResult({
-      transactionId: "txn-1",
+      transactionId: "txn-1" as Id<"posTransaction">,
       transactionNumber: "POS-TXN-001",
       paymentAllocated: false,
     });
@@ -464,8 +464,10 @@ describe("completeTransaction trace ordering", () => {
       }),
     ).resolves.toEqual(
       expect.objectContaining({
-        success: true,
-        transactionId: "txn-1",
+        kind: "ok",
+        data: expect.objectContaining({
+          transactionId: "txn-1",
+        }),
       }),
     );
 
@@ -522,7 +524,15 @@ describe("completeTransaction trace ordering", () => {
         sessionId: "session-1" as Id<"posSession">,
         payments: [{ method: "cash", amount: 10, timestamp: 1 }],
       }),
-    ).rejects.toThrow("Open the cash drawer before completing this sale.");
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "precondition_failed",
+          message: "Open the cash drawer before completing this sale.",
+        }),
+      }),
+    );
   });
 
   it("does not fail direct sale completion when workflowTraceId persistence fails", async () => {
@@ -575,8 +585,10 @@ describe("completeTransaction trace ordering", () => {
       }),
     ).resolves.toEqual(
       expect.objectContaining({
-        success: true,
-        transactionId: "txn-1",
+        kind: "ok",
+        data: expect.objectContaining({
+          transactionId: "txn-1",
+        }),
       }),
     );
   });

--- a/packages/athena-webapp/convex/pos/public/customers.ts
+++ b/packages/athena-webapp/convex/pos/public/customers.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { mutation, query } from "../../_generated/server";
+import { commandResultValidator } from "../../lib/commandResultValidators";
 import {
   createCustomer as createCustomerCommand,
   linkToGuest as linkToGuestCommand,
@@ -80,12 +81,14 @@ export const createCustomer = mutation({
     address: v.optional(customerAddressValidator),
     notes: v.optional(v.string()),
   },
-  returns: v.object({
-    _id: v.id("posCustomer"),
-    name: v.string(),
-    email: v.optional(v.string()),
-    phone: v.optional(v.string()),
-  }),
+  returns: commandResultValidator(
+    v.object({
+      _id: v.id("posCustomer"),
+      name: v.string(),
+      email: v.optional(v.string()),
+      phone: v.optional(v.string()),
+    }),
+  ),
   handler: async (ctx, args) => createCustomerCommand(ctx, args),
 });
 
@@ -98,7 +101,7 @@ export const updateCustomer = mutation({
     address: v.optional(customerAddressValidator),
     notes: v.optional(v.string()),
   },
-  returns: v.null(),
+  returns: commandResultValidator(v.null()),
   handler: async (ctx, args) => updateCustomerCommand(ctx, args),
 });
 
@@ -135,7 +138,7 @@ export const linkToStoreFrontUser = mutation({
     posCustomerId: v.id("posCustomer"),
     storeFrontUserId: v.id("storeFrontUser"),
   },
-  returns: v.null(),
+  returns: commandResultValidator(v.null()),
   handler: async (ctx, args) => linkToStoreFrontUserCommand(ctx, args),
 });
 
@@ -144,7 +147,7 @@ export const linkToGuest = mutation({
     posCustomerId: v.id("posCustomer"),
     guestId: v.id("guest"),
   },
-  returns: v.null(),
+  returns: commandResultValidator(v.null()),
   handler: async (ctx, args) => linkToGuestCommand(ctx, args),
 });
 

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { mutation, query } from "../../_generated/server";
+import { commandResultValidator } from "../../lib/commandResultValidators";
 import {
   completeTransaction as completeTransactionCommand,
   createTransactionFromSessionHandler,
@@ -61,6 +62,13 @@ export const completeTransaction = mutation({
     staffProfileId: v.optional(v.id("staffProfile")),
     registerSessionId: v.optional(v.id("registerSession")),
   },
+  returns: commandResultValidator(
+    v.object({
+      transactionId: v.id("posTransaction"),
+      transactionNumber: v.string(),
+      transactionItems: v.array(v.id("posTransactionItem")),
+    }),
+  ),
   handler: async (ctx, args) => completeTransactionCommand(ctx, args),
 });
 
@@ -179,6 +187,13 @@ export const createTransactionFromSession = mutation({
     registerSessionId: v.optional(v.id("registerSession")),
     notes: v.optional(v.string()),
   },
+  returns: commandResultValidator(
+    v.object({
+      transactionId: v.id("posTransaction"),
+      transactionNumber: v.string(),
+      transactionItems: v.array(v.id("posTransactionItem")),
+    }),
+  ),
   handler: async (ctx, args) => createTransactionFromSessionHandler(ctx, args),
 });
 

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 12 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, purchaseOrders.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 12 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 347 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 348 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx
@@ -59,6 +59,10 @@ export function CustomerInfoPanel({
 
   const formatter = currencyFormatter(activeStore?.currency || "GHS");
 
+  const showCommandError = (message: string) => {
+    showValidationError([message]);
+  };
+
   const handleSelectCustomer = (customer: POSCustomerSummary) => {
     console.log("🔄 Selecting customer:", customer);
 
@@ -92,21 +96,20 @@ export function CustomerInfoPanel({
       phone: customerInfo.phone.trim() || undefined,
     });
 
-    if (result.success && result.customer) {
-      const nextCustomerInfo = {
-        customerId: result.customer._id,
-        name: result.customer.name,
-        email: result.customer.email || "",
-        phone: result.customer.phone || "",
-      };
-      setCustomerInfo(nextCustomerInfo);
-      void onCustomerCommitted(nextCustomerInfo);
-      setShowCreateForm(false);
-      // Keep the panel open so user can see the edit button and customer details
-      // Toast already shown by createCustomer hook
-    } else {
-      // Error already shown by createCustomer hook
+    if (result.kind !== "ok") {
+      showCommandError(result.error.message);
+      return;
     }
+
+    const nextCustomerInfo = {
+      customerId: result.data._id,
+      name: result.data.name,
+      email: result.data.email || "",
+      phone: result.data.phone || "",
+    };
+    setCustomerInfo(nextCustomerInfo);
+    void onCustomerCommitted(nextCustomerInfo);
+    setShowCreateForm(false);
   };
 
   const handleStartEdit = () => {
@@ -136,20 +139,20 @@ export function CustomerInfoPanel({
       phone: editingCustomer.phone.trim() || undefined,
     });
 
-    if (result.success) {
-      const nextCustomerInfo = {
-        customerId: editingCustomer.customerId,
-        name: editingCustomer.name.trim(),
-        email: editingCustomer.email.trim(),
-        phone: editingCustomer.phone.trim(),
-      };
-      setCustomerInfo(nextCustomerInfo);
-      void onCustomerCommitted(nextCustomerInfo);
-      setIsEditing(false);
-      // Toast already shown by updateCustomer hook
-    } else {
-      // Error already shown by updateCustomer hook
+    if (result.kind !== "ok") {
+      showCommandError(result.error.message);
+      return;
     }
+
+    const nextCustomerInfo = {
+      customerId: editingCustomer.customerId,
+      name: editingCustomer.name.trim(),
+      email: editingCustomer.email.trim(),
+      phone: editingCustomer.phone.trim(),
+    };
+    setCustomerInfo(nextCustomerInfo);
+    void onCustomerCommitted(nextCustomerInfo);
+    setIsEditing(false);
   };
 
   const handleCancelEdit = () => {

--- a/packages/athena-webapp/src/lib/pos/application/dto.ts
+++ b/packages/athena-webapp/src/lib/pos/application/dto.ts
@@ -187,44 +187,24 @@ export type PosMutationFailureDto = {
   message: string;
 };
 
-export type PosCreateSessionResultDto =
-  | {
-      success: true;
-      data: {
-        sessionId: Id<"posSession">;
-        expiresAt: number;
-      };
-    }
-  | PosMutationFailureDto;
+export type PosCreateSessionResultDto = CommandResult<{
+  sessionId: Id<"posSession">;
+  expiresAt: number;
+}>;
 
 export type PosStartSessionResultDto = PosCreateSessionResultDto;
 
-export type PosAddItemResultDto =
-  | {
-      success: true;
-      data: {
-        itemId: Id<"posSessionItem">;
-        expiresAt: number;
-      };
-    }
-  | PosMutationFailureDto;
+export type PosAddItemResultDto = CommandResult<{
+  itemId: Id<"posSessionItem">;
+  expiresAt: number;
+}>;
 
-export type PosHoldSessionResultDto =
-  | {
-      success: true;
-      data: {
-        sessionId: Id<"posSession">;
-        expiresAt: number;
-      };
-    }
-  | PosMutationFailureDto;
+export type PosHoldSessionResultDto = CommandResult<{
+  sessionId: Id<"posSession">;
+  expiresAt: number;
+}>;
 
-export type PosCompleteTransactionResultDto =
-  | {
-      success: true;
-      data: {
-        sessionId: Id<"posSession">;
-        transactionNumber: string;
-      };
-    }
-  | PosMutationFailureDto;
+export type PosCompleteTransactionResultDto = CommandResult<{
+  sessionId: Id<"posSession">;
+  transactionNumber: string;
+}>;

--- a/packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts
+++ b/packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts
@@ -1,13 +1,13 @@
 import type { PosAddItemInput } from "../dto";
 import type { PosCommandGateway } from "../ports";
-import { mapLegacyMutationResult, mapThrownError } from "../results";
+import { mapCommandResult, mapThrownError } from "../results";
 
 export async function addItem(input: {
   gateway: Pick<PosCommandGateway, "addItem">;
   command: PosAddItemInput;
 }) {
   try {
-    return mapLegacyMutationResult(await input.gateway.addItem(input.command));
+    return mapCommandResult(await input.gateway.addItem(input.command));
   } catch (error) {
     return mapThrownError(error);
   }

--- a/packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts
+++ b/packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts
@@ -1,13 +1,13 @@
 import type { PosCompleteTransactionInput } from "../dto";
 import type { PosCommandGateway } from "../ports";
-import { mapLegacyMutationResult, mapThrownError } from "../results";
+import { mapCommandResult, mapThrownError } from "../results";
 
 export async function completeTransaction(input: {
   gateway: Pick<PosCommandGateway, "completeTransaction">;
   command: PosCompleteTransactionInput;
 }) {
   try {
-    return mapLegacyMutationResult(
+    return mapCommandResult(
       await input.gateway.completeTransaction(input.command),
     );
   } catch (error) {

--- a/packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts
+++ b/packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts
@@ -1,13 +1,13 @@
 import type { PosHoldSessionInput } from "../dto";
 import type { PosCommandGateway } from "../ports";
-import { mapLegacyMutationResult, mapThrownError } from "../results";
+import { mapCommandResult, mapThrownError } from "../results";
 
 export async function holdSession(input: {
   gateway: Pick<PosCommandGateway, "holdSession">;
   command: PosHoldSessionInput;
 }) {
   try {
-    return mapLegacyMutationResult(await input.gateway.holdSession(input.command));
+    return mapCommandResult(await input.gateway.holdSession(input.command));
   } catch (error) {
     return mapThrownError(error);
   }

--- a/packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts
+++ b/packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts
@@ -1,13 +1,13 @@
 import type { PosStartSessionInput } from "../dto";
 import type { PosCommandGateway } from "../ports";
-import { mapLegacyMutationResult, mapThrownError } from "../results";
+import { mapCommandResult, mapThrownError } from "../results";
 
 export async function startSession(input: {
   gateway: Pick<PosCommandGateway, "startSession">;
   command: PosStartSessionInput;
 }) {
   try {
-    return mapLegacyMutationResult(await input.gateway.startSession(input.command));
+    return mapCommandResult(await input.gateway.startSession(input.command));
   } catch (error) {
     return mapThrownError(error);
   }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts
@@ -1,4 +1,8 @@
 import { useMutation, useQuery } from "convex/react";
+import {
+  type NormalizedCommandResult,
+  runCommand,
+} from "@/lib/errors/runCommand";
 
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
@@ -29,18 +33,14 @@ export function useConvexPosCustomerCreate() {
       country?: string;
     };
     notes?: string;
-  }) => {
-    try {
-      const customer = await createCustomer(customerData);
-      return { success: true as const, customer };
-    } catch (error) {
-      return {
-        success: false as const,
-        error:
-          error instanceof Error ? error.message : "Failed to create customer",
-      };
-    }
-  };
+  }): Promise<
+    NormalizedCommandResult<{
+      _id: Id<"posCustomer">;
+      name: string;
+      email?: string;
+      phone?: string;
+    }>
+  > => runCommand(() => createCustomer(customerData));
 }
 
 export function useConvexPosCustomerUpdate() {
@@ -61,16 +61,6 @@ export function useConvexPosCustomerUpdate() {
       };
       notes?: string;
     },
-  ) => {
-    try {
-      await updateCustomer({ customerId, ...updates });
-      return { success: true as const };
-    } catch (error) {
-      return {
-        success: false as const,
-        error:
-          error instanceof Error ? error.message : "Failed to update customer",
-      };
-    }
-  };
+  ): Promise<NormalizedCommandResult<null>> =>
+    runCommand(() => updateCustomer({ customerId, ...updates }));
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery } from "convex/react";
 
 import type { CartItem } from "@/components/pos/types";
+import {
+  type NormalizedCommandResult,
+  runCommand,
+} from "@/lib/errors/runCommand";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import type { POSSession } from "~/types";
@@ -20,6 +24,15 @@ export type PosSessionDetail = POSSession & {
   tax?: number;
   total?: number;
   holdReason?: string;
+};
+
+type SessionCommandPayload = {
+  sessionId?: Id<"posSession">;
+  expiresAt?: number;
+};
+
+type RemoveItemPayload = {
+  expiresAt?: number;
 };
 
 export function useConvexActiveSession(input: {
@@ -88,11 +101,20 @@ export function useConvexSessionActions() {
   const removeItemMutation = useMutation(api.inventory.posSessionItems.removeItem);
 
   return {
-    resumeSession: resumeSessionMutation,
-    voidSession: voidSessionMutation,
-    updateSession: updateSessionMutation,
-    syncSessionCheckoutState: syncSessionCheckoutStateMutation,
-    releaseSessionInventoryHoldsAndDeleteItems: releaseSessionMutation,
-    removeItem: removeItemMutation,
+    resumeSession: (args: Parameters<typeof resumeSessionMutation>[0]) =>
+      runCommand<SessionCommandPayload>(() => resumeSessionMutation(args)),
+    voidSession: (args: Parameters<typeof voidSessionMutation>[0]) =>
+      runCommand<{ sessionId?: Id<"posSession"> }>(() => voidSessionMutation(args)),
+    updateSession: (args: Parameters<typeof updateSessionMutation>[0]) =>
+      runCommand<SessionCommandPayload>(() => updateSessionMutation(args)),
+    syncSessionCheckoutState: (
+      args: Parameters<typeof syncSessionCheckoutStateMutation>[0],
+    ) => runCommand<SessionCommandPayload>(() => syncSessionCheckoutStateMutation(args)),
+    releaseSessionInventoryHoldsAndDeleteItems: (
+      args: Parameters<typeof releaseSessionMutation>[0],
+    ) =>
+      runCommand<{ sessionId?: Id<"posSession"> }>(() => releaseSessionMutation(args)),
+    removeItem: (args: Parameters<typeof removeItemMutation>[0]) =>
+      runCommand<RemoveItemPayload>(() => removeItemMutation(args)),
   };
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -221,37 +221,33 @@ describe("useRegisterViewModel", () => {
 
     mockUseQuery.mockImplementation(() => mockCashier);
     mockStartSession.mockReset();
-    mockStartSession.mockResolvedValue({
-      success: true,
-      data: {
+    mockStartSession.mockResolvedValue(
+      ok({
         sessionId: "session-2" as Id<"posSession">,
         expiresAt: Date.now() + 60_000,
-      },
-    });
+      }),
+    );
     mockAddItem.mockReset();
-    mockAddItem.mockResolvedValue({
-      success: true,
-      data: {
+    mockAddItem.mockResolvedValue(
+      ok({
         itemId: "item-2" as Id<"posSessionItem">,
         expiresAt: Date.now() + 60_000,
-      },
-    });
+      }),
+    );
     mockHoldSession.mockReset();
-    mockHoldSession.mockResolvedValue({
-      success: true,
-      data: {
+    mockHoldSession.mockResolvedValue(
+      ok({
         sessionId: "session-1" as Id<"posSession">,
         expiresAt: Date.now() + 60_000,
-      },
-    });
+      }),
+    );
     mockCompleteTransaction.mockReset();
-    mockCompleteTransaction.mockResolvedValue({
-      success: true,
-      data: {
+    mockCompleteTransaction.mockResolvedValue(
+      ok({
         sessionId: "session-1" as Id<"posSession">,
         transactionNumber: "TXN-0001",
-      },
-    });
+      }),
+    );
     mockOpenDrawer.mockReset();
     mockOpenDrawer.mockResolvedValue(
       ok({
@@ -267,47 +263,44 @@ describe("useRegisterViewModel", () => {
       }),
     );
     mockResumeSession.mockReset();
-    mockResumeSession.mockResolvedValue({
-      success: true,
-      data: {
+    mockResumeSession.mockResolvedValue(
+      ok({
         sessionId: "session-2" as Id<"posSession">,
         expiresAt: Date.now() + 60_000,
-      },
-    });
+      }),
+    );
     mockVoidSession.mockReset();
-    mockVoidSession.mockResolvedValue({
-      success: true,
-      data: {
+    mockVoidSession.mockResolvedValue(
+      ok({
         sessionId: "session-1" as Id<"posSession">,
-      },
-    });
+      }),
+    );
     mockUpdateSession.mockReset();
-    mockUpdateSession.mockResolvedValue({
+    mockUpdateSession.mockResolvedValue(
+      ok({
       sessionId: "session-1" as Id<"posSession">,
       expiresAt: Date.now() + 60_000,
-    });
+      }),
+    );
     mockSyncSessionCheckoutState.mockReset();
-    mockSyncSessionCheckoutState.mockResolvedValue({
-      success: true,
-      data: {
+    mockSyncSessionCheckoutState.mockResolvedValue(
+      ok({
         sessionId: "session-1" as Id<"posSession">,
         expiresAt: Date.now() + 60_000,
-      },
-    });
+      }),
+    );
     mockReleaseSessionInventoryHoldsAndDeleteItems.mockReset();
-    mockReleaseSessionInventoryHoldsAndDeleteItems.mockResolvedValue({
-      success: true,
-      data: {
+    mockReleaseSessionInventoryHoldsAndDeleteItems.mockResolvedValue(
+      ok({
         sessionId: "session-1" as Id<"posSession">,
-      },
-    });
+      }),
+    );
     mockRemoveItem.mockReset();
-    mockRemoveItem.mockResolvedValue({
-      success: true,
-      data: {
+    mockRemoveItem.mockResolvedValue(
+      ok({
         expiresAt: Date.now() + 60_000,
-      },
-    });
+      }),
+    );
     mockNavigateBack.mockReset();
   });
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -378,32 +378,35 @@ export function useRegisterViewModel(): RegisterViewModel {
         return true;
       }
 
-      try {
-        await updateSession({
-          sessionId: session._id as Id<"posSession">,
-          staffProfileId,
-          customerId: customerInfo.customerId,
-          customerInfo: hasCustomerDetails(customerInfo)
-            ? {
-                name: customerInfo.name || undefined,
-                email: customerInfo.email || undefined,
-                phone: customerInfo.phone || undefined,
-              }
-            : undefined,
-          subtotal: activeTotals.subtotal,
-          tax: activeTotals.tax,
-          total: activeTotals.total,
-        });
+      const result = await updateSession({
+        sessionId: session._id as Id<"posSession">,
+        staffProfileId,
+        customerId: customerInfo.customerId,
+        customerInfo: hasCustomerDetails(customerInfo)
+          ? {
+              name: customerInfo.name || undefined,
+              email: customerInfo.email || undefined,
+              phone: customerInfo.phone || undefined,
+            }
+          : undefined,
+        subtotal: activeTotals.subtotal,
+        tax: activeTotals.tax,
+        total: activeTotals.total,
+      });
 
+      if (result.kind === "ok") {
         return true;
-      } catch (error) {
+      }
+
+      if (result.kind === "unexpected_error") {
         logger.error(
           "[POS] Failed to update session metadata",
-          error instanceof Error ? error : new Error(String(error)),
+          new Error(result.error.message),
         );
-        toast.error("Failed to save session details");
-        return false;
       }
+
+      toast.error(result.error.message);
+      return false;
     },
     [
       activeTotals.subtotal,
@@ -421,26 +424,26 @@ export function useRegisterViewModel(): RegisterViewModel {
         return;
       }
 
-      try {
-        await updateSession({
-          sessionId: activeSession._id as Id<"posSession">,
-          staffProfileId,
-          customerId: nextCustomerInfo.customerId,
-          customerInfo: hasCustomerDetails(nextCustomerInfo)
-            ? {
-                name: nextCustomerInfo.name || undefined,
-                email: nextCustomerInfo.email || undefined,
-                phone: nextCustomerInfo.phone || undefined,
-              }
-            : undefined,
-          subtotal: activeTotals.subtotal,
-          tax: activeTotals.tax,
-          total: activeTotals.total,
-        });
-      } catch (error) {
+      const result = await updateSession({
+        sessionId: activeSession._id as Id<"posSession">,
+        staffProfileId,
+        customerId: nextCustomerInfo.customerId,
+        customerInfo: hasCustomerDetails(nextCustomerInfo)
+          ? {
+              name: nextCustomerInfo.name || undefined,
+              email: nextCustomerInfo.email || undefined,
+              phone: nextCustomerInfo.phone || undefined,
+            }
+          : undefined,
+        subtotal: activeTotals.subtotal,
+        tax: activeTotals.tax,
+        total: activeTotals.total,
+      });
+
+      if (result.kind !== "ok") {
         logger.warn("[POS] Failed to sync committed customer details", {
           sessionId: activeSession._id,
-          error: error instanceof Error ? error.message : String(error),
+          error: result.error.message,
         });
       }
     },
@@ -471,22 +474,22 @@ export function useRegisterViewModel(): RegisterViewModel {
         return;
       }
 
-      try {
-        await syncSessionCheckoutState({
-          sessionId: activeSession._id as Id<"posSession">,
-          staffProfileId,
-          checkoutStateVersion: args.checkoutStateVersion,
-          payments: args.nextPayments.map(({ id, ...payment }) => payment),
-          stage: args.stage,
-          paymentMethod: args.paymentMethod,
-          amount: args.amount,
-          previousAmount: args.previousAmount,
-        });
-      } catch (error) {
+      const result = await syncSessionCheckoutState({
+        sessionId: activeSession._id as Id<"posSession">,
+        staffProfileId,
+        checkoutStateVersion: args.checkoutStateVersion,
+        payments: args.nextPayments.map(({ id, ...payment }) => payment),
+        stage: args.stage,
+        paymentMethod: args.paymentMethod,
+        amount: args.amount,
+        previousAmount: args.previousAmount,
+      });
+
+      if (result.kind !== "ok") {
         logger.warn("[POS] Failed to sync checkout state", {
           sessionId: activeSession._id,
           stage: args.stage,
-          error: error instanceof Error ? error.message : String(error),
+          error: result.error.message,
         });
       }
     },
@@ -564,8 +567,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       sessionId: activeSession._id as Id<"posSession">,
     });
 
-    if (!result.success) {
-      toast.error(result.message);
+    if (result.kind !== "ok") {
+      toast.error(result.error.message);
       return false;
     }
 
@@ -601,8 +604,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       terminalId: terminal._id,
     });
 
-    if (!result.success) {
-      toast.error(result.message);
+    if (result.kind !== "ok") {
+      toast.error(result.error.message);
       return;
     }
 
@@ -765,8 +768,8 @@ export function useRegisterViewModel(): RegisterViewModel {
           terminalId: terminal._id,
         });
 
-        if (!result.success) {
-          toast.error(result.message);
+        if (result.kind !== "ok") {
+          toast.error(result.error.message);
           bootstrapInitialized.current = false;
         }
 
@@ -906,8 +909,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         itemId,
       });
 
-      if (!result.success) {
-        toast.error(result.message);
+      if (result.kind !== "ok") {
+        toast.error(result.error.message);
       }
 
       return;
@@ -958,8 +961,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       itemId,
     });
 
-    if (!result.success) {
-      toast.error(result.message);
+    if (result.kind !== "ok") {
+      toast.error(result.error.message);
     }
   }, [activeSession, removeItem, staffProfileId]);
 
@@ -974,8 +977,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       checkoutStateVersion,
     });
 
-    if (!result.success) {
-      toast.error(result.message);
+    if (result.kind !== "ok") {
+      toast.error(result.error.message);
       return;
     }
 
@@ -1358,8 +1361,8 @@ export function useRegisterViewModel(): RegisterViewModel {
           onResumeSession: handleResumeSession,
           onVoidHeldSession: async (sessionId: Id<"posSession">) => {
             const result = await voidSession({ sessionId });
-            if (!result.success) {
-              toast.error(result.message);
+            if (result.kind !== "ok") {
+              toast.error(result.error.message);
               return;
             }
 


### PR DESCRIPTION
## Summary
- migrate POS session, session-item, customer, and transaction mutations onto CommandResult/user_error contracts
- normalize register and customer browser gateways through runCommand so durable surfaces only show safe inline/toast copy
- update POS register and transaction tests, then rebuild graphify artifacts

## Why
The remaining POS register and customer flows were still mixing legacy success/message envelopes with thrown server errors. This change brings those write paths onto the shared server/error foundation so expected failures stay user-safe and unexpected faults collapse through the generic fallback.

## Validation
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter '@athena/webapp' test -- convex/pos/application/completeTransaction.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts
- bun run --filter '@athena/webapp' test convex/pos/application/sessionCommands.test.ts convex/pos/application/completeTransaction.test.ts convex/pos/public/transactions.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/CashierAuthDialog.test.tsx src/components/pos/register/POSRegisterView.test.tsx
- bun run --filter '@athena/webapp' audit:convex
- bun run --filter '@athena/webapp' lint:convex:changed
- bun run --filter '@athena/webapp' build
- git diff --check
- bun run graphify:rebuild

Linear: https://linear.app/v26-labs/issue/V26-358/migrate-pos-register-and-customer-command-surfaces-to-the-shared