### PR TITLE
V26-379: Centralize register-session status policy for POS drawer readiness

### DIFF
--- a/docs/plans/2026-04-24-001-fix-pos-closing-drawer-bootstrap-plan.md
+++ b/docs/plans/2026-04-24-001-fix-pos-closing-drawer-bootstrap-plan.md
@@ -1,0 +1,249 @@
+---
+title: fix: Centralize register-session status policy for POS drawer readiness
+type: fix
+status: active
+date: 2026-04-24
+---
+
+# fix: Centralize register-session status policy for POS drawer readiness
+
+## Overview
+
+Fix the lingering POS drawer bootstrap bug by making register-session status semantics explicit. `open` and `active` are usable for POS sale work, `closing` is visible to cash-control closeout but not usable for POS, and `closed` is historical. The implementation should remove duplicated local interpretations of those states so future lifecycle edge cases are handled by one shared policy.
+
+---
+
+## Problem Frame
+
+The observed bug is an authenticated cashier reaching POS and getting "Open the cash drawer before starting a sale" when the resolved register session is `closing`. The first-principles issue is broader: multiple layers encode status meaning independently.
+
+- POS command boundaries reject non-usable drawers using local `open || active` helpers.
+- POS active-drawer lookup currently returns any non-closed drawer.
+- Browser bootstrap treats any non-null `activeRegisterSession` as drawer-ready.
+- Cash-control views intentionally include `closing`.
+- Duplicate-drawer conflict checks intentionally block `closing`.
+
+Those are different policies, not one policy with different names. This plan makes the policies explicit and routes callers through the right one.
+
+---
+
+## Requirements Trace
+
+- R1. POS sale readiness accepts only `open` and `active` register sessions.
+- R2. Cash-control operational visibility includes `open`, `active`, and `closing`.
+- R3. Duplicate drawer opening remains blocked by `open`, `active`, and `closing`.
+- R4. Browser bootstrap must not auto-start, auto-resume, or auto-bind using stale `closing` drawer data.
+- R5. Regression coverage must include a status matrix plus the server and browser closing-drawer bug paths.
+
+---
+
+## Scope Boundaries
+
+- Do not change register-session lifecycle transitions.
+- Do not allow a new drawer while a previous drawer is still `closing`.
+- Do not hide `closing` sessions from closeout/deposit/dashboard cash-control surfaces.
+- Do not add public Convex functions or generated client artifacts.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/operations/registerSessions.ts` owns register-session lifecycle transitions and active-drawer lookup.
+- `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`, `packages/athena-webapp/convex/inventory/posSessions.ts`, and `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` duplicate POS-usable status checks.
+- `packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts` duplicates in-store collection status checks.
+- `packages/athena-webapp/convex/cashControls/deposits.ts` duplicates dashboard visibility buckets.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` currently relies on non-null drawer DTOs instead of drawer usability.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md` says POS drawer invariants belong at command boundaries; this fix adds a shared status vocabulary so read-side bootstrap and write-side validation agree.
+
+### External References
+
+- Not used. The repo has direct local patterns for this lifecycle domain.
+
+---
+
+## Key Technical Decisions
+
+- Add a browser-safe shared status policy module under `packages/athena-webapp/shared`.
+- Keep policy names context-specific: POS usability, cash-control visibility, and duplicate-drawer conflict blocking.
+- Replace duplicated local predicates with the shared policy where the policy is semantically the same.
+- Keep exact lifecycle transition logic in `operations/registerSessions.ts`; transitions are not the same thing as contextual status policy.
+
+---
+
+## Implementation Units
+
+- [ ] U1. **Add shared register-session status policy**
+
+**Goal:** Define the domain vocabulary once and cover it with a status matrix.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/shared/registerSessionStatus.ts`
+- Test: `packages/athena-webapp/shared/registerSessionStatus.test.ts`
+
+**Approach:**
+- Export `RegisterSessionStatus` and named predicates for POS usability, cash-control visibility, and duplicate-drawer conflict blocking.
+- Accept unknown/string status input at call sites that receive persisted documents so invalid or absent values fail closed.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Browser-safe shared helpers in `packages/athena-webapp/shared/commandResult.ts`.
+
+**Test scenarios:**
+- Status matrix: `open` and `active` are POS-usable; `closing` and `closed` are not.
+- Status matrix: `open`, `active`, and `closing` block duplicate drawer opening; `closed` does not.
+- Status matrix: `open`, `active`, and `closing` are cash-control visible; `closed` is not.
+
+**Verification:**
+- Shared policy tests pass and the module can be imported from both Convex and browser code.
+
+---
+
+- [ ] U2. **Replace server-side duplicated status checks**
+
+**Goal:** Make POS commands, POS active-drawer lookup, inventory session mutation, in-store payment attribution, and cash-control dashboard bucketing use the shared policy.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Modify: `packages/athena-webapp/convex/inventory/posSessions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Test: `packages/athena-webapp/convex/operations/registerSessions.trace.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sessionCommands.test.ts`
+- Test: existing targeted tests for touched cash-control/transaction surfaces as needed
+
+**Approach:**
+- Use POS usability for active drawer lookup and command/session mutation boundaries.
+- Use duplicate-drawer conflict blocking for open-drawer conflict detection.
+- Use cash-control visibility for dashboard lists and closeout-facing buckets.
+- Preserve explicit command validation failures for `closing` register-session ids.
+
+**Execution note:** Test-first for the known closing-drawer server path.
+
+**Patterns to follow:**
+- Existing command-boundary validation in `sessionCommands.ts`.
+- Existing cash-control dashboard buckets in `deposits.ts`.
+
+**Test scenarios:**
+- Server edge case: latest register/terminal session is `closing` -> POS active drawer lookup returns `null`.
+- Server happy path: latest register/terminal session is `open` or `active` -> POS active drawer lookup returns it.
+- Conflict path: opening a drawer while latest session is `closing` still fails as duplicate/non-closed conflict.
+- Command path: explicit `closing` register-session id still returns `validationFailed` and creates no POS session.
+
+**Verification:**
+- Server status semantics are expressed through the shared policy and all targeted server tests pass.
+
+---
+
+- [ ] U3. **Defend browser bootstrap against stale closing-drawer DTOs**
+
+**Goal:** Prevent stale or cached `closing` drawer data from enabling POS bootstrap on the client.
+
+**Requirements:** R1, R4, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+
+**Approach:**
+- Derive a `usableActiveRegisterSession` from `activeRegisterSession` and the shared POS usability predicate.
+- Use that derived drawer id for auto-start, manual start, recovery binding, and drawer-gate decisions.
+- Treat a non-usable active register session as missing drawer state for startup and as recovery gate state when a POS session is already active.
+
+**Execution note:** Test-first for the authenticated cashier plus `closing` drawer state.
+
+**Patterns to follow:**
+- Existing missing-drawer and mismatched-drawer tests in `useRegisterViewModel.test.ts`.
+
+**Test scenarios:**
+- Browser edge case: `activeRegisterSession.status = "closing"` with no active POS session -> drawer gate renders, product entry is disabled, and `startSession` does not fire.
+- Browser recovery edge case: active POS session bound to a `closing` drawer -> recovery gate renders, product entry is disabled, and no start/bind command fires.
+- Happy path: `open` and `active` drawers continue to support current POS bootstrap behavior.
+
+**Verification:**
+- Authenticated cashiers never reach live POS bootstrap because of a `closing` drawer.
+
+---
+
+- [ ] U4. **Validate and refresh generated graph artifacts**
+
+**Goal:** Prove the foundational fix and keep repo graph artifacts current.
+
+**Requirements:** R5
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `graphify-out/GRAPH_REPORT.md`
+- Modify: `graphify-out/graph.json`
+- Modify: `graphify-out/wiki/index.md`
+- Modify: `graphify-out/wiki/packages/athena-webapp.md`
+
+**Approach:**
+- Run targeted tests first, then relevant Convex audit/lint, typecheck, build, and graphify rebuild.
+- Update the existing solution note only if implementation reveals a reusable nuance beyond the status policy captured here.
+
+**Execution note:** Sensor-only for generated artifacts.
+
+**Patterns to follow:**
+- `packages/athena-webapp/docs/agent/testing.md` POS register bootstrap and cash-control validation guidance.
+
+**Test scenarios:**
+- Test expectation: none -- this unit validates and refreshes derived artifacts rather than changing behavior.
+
+**Verification:**
+- Targeted and relevant broader sensors pass or any unrelated blocker is documented precisely.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Shared status policy feeds POS commands, POS active-drawer lookup, browser bootstrap, cash-control dashboard, and payment attribution.
+- **Error propagation:** Invalid POS drawer states should be stopped before bootstrap where possible and remain safe command-result failures where direct command calls occur.
+- **State lifecycle risks:** `closing` remains closeout-only and duplicate-opening remains blocked until `closed`.
+- **API surface parity:** No public API or DTO status union changes.
+- **Integration coverage:** Matrix tests plus server/browser regressions cover the exact context split that caused the bug.
+- **Unchanged invariants:** Register-session transitions remain `open -> active/closing`, `active -> closing`, and `closing -> closed`.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A shared helper could overgeneralize status semantics | Keep separate context-specific predicate names instead of one vague `isActive` helper |
+| Filtering `closing` too broadly could break closeout surfaces | Use cash-control visibility predicate for closeout/dashboard code |
+| Browser and server could drift again | Import the same browser-safe policy module on both sides |
+
+---
+
+## Documentation / Operational Notes
+
+- If this fix lands, the existing POS drawer invariant solution note should mention the shared status-policy layer as the durable prevention mechanism.
+
+---
+
+## Sources & References
+
+- Related Linear issue: V26-379
+- Related learning: `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`
+- Related code: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`

--- a/docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md
+++ b/docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md
@@ -54,7 +54,7 @@ The drawer validator should require:
 - A persisted `posSession.registerSessionId`.
 - A matching `registerSession` row.
 - The same store.
-- An open or active drawer status.
+- A POS-usable drawer status from the shared register-session policy.
 - Matching terminal and/or register number identity.
 
 For recovery, bind the preserved session to the newly opened drawer before allowing sale mutation. Do not create a replacement POS session, because that can drop cart, customer, or payment draft state.
@@ -62,10 +62,11 @@ For recovery, bind the preserved session to the newly opened drawer before allow
 ## Prevention
 
 - Treat UI gates as ergonomics, not authorization or invariant enforcement.
+- Define drawer status semantics once. POS sale mutation may use only `open` or `active`; duplicate drawer checks and cash-control closeout views may still need to include `closing`.
 - Add command-level tests for missing, closed, and mismatched drawer bindings whenever a POS mutation assumes an open drawer.
 - Reuse the same identity/status validation for start, resume, bind, item mutation, item removal, cart clear, payment sync, and completion flows.
 - Keep recovery flows idempotent: if the session is already bound to the same drawer, return success without mutating unrelated sale state.
 
 ## Related Issues
 
-- Linear: V26-373, V26-374, V26-375, V26-376, V26-377, V26-378.
+- Linear: V26-373, V26-374, V26-375, V26-376, V26-377, V26-378, V26-379.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1498 files · ~0 words
+- 1500 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3796 nodes · 3350 edges · 1413 communities detected
+- 3803 nodes · 3357 edges · 1415 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1423,6 +1423,8 @@
 - [[_COMMUNITY_Community 1410|Community 1410]]
 - [[_COMMUNITY_Community 1411|Community 1411]]
 - [[_COMMUNITY_Community 1412|Community 1412]]
+- [[_COMMUNITY_Community 1413|Community 1413]]
+- [[_COMMUNITY_Community 1414|Community 1414]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1547,20 +1549,20 @@ Cohesion: 0.16
 Nodes (6): diffGeneratedHarnessDocs(), diffWorkingTreeAddedNonGenerated(), formatBlockerList(), runPrePushReview(), snapshotGeneratedHarnessDocs(), toSortedArray()
 
 ### Community 24 - "Community 24"
+Cohesion: 0.21
+Nodes (12): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionTransactionPatch() (+4 more)
+
+### Community 25 - "Community 25"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.19
 Nodes (9): hasCustomerSnapshotValue(), isUsableRegisterSession(), normalizeCustomerSnapshot(), normalizeRegisterNumber(), persistSessionWorkflowTraceIdBestEffort(), recordSessionLifecycleTraceBestEffort(), registerSessionMatchesIdentity(), resolveCustomerTraceStage() (+1 more)
-
-### Community 27 - "Community 27"
-Cohesion: 0.23
-Nodes (12): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionTransactionPatch() (+4 more)
 
 ### Community 28 - "Community 28"
 Cohesion: 0.13
@@ -1708,19 +1710,19 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 64 - "Community 64"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 65 - "Community 65"
 Cohesion: 0.43
-Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 66 - "Community 66"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
 ### Community 67 - "Community 67"
-Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 68 - "Community 68"
 Cohesion: 0.36
@@ -1855,36 +1857,36 @@ Cohesion: 0.33
 Nodes (1): ValkeyClient
 
 ### Community 101 - "Community 101"
-Cohesion: 0.53
-Nodes (5): buildInStorePaymentAllocations(), isActiveRegisterSessionStatus(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 102 - "Community 102"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 103 - "Community 103"
+### Community 102 - "Community 102"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+
+### Community 103 - "Community 103"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 104 - "Community 104"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 105 - "Community 105"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 106 - "Community 106"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
+
+### Community 106 - "Community 106"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 107 - "Community 107"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 108 - "Community 108"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
 ### Community 109 - "Community 109"
 Cohesion: 0.4
@@ -1907,16 +1909,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 114 - "Community 114"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 115 - "Community 115"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 116 - "Community 116"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 116 - "Community 116"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 117 - "Community 117"
 Cohesion: 0.33
@@ -1927,52 +1929,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 119 - "Community 119"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 120 - "Community 120"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 121 - "Community 121"
-Cohesion: 0.4
-Nodes (2): hasCustomerDetails(), useRegisterViewModel()
 
 ### Community 122 - "Community 122"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): hasCustomerDetails(), useRegisterViewModel()
 
 ### Community 123 - "Community 123"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 124 - "Community 124"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 125 - "Community 125"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 126 - "Community 126"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 127 - "Community 127"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 128 - "Community 128"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 128 - "Community 128"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 129 - "Community 129"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 131 - "Community 131"
 Cohesion: 0.53
@@ -1991,8 +1993,8 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 135 - "Community 135"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 136 - "Community 136"
 Cohesion: 0.4
@@ -2003,44 +2005,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 138 - "Community 138"
-Cohesion: 0.7
-Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 139 - "Community 139"
 Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
 ### Community 140 - "Community 140"
-Cohesion: 0.5
-Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 141 - "Community 141"
 Cohesion: 0.5
-Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
+Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
 ### Community 142 - "Community 142"
+Cohesion: 0.5
+Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
+
+### Community 143 - "Community 143"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 147 - "Community 147"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 148 - "Community 148"
 Cohesion: 0.4
@@ -2048,7 +2050,7 @@ Nodes (0):
 
 ### Community 149 - "Community 149"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 150 - "Community 150"
 Cohesion: 0.4
@@ -2080,7 +2082,7 @@ Nodes (0):
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 158 - "Community 158"
 Cohesion: 0.4
@@ -2107,32 +2109,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 164 - "Community 164"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 165 - "Community 165"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.6
 Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.5
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 170 - "Community 170"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 171 - "Community 171"
 Cohesion: 0.4
@@ -2143,36 +2145,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 173 - "Community 173"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 174 - "Community 174"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 175 - "Community 175"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 176 - "Community 176"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 178 - "Community 178"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 179 - "Community 179"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 180 - "Community 180"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
@@ -2195,8 +2197,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 186 - "Community 186"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 187 - "Community 187"
 Cohesion: 0.83
@@ -2404,50 +2406,50 @@ Nodes (0):
 
 ### Community 238 - "Community 238"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 239 - "Community 239"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 240 - "Community 240"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 241 - "Community 241"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 242 - "Community 242"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 244 - "Community 244"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 246 - "Community 246"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 247 - "Community 247"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 248 - "Community 248"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 249 - "Community 249"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 250 - "Community 250"
@@ -2459,16 +2461,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 252 - "Community 252"
-Cohesion: 1.0
-Nodes (2): expenseItemError(), mapExpenseValidationError()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 253 - "Community 253"
 Cohesion: 1.0
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Nodes (2): expenseItemError(), mapExpenseValidationError()
 
 ### Community 254 - "Community 254"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 255 - "Community 255"
 Cohesion: 0.67
@@ -2487,48 +2489,48 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 259 - "Community 259"
-Cohesion: 1.0
-Nodes (2): mapOpenDrawerUserError(), openDrawer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (2): buildRegisterState(), getRegisterState()
+Nodes (2): mapOpenDrawerUserError(), openDrawer()
 
 ### Community 261 - "Community 261"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterState(), getRegisterState()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 263 - "Community 263"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 264 - "Community 264"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 266 - "Community 266"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 266 - "Community 266"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 269 - "Community 269"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 269 - "Community 269"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.67
@@ -2539,32 +2541,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 275 - "Community 275"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 276 - "Community 276"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 277 - "Community 277"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 278 - "Community 278"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
@@ -2579,16 +2581,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 282 - "Community 282"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 284 - "Community 284"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.67
@@ -2596,11 +2598,11 @@ Nodes (0):
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.67
@@ -2608,19 +2610,19 @@ Nodes (0):
 
 ### Community 289 - "Community 289"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 291 - "Community 291"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 292 - "Community 292"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 292 - "Community 292"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 293 - "Community 293"
 Cohesion: 0.67
@@ -2635,12 +2637,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
-
-### Community 297 - "Community 297"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 297 - "Community 297"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
@@ -2676,79 +2678,79 @@ Nodes (0):
 
 ### Community 306 - "Community 306"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 314 - "Community 314"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 315 - "Community 315"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 323 - "Community 323"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 324 - "Community 324"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.67
@@ -2776,11 +2778,11 @@ Nodes (0):
 
 ### Community 331 - "Community 331"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 333 - "Community 333"
 Cohesion: 0.67
@@ -2795,16 +2797,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 336 - "Community 336"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 337 - "Community 337"
 Cohesion: 1.0
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 337 - "Community 337"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 338 - "Community 338"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.67
@@ -2812,63 +2814,63 @@ Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 341 - "Community 341"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 342 - "Community 342"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 344 - "Community 344"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 345 - "Community 345"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 347 - "Community 347"
-Cohesion: 0.67
-Nodes (1): manualChunks()
-
 ### Community 348 - "Community 348"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 349 - "Community 349"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 350 - "Community 350"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 351 - "Community 351"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 352 - "Community 352"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 353 - "Community 353"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 354 - "Community 354"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 355 - "Community 355"
 Cohesion: 0.67
@@ -2879,12 +2881,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 357 - "Community 357"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 358 - "Community 358"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 358 - "Community 358"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 359 - "Community 359"
 Cohesion: 0.67
@@ -2895,12 +2897,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 361 - "Community 361"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 362 - "Community 362"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.67
@@ -2979,16 +2981,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 382 - "Community 382"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 383 - "Community 383"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 384 - "Community 384"
+### Community 383 - "Community 383"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 384 - "Community 384"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 385 - "Community 385"
 Cohesion: 1.0
@@ -3003,20 +3005,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 388 - "Community 388"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 389 - "Community 389"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 390 - "Community 390"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 391 - "Community 391"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 392 - "Community 392"
 Cohesion: 1.0
@@ -7102,2050 +7104,2060 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1413 - "Community 1413"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1414 - "Community 1414"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 391`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 392`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 393`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 394`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 395`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 396`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 397`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 398`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 399`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 400`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 401`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 402`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 403`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 404`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 405`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 406`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 407`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 408`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 409`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 410`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 411`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 412`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
+- **Thin community `Community 413`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 414`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 415`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 416`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 417`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 418`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 419`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 420`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 421`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 422`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 423`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 424`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 425`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 426`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 427`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 428`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 429`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 430`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 431`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 432`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 433`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 434`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 435`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 436`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 437`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
+- **Thin community `Community 438`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 439`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 440`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 441`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 442`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 443`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 444`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 445`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 446`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 447`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 448`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 449`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 450`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 451`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 452`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 453`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 454`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 455`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 456`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 457`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 458`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 459`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 460`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 461`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 462`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 463`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 464`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 465`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 466`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 467`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 468`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 469`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 470`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 471`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 472`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 473`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 474`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 475`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 476`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 477`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 478`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 479`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 480`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 481`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 482`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 483`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 484`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 485`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 486`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 487`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 488`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 489`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 490`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 491`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 492`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 493`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 494`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 495`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 496`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 497`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 498`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 499`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 500`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 501`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 502`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 503`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 504`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 505`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 506`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
+- **Thin community `Community 507`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 508`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 509`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 510`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 511`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 512`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 513`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 514`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 515`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 516`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 517`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 518`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 519`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 520`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 521`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 522`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 523`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 524`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 525`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 526`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 527`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 528`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 529`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 530`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 531`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 532`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 533`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 534`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 535`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 536`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 537`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 538`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 539`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 540`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 541`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 542`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 543`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 544`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 545`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 546`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 547`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 548`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 549`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 550`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 551`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 552`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 553`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 554`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 555`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 556`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 557`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 558`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 559`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 560`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 561`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 562`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 563`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 564`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 565`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 566`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 567`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 568`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 569`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 570`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 571`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 572`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 573`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 574`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 575`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 576`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 577`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 578`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 579`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 580`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 581`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 582`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 583`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 584`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 585`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 586`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 587`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 588`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 589`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 590`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 591`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 592`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 593`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 594`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 595`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 596`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 597`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 598`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 599`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 600`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 601`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 602`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 603`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 604`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 605`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 606`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 607`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 608`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 609`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 610`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 611`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 612`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 613`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 614`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 615`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 616`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 617`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 618`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 619`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 620`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 621`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 622`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 623`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 624`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 625`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 626`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 627`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 628`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 629`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 630`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 631`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 632`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 633`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 634`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 635`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 636`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 637`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 638`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 639`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 640`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 641`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 642`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 643`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 644`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 645`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 646`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 647`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 648`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 649`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 650`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 651`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 652`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 653`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 654`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 655`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 656`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 657`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 658`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 659`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 660`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 661`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 662`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 663`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 664`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 665`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 666`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 667`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 668`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 669`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 670`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 671`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 672`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 673`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 674`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 675`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 676`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 677`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 678`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 679`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 680`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 681`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 682`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 683`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 684`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 685`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 686`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 687`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 688`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 689`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 690`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 691`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 692`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 693`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 694`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 695`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 696`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 697`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 698`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 699`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 700`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 701`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 702`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 703`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 704`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 705`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 706`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 707`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 708`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 709`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 710`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 711`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 712`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 713`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 714`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 715`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 716`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 717`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 718`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 719`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 720`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 721`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 722`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 723`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 724`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 725`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 726`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 727`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 728`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 729`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 730`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 731`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 732`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 733`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 734`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 735`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 736`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 737`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 738`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 739`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 740`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 741`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 742`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `api.d.ts`
+- **Thin community `Community 743`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `api.js`
+- **Thin community `Community 744`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 745`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `server.d.ts`
+- **Thin community `Community 746`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `server.js`
+- **Thin community `Community 747`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `app.ts`
+- **Thin community `Community 748`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `auth.config.js`
+- **Thin community `Community 749`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `auth.ts`
+- **Thin community `Community 750`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 751`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `countries.ts`
+- **Thin community `Community 752`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `email.ts`
+- **Thin community `Community 753`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `ghana.ts`
+- **Thin community `Community 754`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `payment.ts`
+- **Thin community `Community 755`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `crons.ts`
+- **Thin community `Community 756`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 757`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 758`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 759`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 760`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `env.ts`
+- **Thin community `Community 761`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `analytics.ts`
+- **Thin community `Community 762`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `auth.ts`
+- **Thin community `Community 763`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 764`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `categories.ts`
+- **Thin community `Community 765`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `colors.ts`
+- **Thin community `Community 766`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `index.ts`
+- **Thin community `Community 767`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `organizations.ts`
+- **Thin community `Community 768`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `products.ts`
+- **Thin community `Community 769`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `stores.ts`
+- **Thin community `Community 770`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 771`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `index.ts`
+- **Thin community `Community 772`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `bag.ts`
+- **Thin community `Community 773`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `guest.ts`
+- **Thin community `Community 774`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `index.ts`
+- **Thin community `Community 775`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `me.ts`
+- **Thin community `Community 776`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `offers.ts`
+- **Thin community `Community 777`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 778`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `paystack.ts`
+- **Thin community `Community 779`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `reviews.ts`
+- **Thin community `Community 780`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `rewards.ts`
+- **Thin community `Community 781`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 782`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `security.test.ts`
+- **Thin community `Community 783`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `storefront.ts`
+- **Thin community `Community 784`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `upsells.ts`
+- **Thin community `Community 785`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `user.ts`
+- **Thin community `Community 786`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 787`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `health.test.ts`
+- **Thin community `Community 788`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `http.ts`
+- **Thin community `Community 789`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 790`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 791`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 792`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `categories.ts`
+- **Thin community `Community 793`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `colors.ts`
+- **Thin community `Community 794`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 795`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 796`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 797`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 798`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `organizations.ts`
+- **Thin community `Community 799`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `pos.ts`
+- **Thin community `Community 800`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 801`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 802`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `productSku.ts`
+- **Thin community `Community 803`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 804`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 805`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 806`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 807`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 808`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 809`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 810`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 811`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 812`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `client.test.ts`
+- **Thin community `Community 813`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `config.test.ts`
+- **Thin community `Community 814`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 815`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `types.ts`
+- **Thin community `Community 816`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 817`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 818`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 819`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 820`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 821`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `dto.ts`
+- **Thin community `Community 822`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 823`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 824`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `openDrawer.test.ts`
+- **Thin community `Community 825`** (1 nodes): `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 826`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `types.ts`
+- **Thin community `Community 827`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 828`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `catalog.ts`
+- **Thin community `Community 829`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `customers.ts`
+- **Thin community `Community 830`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `register.ts`
+- **Thin community `Community 831`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `terminals.ts`
+- **Thin community `Community 832`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `transactions.ts`
+- **Thin community `Community 833`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `schema.ts`
+- **Thin community `Community 834`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 835`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 836`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 837`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 838`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `category.ts`
+- **Thin community `Community 839`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `color.ts`
+- **Thin community `Community 840`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 841`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 842`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `index.ts`
+- **Thin community `Community 843`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 844`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `organization.ts`
+- **Thin community `Community 845`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 846`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `product.ts`
+- **Thin community `Community 847`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 848`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 849`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `store.ts`
+- **Thin community `Community 850`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 851`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `index.ts`
+- **Thin community `Community 852`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 853`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 854`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 855`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 856`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 857`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `index.ts`
+- **Thin community `Community 858`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 859`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 860`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 861`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 862`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 863`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 864`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 865`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 866`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 867`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `customer.ts`
+- **Thin community `Community 868`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 869`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 870`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 871`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 872`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `index.ts`
+- **Thin community `Community 873`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `posSession.ts`
+- **Thin community `Community 874`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 875`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 876`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 877`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 878`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `index.ts`
+- **Thin community `Community 879`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 880`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 881`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 882`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 883`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 884`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `index.ts`
+- **Thin community `Community 885`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 886`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 887`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 888`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 889`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `vendor.ts`
+- **Thin community `Community 890`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `analytics.ts`
+- **Thin community `Community 891`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `bag.ts`
+- **Thin community `Community 892`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 893`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 894`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 895`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `customer.ts`
+- **Thin community `Community 896`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `guest.ts`
+- **Thin community `Community 897`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `index.ts`
+- **Thin community `Community 898`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `offer.ts`
+- **Thin community `Community 899`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 900`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 901`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `review.ts`
+- **Thin community `Community 902`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `rewards.ts`
+- **Thin community `Community 903`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 904`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 905`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 906`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 907`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 908`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 909`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 910`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `bag.ts`
+- **Thin community `Community 911`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 912`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `customer.ts`
+- **Thin community `Community 913`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `guest.ts`
+- **Thin community `Community 914`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 915`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 916`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `payment.ts`
+- **Thin community `Community 917`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 918`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 919`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 920`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `users.ts`
+- **Thin community `Community 921`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `payment.ts`
+- **Thin community `Community 922`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `posSale.test.ts`
+- **Thin community `Community 923`** (1 nodes): `posSale.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 924`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 925`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 926`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 927`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `index.ts`
+- **Thin community `Community 928`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 929`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `auth.ts`
+- **Thin community `Community 930`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 931`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 932`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 933`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 934`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 935`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 936`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 937`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `constants.ts`
+- **Thin community `Community 938`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 939`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 940`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 941`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `types.ts`
+- **Thin community `Community 942`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 943`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 944`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 945`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 946`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 947`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 948`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 949`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 950`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `columns.tsx`
+- **Thin community `Community 951`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 952`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 953`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 954`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 955`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `columns.tsx`
+- **Thin community `Community 956`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 957`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 958`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `chart.tsx`
+- **Thin community `Community 959`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `columns.tsx`
+- **Thin community `Community 960`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 961`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 962`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `columns.tsx`
+- **Thin community `Community 963`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `constants.ts`
+- **Thin community `Community 964`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 965`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 967`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `data.ts`
+- **Thin community `Community 968`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `columns.tsx`
+- **Thin community `Community 969`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 970`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 971`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `columns.tsx`
+- **Thin community `Community 972`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 973`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 979`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `constants.ts`
+- **Thin community `Community 980`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 981`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 982`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data.ts`
+- **Thin community `Community 984`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 985`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 986`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 987`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 988`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 989`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `columns.tsx`
+- **Thin community `Community 990`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 991`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 992`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 994`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 995`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `columns.tsx`
+- **Thin community `Community 996`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `constants.ts`
+- **Thin community `Community 997`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 998`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 999`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1000`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1002`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1003`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1004`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1005`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1006`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1007`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1009`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1011`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1012`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1013`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1014`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1015`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1016`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1017`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1018`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1019`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `constants.ts`
+- **Thin community `Community 1020`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1021`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1022`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1023`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `data.ts`
+- **Thin community `Community 1024`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1025`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `constants.ts`
+- **Thin community `Community 1026`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1027`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1028`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1029`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1030`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `data.ts`
+- **Thin community `Community 1031`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1032`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `constants.ts`
+- **Thin community `Community 1033`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1034`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1035`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1036`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1037`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `data.ts`
+- **Thin community `Community 1038`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1039`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1040`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1041`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1042`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1043`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1044`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1045`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1046`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1047`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1048`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1049`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1050`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1051`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1052`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1053`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1054`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1055`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1056`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1057`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1058`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1059`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1060`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `WorkflowTraceLink.test.tsx`
+- **Thin community `Community 1061`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `types.ts`
+- **Thin community `Community 1062`** (1 nodes): `WorkflowTraceLink.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1063`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1064`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1065`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1066`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1067`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1068`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 1069`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1070`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1071`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1072`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1073`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1074`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1075`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1076`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1077`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1078`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1079`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1080`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1081`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `data.ts`
+- **Thin community `Community 1082`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1083`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1084`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1085`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1086`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1087`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1089`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1090`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1091`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1092`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1093`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1094`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1095`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `constants.ts`
+- **Thin community `Community 1096`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1097`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1098`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1099`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data.ts`
+- **Thin community `Community 1100`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `types.ts`
+- **Thin community `Community 1101`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1102`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1103`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1104`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1105`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `index.tsx`
+- **Thin community `Community 1106`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1107`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1108`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1109`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1110`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `index.tsx`
+- **Thin community `Community 1111`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1112`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1113`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1114`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `button.tsx`
+- **Thin community `Community 1115`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1116`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `card.tsx`
+- **Thin community `Community 1117`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1118`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1119`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `command.tsx`
+- **Thin community `Community 1120`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1121`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1122`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1123`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `form.tsx`
+- **Thin community `Community 1124`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1125`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1126`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `input.tsx`
+- **Thin community `Community 1127`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1128`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1129`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1130`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1131`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1132`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `select.tsx`
+- **Thin community `Community 1133`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1134`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1135`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1136`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `table.tsx`
+- **Thin community `Community 1137`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1138`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1139`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1140`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1141`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1142`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1143`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1144`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1145`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `constants.ts`
+- **Thin community `Community 1146`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1147`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1148`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1149`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `data.ts`
+- **Thin community `Community 1150`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1151`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1152`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1153`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1154`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1155`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1156`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1157`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1158`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1159`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1160`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1161`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1162`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1163`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `index.ts`
+- **Thin community `Community 1164`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `config.ts`
+- **Thin community `Community 1165`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1166`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1167`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1168`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1169`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1170`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `aws.ts`
+- **Thin community `Community 1171`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `constants.ts`
+- **Thin community `Community 1172`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `countries.ts`
+- **Thin community `Community 1173`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1174`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1175`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1176`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1177`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1178`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1179`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `dto.ts`
+- **Thin community `Community 1180`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `ports.ts`
+- **Thin community `Community 1181`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `constants.ts`
+- **Thin community `Community 1182`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1183`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `index.ts`
+- **Thin community `Community 1185`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `types.ts`
+- **Thin community `Community 1187`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1188`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1189`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1190`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1191`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1192`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `category.ts`
+- **Thin community `Community 1194`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `product.ts`
+- **Thin community `Community 1195`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `store.ts`
+- **Thin community `Community 1196`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1197`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `user.ts`
+- **Thin community `Community 1198`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1199`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1201`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1202`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1203`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `index.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `index.tsx`
+- **Thin community `Community 1204`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1205`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1206`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1207`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1208`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1209`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1210`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `index.tsx`
+- **Thin community `Community 1211`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1212`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1213`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1214`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `home.tsx`
+- **Thin community `Community 1215`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1216`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1217`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1218`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `index.tsx`
+- **Thin community `Community 1219`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `index.tsx`
+- **Thin community `Community 1220`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1221`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1222`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1223`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `index.tsx`
+- **Thin community `Community 1224`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1225`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1226`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1227`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1228`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1229`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1230`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1231`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1233`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1234`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1235`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1236`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1237`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1238`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `index.tsx`
+- **Thin community `Community 1239`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `index.tsx`
+- **Thin community `Community 1240`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `new.tsx`
+- **Thin community `Community 1241`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1242`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1243`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1244`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1245`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `index.tsx`
+- **Thin community `Community 1246`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `new.tsx`
+- **Thin community `Community 1247`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1248`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1249`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1250`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1251`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1252`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1253`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1254`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1255`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `index.tsx`
+- **Thin community `Community 1256`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1257`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1258`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1259`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1260`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1261`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1262`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1263`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1264`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1265`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1266`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1267`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1268`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1269`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1270`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1271`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1272`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1273`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1274`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `setup.ts`
+- **Thin community `Community 1275`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1277`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `types.ts`
+- **Thin community `Community 1278`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1279`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1280`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1281`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1282`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `types.ts`
+- **Thin community `Community 1284`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1285`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1286`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1288`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1289`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1290`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1292`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1293`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `schema.ts`
+- **Thin community `Community 1294`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1295`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1297`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1299`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1300`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1301`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1302`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1303`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `types.ts`
+- **Thin community `Community 1304`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1306`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1307`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1308`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1309`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1311`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `constants.ts`
+- **Thin community `Community 1312`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1313`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `About.tsx`
+- **Thin community `Community 1314`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1315`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1316`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1317`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1318`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1319`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1320`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1321`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1322`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1323`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `types.ts`
+- **Thin community `Community 1324`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1325`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1326`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1327`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1328`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1329`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1330`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1331`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1332`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1333`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1334`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `button.tsx`
+- **Thin community `Community 1335`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `card.tsx`
+- **Thin community `Community 1336`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1337`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `command.tsx`
+- **Thin community `Community 1338`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1339`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1340`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1341`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `form.tsx`
+- **Thin community `Community 1342`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1343`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1344`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1345`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1346`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `input.tsx`
+- **Thin community `Community 1347`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `label.tsx`
+- **Thin community `Community 1348`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1349`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1350`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1351`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `index.ts`
+- **Thin community `Community 1352`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `types.ts`
+- **Thin community `Community 1353`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1354`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1355`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1356`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1357`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `select.tsx`
+- **Thin community `Community 1358`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1359`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1360`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `table.tsx`
+- **Thin community `Community 1361`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1362`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1363`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1364`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1365`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1366`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `config.ts`
+- **Thin community `Community 1367`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1368`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1369`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1370`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `constants.ts`
+- **Thin community `Community 1371`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `countries.ts`
+- **Thin community `Community 1372`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1373`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1374`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1375`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1376`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `index.ts`
+- **Thin community `Community 1377`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `store.ts`
+- **Thin community `Community 1378`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `bag.ts`
+- **Thin community `Community 1379`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1380`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `category.ts`
+- **Thin community `Community 1381`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `organization.ts`
+- **Thin community `Community 1382`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `product.ts`
+- **Thin community `Community 1383`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `store.ts`
+- **Thin community `Community 1384`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1385`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `user.ts`
+- **Thin community `Community 1386`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `states.ts`
+- **Thin community `Community 1387`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1388`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1389`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1390`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1391`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1392`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1393`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1394`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `index.tsx`
+- **Thin community `Community 1395`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1396`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1397`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1398`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1399`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1400`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1401`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1402`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `index.tsx`
+- **Thin community `Community 1403`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1404`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1405`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1406`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1407`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `index.js`
+- **Thin community `Community 1408`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1409`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1410`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1411`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1412`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1413`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1414`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -995,7 +995,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L503",
+      "source_location": "L504",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1007,7 +1007,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L433",
+      "source_location": "L434",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1019,7 +1019,7 @@
       "relation": "calls",
       "source": "completetransaction_persistworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L487",
+      "source_location": "L488",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1031,7 +1031,7 @@
       "relation": "calls",
       "source": "completetransaction_recordpossaletracebesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L481",
+      "source_location": "L482",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1043,7 +1043,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L493",
+      "source_location": "L494",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1055,7 +1055,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L795",
+      "source_location": "L796",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1067,7 +1067,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L720",
+      "source_location": "L721",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1079,7 +1079,7 @@
       "relation": "calls",
       "source": "completetransaction_persistworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L779",
+      "source_location": "L780",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1091,7 +1091,7 @@
       "relation": "calls",
       "source": "completetransaction_recordpossaletracebesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L773",
+      "source_location": "L774",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1103,7 +1103,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L785",
+      "source_location": "L786",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1115,7 +1115,7 @@
       "relation": "calls",
       "source": "completetransaction_resolvesessionregistersessionid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L679",
+      "source_location": "L680",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1127,7 +1127,7 @@
       "relation": "calls",
       "source": "completetransaction_safetracewrite",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L239",
+      "source_location": "L240",
       "target": "completetransaction_persistworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -1139,7 +1139,7 @@
       "relation": "calls",
       "source": "completetransaction_buildpossaletraceevent",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L201",
+      "source_location": "L202",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -1151,7 +1151,7 @@
       "relation": "calls",
       "source": "completetransaction_buildpossaletracerecord",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L200",
+      "source_location": "L201",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -1163,7 +1163,7 @@
       "relation": "calls",
       "source": "completetransaction_normalizeregisternumber",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L91",
+      "source_location": "L92",
       "target": "completetransaction_registersessionmatchesidentity",
       "weight": 1
     },
@@ -1175,7 +1175,7 @@
       "relation": "calls",
       "source": "completetransaction_isusableregistersession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L279",
+      "source_location": "L280",
       "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
@@ -1187,7 +1187,7 @@
       "relation": "calls",
       "source": "completetransaction_registersessionmatchesidentity",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L280",
+      "source_location": "L281",
       "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
@@ -1199,7 +1199,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionvoid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L602",
+      "source_location": "L603",
       "target": "completetransaction_voidtransaction",
       "weight": 1
     },
@@ -1511,7 +1511,7 @@
       "relation": "calls",
       "source": "deposits_sumdepositsbysession",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L205",
+      "source_location": "L206",
       "target": "deposits_buildcashcontrolsdashboardsnapshot",
       "weight": 1
     },
@@ -6971,7 +6971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L199",
+      "source_location": "L200",
       "target": "deposits_buildcashcontrolsdashboardsnapshot",
       "weight": 1
     },
@@ -6983,7 +6983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L164",
+      "source_location": "L165",
       "target": "deposits_buildregistersessiondeposittargetid",
       "weight": 1
     },
@@ -6995,7 +6995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L171",
+      "source_location": "L172",
       "target": "deposits_buildregistersessionsummary",
       "weight": 1
     },
@@ -7007,7 +7007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L329",
+      "source_location": "L330",
       "target": "deposits_collectstaffprofileids",
       "weight": 1
     },
@@ -7019,7 +7019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L121",
+      "source_location": "L122",
       "target": "deposits_iscashcontroldepositallocation",
       "weight": 1
     },
@@ -7031,7 +7031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L260",
+      "source_location": "L261",
       "target": "deposits_listregistersessionsfordashboard",
       "weight": 1
     },
@@ -7043,7 +7043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L316",
+      "source_location": "L317",
       "target": "deposits_listregistersessiontimeline",
       "weight": 1
     },
@@ -7055,7 +7055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L302",
+      "source_location": "L303",
       "target": "deposits_listsessiondeposits",
       "weight": 1
     },
@@ -7067,7 +7067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L131",
+      "source_location": "L132",
       "target": "deposits_liststaffnames",
       "weight": 1
     },
@@ -7079,7 +7079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L288",
+      "source_location": "L289",
       "target": "deposits_liststoredeposits",
       "weight": 1
     },
@@ -7091,7 +7091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L99",
+      "source_location": "L100",
       "target": "deposits_persistregistersessionworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -7103,7 +7103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L147",
+      "source_location": "L148",
       "target": "deposits_sumdepositsbysession",
       "weight": 1
     },
@@ -7115,7 +7115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L94",
+      "source_location": "L95",
       "target": "deposits_trimoptional",
       "weight": 1
     },
@@ -7139,20 +7139,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L48",
+      "source_location": "L46",
       "target": "paymentallocationattribution_buildinstorepaymentallocations",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "_tgt": "paymentallocationattribution_isactiveregistersessionstatus",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L20",
-      "target": "paymentallocationattribution_isactiveregistersessionstatus",
       "weight": 1
     },
     {
@@ -7163,7 +7151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L24",
+      "source_location": "L22",
       "target": "paymentallocationattribution_normalizeinstorepayments",
       "weight": 1
     },
@@ -7175,7 +7163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L120",
+      "source_location": "L118",
       "target": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "weight": 1
     },
@@ -7187,7 +7175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L83",
+      "source_location": "L81",
       "target": "paymentallocationattribution_selectregistersessionforattribution",
       "weight": 1
     },
@@ -8135,7 +8123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L321",
+      "source_location": "L322",
       "target": "possessions_hascustomersnapshotvalue",
       "weight": 1
     },
@@ -8147,7 +8135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L100",
+      "source_location": "L101",
       "target": "possessions_isusableregistersession",
       "weight": 1
     },
@@ -8159,7 +8147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L193",
+      "source_location": "L194",
       "target": "possessions_listpossessionsbystatusbefore",
       "weight": 1
     },
@@ -8171,7 +8159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L219",
+      "source_location": "L220",
       "target": "possessions_listpossessionsforstorestatus",
       "weight": 1
     },
@@ -8183,7 +8171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L171",
+      "source_location": "L172",
       "target": "possessions_loadpossessionitems",
       "weight": 1
     },
@@ -8195,7 +8183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L306",
+      "source_location": "L307",
       "target": "possessions_normalizecustomersnapshot",
       "weight": 1
     },
@@ -8207,7 +8195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L95",
+      "source_location": "L96",
       "target": "possessions_normalizeregisternumber",
       "weight": 1
     },
@@ -8219,7 +8207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L245",
+      "source_location": "L246",
       "target": "possessions_persistsessionworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -8231,7 +8219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L266",
+      "source_location": "L267",
       "target": "possessions_recordsessionlifecycletracebesteffort",
       "weight": 1
     },
@@ -8243,7 +8231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L104",
+      "source_location": "L105",
       "target": "possessions_registersessionmatchesidentity",
       "weight": 1
     },
@@ -8255,7 +8243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L330",
+      "source_location": "L331",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -8267,7 +8255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L54",
+      "source_location": "L55",
       "target": "possessions_usererrorfromsessioncommandfailure",
       "weight": 1
     },
@@ -8279,7 +8267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L81",
+      "source_location": "L82",
       "target": "possessions_usererrorfromvalidationmessage",
       "weight": 1
     },
@@ -8291,7 +8279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L135",
+      "source_location": "L136",
       "target": "possessions_validatesessiondrawerbinding",
       "weight": 1
     },
@@ -9647,7 +9635,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L26",
+      "source_location": "L30",
       "target": "registersessions_trace_test_buildregistersession",
       "weight": 1
     },
@@ -9659,7 +9647,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L43",
+      "source_location": "L47",
       "target": "registersessions_trace_test_createmutationctx",
       "weight": 1
     },
@@ -9671,7 +9659,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L107",
+      "source_location": "L130",
       "target": "registersessions_trace_test_gethandler",
       "weight": 1
     },
@@ -9683,7 +9671,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L54",
+      "source_location": "L61",
       "target": "registersessions_assertregistersessionidentity",
       "weight": 1
     },
@@ -9695,7 +9683,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L64",
+      "source_location": "L71",
       "target": "registersessions_assertregistersessionmatchestransaction",
       "weight": 1
     },
@@ -9707,7 +9695,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L135",
+      "source_location": "L142",
       "target": "registersessions_assertvalidregistersessiontransition",
       "weight": 1
     },
@@ -9719,7 +9707,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L250",
+      "source_location": "L257",
       "target": "registersessions_buildclosedregistersessionpatch",
       "weight": 1
     },
@@ -9731,7 +9719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L100",
+      "source_location": "L107",
       "target": "registersessions_buildregistersession",
       "weight": 1
     },
@@ -9743,7 +9731,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L195",
+      "source_location": "L202",
       "target": "registersessions_buildregistersessioncloseoutpatch",
       "weight": 1
     },
@@ -9755,7 +9743,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L221",
+      "source_location": "L228",
       "target": "registersessions_buildregistersessiondepositpatch",
       "weight": 1
     },
@@ -9767,7 +9755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L154",
+      "source_location": "L161",
       "target": "registersessions_buildregistersessiontransactionpatch",
       "weight": 1
     },
@@ -9779,7 +9767,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L122",
+      "source_location": "L129",
       "target": "registersessions_calculateregistersessioncashdelta",
       "weight": 1
     },
@@ -9791,7 +9779,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L276",
+      "source_location": "L283",
       "target": "registersessions_findconflictingregistersession",
       "weight": 1
     },
@@ -9803,7 +9791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L47",
+      "source_location": "L54",
       "target": "registersessions_normalizeregistersessionidentity",
       "weight": 1
     },
@@ -9815,7 +9803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L25",
+      "source_location": "L32",
       "target": "registersessions_persistregistersessionworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -9827,8 +9815,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L490",
+      "source_location": "L505",
       "target": "registersessions_recordregistersessiondepositwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "_tgt": "registersessions_registersessionstatusset",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L11",
+      "target": "registersessions_registersessionstatusset",
       "weight": 1
     },
     {
@@ -9839,7 +9839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L20",
+      "source_location": "L27",
       "target": "registersessions_trimoptional",
       "weight": 1
     },
@@ -10535,7 +10535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L51",
+      "source_location": "L52",
       "target": "completetransaction_buildcompletetransactionresult",
       "weight": 1
     },
@@ -10547,7 +10547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L151",
+      "source_location": "L152",
       "target": "completetransaction_buildpossaletraceevent",
       "weight": 1
     },
@@ -10559,7 +10559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L130",
+      "source_location": "L131",
       "target": "completetransaction_buildpossaletracerecord",
       "weight": 1
     },
@@ -10571,7 +10571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L72",
+      "source_location": "L73",
       "target": "completetransaction_calculatetotalpaid",
       "weight": 1
     },
@@ -10583,7 +10583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L374",
+      "source_location": "L375",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -10595,7 +10595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L647",
+      "source_location": "L648",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -10607,7 +10607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L115",
+      "source_location": "L116",
       "target": "completetransaction_isusableregistersession",
       "weight": 1
     },
@@ -10619,7 +10619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L76",
+      "source_location": "L77",
       "target": "completetransaction_normalizeregisternumber",
       "weight": 1
     },
@@ -10631,7 +10631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L227",
+      "source_location": "L228",
       "target": "completetransaction_persistworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -10643,7 +10643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L191",
+      "source_location": "L192",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -10655,7 +10655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L294",
+      "source_location": "L295",
       "target": "completetransaction_recordregistersessionsale",
       "weight": 1
     },
@@ -10667,7 +10667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L319",
+      "source_location": "L320",
       "target": "completetransaction_recordregistersessionvoid",
       "weight": 1
     },
@@ -10679,7 +10679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L81",
+      "source_location": "L82",
       "target": "completetransaction_registersessionmatchesidentity",
       "weight": 1
     },
@@ -10691,7 +10691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L246",
+      "source_location": "L247",
       "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
@@ -10703,7 +10703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L119",
+      "source_location": "L120",
       "target": "completetransaction_safetracewrite",
       "weight": 1
     },
@@ -10715,7 +10715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L344",
+      "source_location": "L345",
       "target": "completetransaction_updateinventory",
       "weight": 1
     },
@@ -10727,7 +10727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L578",
+      "source_location": "L579",
       "target": "completetransaction_voidtransaction",
       "weight": 1
     },
@@ -10847,7 +10847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L692",
+      "source_location": "L693",
       "target": "sessioncommands_buildnextsessionnumber",
       "weight": 1
     },
@@ -10859,7 +10859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L650",
+      "source_location": "L651",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -10871,7 +10871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L145",
+      "source_location": "L146",
       "target": "sessioncommands_createpossessioncommandservice",
       "weight": 1
     },
@@ -10883,7 +10883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L885",
+      "source_location": "L886",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -10895,7 +10895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L708",
+      "source_location": "L709",
       "target": "sessioncommands_isactiveregistersession",
       "weight": 1
     },
@@ -10907,7 +10907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L797",
+      "source_location": "L798",
       "target": "sessioncommands_issessionexpired",
       "weight": 1
     },
@@ -10919,7 +10919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L703",
+      "source_location": "L704",
       "target": "sessioncommands_normalizeregisternumber",
       "weight": 1
     },
@@ -10931,7 +10931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L662",
+      "source_location": "L663",
       "target": "sessioncommands_recordsessionlifecyclebesteffort",
       "weight": 1
     },
@@ -10943,7 +10943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L714",
+      "source_location": "L715",
       "target": "sessioncommands_registersessionmatchesidentity",
       "weight": 1
     },
@@ -10955,7 +10955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L745",
+      "source_location": "L746",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -10967,7 +10967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L629",
+      "source_location": "L630",
       "target": "sessioncommands_runbindsessiontoregistersessioncommand",
       "weight": 1
     },
@@ -10979,7 +10979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L618",
+      "source_location": "L619",
       "target": "sessioncommands_runholdsessioncommand",
       "weight": 1
     },
@@ -10991,7 +10991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L643",
+      "source_location": "L644",
       "target": "sessioncommands_runremovesessionitemcommand",
       "weight": 1
     },
@@ -11003,7 +11003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L622",
+      "source_location": "L623",
       "target": "sessioncommands_runresumesessioncommand",
       "weight": 1
     },
@@ -11015,7 +11015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L611",
+      "source_location": "L612",
       "target": "sessioncommands_runstartsessioncommand",
       "weight": 1
     },
@@ -11027,7 +11027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L636",
+      "source_location": "L637",
       "target": "sessioncommands_runupsertsessionitemcommand",
       "weight": 1
     },
@@ -11039,7 +11039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L878",
+      "source_location": "L879",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -11051,7 +11051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L801",
+      "source_location": "L802",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -11063,7 +11063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L779",
+      "source_location": "L780",
       "target": "sessioncommands_validateactivesessionregisterbinding",
       "weight": 1
     },
@@ -11075,7 +11075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L845",
+      "source_location": "L846",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -11363,7 +11363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1439",
+      "source_location": "L1474",
       "target": "sessioncommands_test_builditem",
       "weight": 1
     },
@@ -11375,7 +11375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1433",
+      "source_location": "L1468",
       "target": "sessioncommands_test_buildregistersession",
       "weight": 1
     },
@@ -11387,7 +11387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1429",
+      "source_location": "L1464",
       "target": "sessioncommands_test_buildsession",
       "weight": 1
     },
@@ -11399,7 +11399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1449",
+      "source_location": "L1484",
       "target": "sessioncommands_test_createcommandservice",
       "weight": 1
     },
@@ -11411,7 +11411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1209",
+      "source_location": "L1244",
       "target": "sessioncommands_test_createdependencies",
       "weight": 1
     },
@@ -11423,7 +11423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1286",
+      "source_location": "L1321",
       "target": "sessioncommands_test_createfakerepository",
       "weight": 1
     },
@@ -11435,7 +11435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1191",
+      "source_location": "L1226",
       "target": "sessioncommands_test_loadcommandservice",
       "weight": 1
     },
@@ -14977,6 +14977,66 @@
       "source_file": "packages/athena-webapp/shared/commandResult.ts",
       "source_location": "L44",
       "target": "commandresult_usererror",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "_tgt": "registersessionstatus_includesregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33",
+      "target": "registersessionstatus_includesregistersessionstatus",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "_tgt": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57",
+      "target": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "_tgt": "registersessionstatus_isposusableregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43",
+      "target": "registersessionstatus_isposusableregistersessionstatus",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "_tgt": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50",
+      "target": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "_tgt": "registersessionstatus_isregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24",
+      "target": "registersessionstatus_isregistersessionstatus",
       "weight": 1
     },
     {
@@ -23831,7 +23891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L84",
+      "source_location": "L85",
       "target": "useregisterviewmodel_createpaymentid",
       "weight": 1
     },
@@ -23843,7 +23903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L58",
+      "source_location": "L59",
       "target": "useregisterviewmodel_hascustomerdetails",
       "weight": 1
     },
@@ -23855,7 +23915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L71",
+      "source_location": "L72",
       "target": "useregisterviewmodel_mapsessioncustomer",
       "weight": 1
     },
@@ -23867,7 +23927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L91",
+      "source_location": "L92",
       "target": "useregisterviewmodel_trimoptional",
       "weight": 1
     },
@@ -23879,7 +23939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L96",
+      "source_location": "L97",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -31283,20 +31343,8 @@
       "relation": "calls",
       "source": "paymentallocationattribution_normalizeinstorepayments",
       "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L67",
+      "source_location": "L65",
       "target": "paymentallocationattribution_buildinstorepaymentallocations",
-      "weight": 1
-    },
-    {
-      "_src": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "_tgt": "paymentallocationattribution_isactiveregistersessionstatus",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "paymentallocationattribution_isactiveregistersessionstatus",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L136",
-      "target": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "weight": 1
     },
     {
@@ -31307,7 +31355,7 @@
       "relation": "calls",
       "source": "paymentallocationattribution_selectregistersessionforattribution",
       "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L157",
+      "source_location": "L155",
       "target": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "weight": 1
     },
@@ -31403,7 +31451,7 @@
       "relation": "calls",
       "source": "possessions_persistsessionworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L288",
+      "source_location": "L289",
       "target": "possessions_recordsessionlifecycletracebesteffort",
       "weight": 1
     },
@@ -31415,7 +31463,7 @@
       "relation": "calls",
       "source": "possessions_normalizeregisternumber",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L111",
+      "source_location": "L112",
       "target": "possessions_registersessionmatchesidentity",
       "weight": 1
     },
@@ -31427,7 +31475,7 @@
       "relation": "calls",
       "source": "possessions_hascustomersnapshotvalue",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L352",
+      "source_location": "L353",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -31439,7 +31487,7 @@
       "relation": "calls",
       "source": "possessions_normalizecustomersnapshot",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L339",
+      "source_location": "L340",
       "target": "possessions_resolvecustomertracestage",
       "weight": 1
     },
@@ -31451,7 +31499,7 @@
       "relation": "calls",
       "source": "possessions_isusableregistersession",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L159",
+      "source_location": "L160",
       "target": "possessions_validatesessiondrawerbinding",
       "weight": 1
     },
@@ -31463,7 +31511,7 @@
       "relation": "calls",
       "source": "possessions_registersessionmatchesidentity",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L160",
+      "source_location": "L161",
       "target": "possessions_validatesessiondrawerbinding",
       "weight": 1
     },
@@ -32123,7 +32171,7 @@
       "relation": "calls",
       "source": "registersessions_normalizeregistersessionidentity",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L55",
+      "source_location": "L62",
       "target": "registersessions_assertregistersessionidentity",
       "weight": 1
     },
@@ -32135,7 +32183,7 @@
       "relation": "calls",
       "source": "registersessions_normalizeregistersessionidentity",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L68",
+      "source_location": "L75",
       "target": "registersessions_assertregistersessionmatchestransaction",
       "weight": 1
     },
@@ -32147,7 +32195,7 @@
       "relation": "calls",
       "source": "registersessions_assertvalidregistersessiontransition",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L263",
+      "source_location": "L270",
       "target": "registersessions_buildclosedregistersessionpatch",
       "weight": 1
     },
@@ -32159,7 +32207,7 @@
       "relation": "calls",
       "source": "registersessions_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L270",
+      "source_location": "L277",
       "target": "registersessions_buildclosedregistersessionpatch",
       "weight": 1
     },
@@ -32171,7 +32219,7 @@
       "relation": "calls",
       "source": "registersessions_normalizeregistersessionidentity",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L111",
+      "source_location": "L118",
       "target": "registersessions_buildregistersession",
       "weight": 1
     },
@@ -32183,7 +32231,7 @@
       "relation": "calls",
       "source": "registersessions_assertvalidregistersessiontransition",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L208",
+      "source_location": "L215",
       "target": "registersessions_buildregistersessioncloseoutpatch",
       "weight": 1
     },
@@ -32195,7 +32243,7 @@
       "relation": "calls",
       "source": "registersessions_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L212",
+      "source_location": "L219",
       "target": "registersessions_buildregistersessioncloseoutpatch",
       "weight": 1
     },
@@ -32207,7 +32255,7 @@
       "relation": "calls",
       "source": "registersessions_calculateregistersessioncashdelta",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L166",
+      "source_location": "L173",
       "target": "registersessions_buildregistersessiontransactionpatch",
       "weight": 1
     },
@@ -32219,7 +32267,7 @@
       "relation": "calls",
       "source": "registersessions_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L50",
+      "source_location": "L57",
       "target": "registersessions_normalizeregistersessionidentity",
       "weight": 1
     },
@@ -32231,8 +32279,44 @@
       "relation": "calls",
       "source": "registersessions_buildregistersessiondepositpatch",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L510",
+      "source_location": "L525",
       "target": "registersessions_recordregistersessiondepositwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "_tgt": "registersessionstatus_includesregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessionstatus_includesregistersessionstatus",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L58",
+      "target": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "weight": 1
+    },
+    {
+      "_src": "registersessionstatus_isposusableregistersessionstatus",
+      "_tgt": "registersessionstatus_includesregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessionstatus_includesregistersessionstatus",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L44",
+      "target": "registersessionstatus_isposusableregistersessionstatus",
+      "weight": 1
+    },
+    {
+      "_src": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "_tgt": "registersessionstatus_includesregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessionstatus_includesregistersessionstatus",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L51",
+      "target": "registersessionstatus_isregistersessionconflictblockingstatus",
       "weight": 1
     },
     {
@@ -37487,7 +37571,7 @@
       "relation": "calls",
       "source": "sessioncommands_createpossessioncommandservice",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L653",
+      "source_location": "L654",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -37499,7 +37583,7 @@
       "relation": "calls",
       "source": "sessioncommands_normalizeregisternumber",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L721",
+      "source_location": "L722",
       "target": "sessioncommands_registersessionmatchesidentity",
       "weight": 1
     },
@@ -37511,7 +37595,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L771",
+      "source_location": "L772",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -37523,7 +37607,7 @@
       "relation": "calls",
       "source": "sessioncommands_isactiveregistersession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L768",
+      "source_location": "L769",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -37535,7 +37619,7 @@
       "relation": "calls",
       "source": "sessioncommands_registersessionmatchesidentity",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L769",
+      "source_location": "L770",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -37547,7 +37631,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L774",
+      "source_location": "L775",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -37559,7 +37643,7 @@
       "relation": "calls",
       "source": "sessioncommands_runbindsessiontoregistersessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L633",
+      "source_location": "L634",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -37571,7 +37655,7 @@
       "relation": "calls",
       "source": "sessioncommands_runholdsessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L619",
+      "source_location": "L620",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -37583,7 +37667,7 @@
       "relation": "calls",
       "source": "sessioncommands_runremovesessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L647",
+      "source_location": "L648",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -37595,7 +37679,7 @@
       "relation": "calls",
       "source": "sessioncommands_runresumesessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L626",
+      "source_location": "L627",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -37607,7 +37691,7 @@
       "relation": "calls",
       "source": "sessioncommands_runstartsessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L615",
+      "source_location": "L616",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -37619,7 +37703,7 @@
       "relation": "calls",
       "source": "sessioncommands_runupsertsessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L640",
+      "source_location": "L641",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -37631,7 +37715,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L807",
+      "source_location": "L808",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -37643,7 +37727,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L820",
+      "source_location": "L821",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -37655,7 +37739,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L842",
+      "source_location": "L843",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -37667,7 +37751,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesessionregisterbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L785",
+      "source_location": "L786",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -37679,7 +37763,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L788",
+      "source_location": "L789",
       "target": "sessioncommands_validateactivesessionregisterbinding",
       "weight": 1
     },
@@ -37691,7 +37775,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L851",
+      "source_location": "L852",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -37703,7 +37787,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L861",
+      "source_location": "L862",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -37715,7 +37799,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L875",
+      "source_location": "L876",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -40043,7 +40127,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L193",
+      "source_location": "L199",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -41289,6 +41373,24 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
       "norm_label": "bulkoperationspage.tsx",
@@ -41296,7 +41398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -41305,7 +41407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -41314,7 +41416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -41323,7 +41425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -41332,7 +41434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -41341,7 +41443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -41350,7 +41452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -41359,169 +41461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "label": "MetricCard.tsx",
-      "norm_label": "metriccard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "label": "paymentAllocationAttribution.ts",
-      "norm_label": "paymentallocationattribution.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "paymentallocationattribution_buildinstorepaymentallocations",
-      "label": "buildInStorePaymentAllocations()",
-      "norm_label": "buildinstorepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "paymentallocationattribution_isactiveregistersessionstatus",
-      "label": "isActiveRegisterSessionStatus()",
-      "norm_label": "isactiveregistersessionstatus()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "paymentallocationattribution_normalizeinstorepayments",
-      "label": "normalizeInStorePayments()",
-      "norm_label": "normalizeinstorepayments()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
-      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "paymentallocationattribution_selectregistersessionforattribution",
-      "label": "selectRegisterSessionForAttribution()",
-      "norm_label": "selectregistersessionforattribution()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 1010,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
-      "label": "index.test.tsx",
-      "norm_label": "index.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1011,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
-      "label": "OperationsQueueView.auth.test.tsx",
-      "norm_label": "operationsqueueview.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1012,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
-      "label": "OperationsQueueView.test.tsx",
-      "norm_label": "operationsqueueview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1013,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
-      "label": "StockAdjustmentWorkspace.test.tsx",
-      "norm_label": "stockadjustmentworkspace.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1014,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
-      "label": "OrderStatus.test.tsx",
-      "norm_label": "orderstatus.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1015,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
-      "label": "OrderStatus.tsx",
-      "norm_label": "orderstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1016,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1017,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
-      "label": "ReturnExchangeView.test.tsx",
-      "norm_label": "returnexchangeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 102,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
       "label": "security.ts",
@@ -41530,7 +41470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 102,
+      "community": 101,
       "file_type": "code",
       "id": "security_buildcanonicalcheckoutproducts",
       "label": "buildCanonicalCheckoutProducts()",
@@ -41539,7 +41479,7 @@
       "source_location": "L42"
     },
     {
-      "community": 102,
+      "community": 101,
       "file_type": "code",
       "id": "security_hasvalidpositivequantity",
       "label": "hasValidPositiveQuantity()",
@@ -41548,7 +41488,7 @@
       "source_location": "L27"
     },
     {
-      "community": 102,
+      "community": 101,
       "file_type": "code",
       "id": "security_isamounttampered",
       "label": "isAmountTampered()",
@@ -41557,7 +41497,7 @@
       "source_location": "L65"
     },
     {
-      "community": 102,
+      "community": 101,
       "file_type": "code",
       "id": "security_isauthorizedresourceowner",
       "label": "isAuthorizedResourceOwner()",
@@ -41566,7 +41506,7 @@
       "source_location": "L31"
     },
     {
-      "community": 102,
+      "community": 101,
       "file_type": "code",
       "id": "security_isduplicatechargesuccess",
       "label": "isDuplicateChargeSuccess()",
@@ -41575,97 +41515,97 @@
       "source_location": "L76"
     },
     {
-      "community": 1020,
+      "community": 1010,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1021,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1022,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1011,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
+      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
+      "label": "MetricCard.tsx",
+      "norm_label": "metriccard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1012,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.test.ts",
+      "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
+      "label": "index.test.tsx",
+      "norm_label": "index.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1013,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
+      "label": "OperationsQueueView.auth.test.tsx",
+      "norm_label": "operationsqueueview.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1014,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
+      "label": "OperationsQueueView.test.tsx",
+      "norm_label": "operationsqueueview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1015,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
+      "label": "StockAdjustmentWorkspace.test.tsx",
+      "norm_label": "stockadjustmentworkspace.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1016,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
+      "label": "OrderStatus.test.tsx",
+      "norm_label": "orderstatus.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1029,
+      "community": 1017,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
+      "label": "OrderStatus.tsx",
+      "norm_label": "orderstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1"
     },
     {
-      "community": 103,
+      "community": 1018,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1019,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 102,
       "file_type": "code",
       "id": "expensesessions_buildnextexpensesessionnumber",
       "label": "buildNextExpenseSessionNumber()",
@@ -41674,7 +41614,7 @@
       "source_location": "L72"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "expensesessions_expensesessionerror",
       "label": "expenseSessionError()",
@@ -41683,7 +41623,7 @@
       "source_location": "L42"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
       "label": "listExpenseSessionsByStatusBefore()",
@@ -41692,7 +41632,7 @@
       "source_location": "L105"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -41701,7 +41641,7 @@
       "source_location": "L80"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "expensesessions_mapexpensesessionvalidationerror",
       "label": "mapExpenseSessionValidationError()",
@@ -41710,7 +41650,7 @@
       "source_location": "L56"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -41719,97 +41659,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1030,
+      "community": 1020,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
+      "label": "ReturnExchangeView.test.tsx",
+      "norm_label": "returnexchangeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1021,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "label": "inviteColumns.tsx",
-      "norm_label": "invitecolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1032,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1022,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1023,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1024,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1036,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1025,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1026,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "label": "membersColumns.tsx",
-      "norm_label": "memberscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
+      "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 1027,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
-      "label": "organization-switcher.test.tsx",
-      "norm_label": "organization-switcher.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 104,
+      "community": 1028,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1029,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 103,
       "file_type": "code",
       "id": "assigncustomer_createcustomer",
       "label": "createCustomer()",
@@ -41818,7 +41758,7 @@
       "source_location": "L18"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "assigncustomer_linktoguest",
       "label": "linkToGuest()",
@@ -41827,7 +41767,7 @@
       "source_location": "L176"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "assigncustomer_linktostorefrontuser",
       "label": "linkToStoreFrontUser()",
@@ -41836,7 +41776,7 @@
       "source_location": "L133"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "assigncustomer_updatecustomer",
       "label": "updateCustomer()",
@@ -41845,7 +41785,7 @@
       "source_location": "L86"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "assigncustomer_updatecustomerstats",
       "label": "updateCustomerStats()",
@@ -41854,7 +41794,7 @@
       "source_location": "L117"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
       "label": "assignCustomer.ts",
@@ -41863,97 +41803,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1040,
+      "community": 1030,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "label": "CartItems.tsx",
-      "norm_label": "cartitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1031,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
-      "label": "CashierAuthDialog.test.tsx",
-      "norm_label": "cashierauthdialog.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1032,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "label": "CashierAuthDialog.tsx",
-      "norm_label": "cashierauthdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1033,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
+      "label": "inviteColumns.tsx",
+      "norm_label": "invitecolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1034,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
-      "label": "ProductLookup.tsx",
-      "norm_label": "productlookup.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1035,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
-      "label": "RegisterActions.tsx",
-      "norm_label": "registeractions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1036,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "label": "SearchResultsSection.tsx",
-      "norm_label": "searchresultssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1037,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
-      "label": "SessionManager.test.tsx",
-      "norm_label": "sessionmanager.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1038,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
-      "label": "SessionManager.tsx",
-      "norm_label": "sessionmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 1039,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
-      "label": "TotalsDisplay.test.tsx",
-      "norm_label": "totalsdisplay.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
       "label": "searchCustomers.ts",
@@ -41962,7 +41902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "searchcustomers_findbystorefrontuser",
       "label": "findByStoreFrontUser()",
@@ -41971,7 +41911,7 @@
       "source_location": "L77"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "searchcustomers_findpotentialmatches",
       "label": "findPotentialMatches()",
@@ -41980,7 +41920,7 @@
       "source_location": "L104"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "searchcustomers_getcustomerbyid",
       "label": "getCustomerById()",
@@ -41989,7 +41929,7 @@
       "source_location": "L48"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "searchcustomers_getcustomertransactions",
       "label": "getCustomerTransactions()",
@@ -41998,7 +41938,7 @@
       "source_location": "L57"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "searchcustomers_searchcustomers",
       "label": "searchCustomers()",
@@ -42007,97 +41947,97 @@
       "source_location": "L15"
     },
     {
-      "community": 1050,
+      "community": 1040,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "label": "ExpenseReportView.tsx",
-      "norm_label": "expensereportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
+      "label": "membersColumns.tsx",
+      "norm_label": "memberscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1041,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "label": "expenseReportColumns.tsx",
-      "norm_label": "expensereportcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
+      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
+      "label": "organization-switcher.test.tsx",
+      "norm_label": "organization-switcher.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1042,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
-      "label": "POSRegisterView.test.tsx",
-      "norm_label": "posregisterview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
+      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
+      "label": "CartItems.tsx",
+      "norm_label": "cartitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1043,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "label": "CashierAuthDialog.test.tsx",
+      "norm_label": "cashierauthdialog.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1044,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
+      "label": "CashierAuthDialog.tsx",
+      "norm_label": "cashierauthdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1045,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
       "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1046,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
-      "label": "RegisterActionBar.tsx",
-      "norm_label": "registeractionbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
+      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
+      "label": "ProductLookup.tsx",
+      "norm_label": "productlookup.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1047,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
-      "label": "RegisterCheckoutPanel.tsx",
-      "norm_label": "registercheckoutpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
+      "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
+      "label": "RegisterActions.tsx",
+      "norm_label": "registeractions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1048,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
-      "label": "HeldSessionsList.test.tsx",
-      "norm_label": "heldsessionslist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
+      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
+      "label": "SearchResultsSection.tsx",
+      "norm_label": "searchresultssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1049,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
-      "label": "TransactionView.test.tsx",
-      "norm_label": "transactionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
+      "label": "SessionManager.test.tsx",
+      "norm_label": "sessionmanager.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
-      "label": "TransactionsView.test.tsx",
-      "norm_label": "transactionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "orderemailservice_buildorderstatusmessage",
       "label": "buildOrderStatusMessage()",
@@ -42106,7 +42046,7 @@
       "source_location": "L49"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "orderemailservice_buildpickupdetails",
       "label": "buildPickupDetails()",
@@ -42115,7 +42055,7 @@
       "source_location": "L77"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "orderemailservice_sendpaymentverificationemails",
       "label": "sendPaymentVerificationEmails()",
@@ -42124,7 +42064,7 @@
       "source_location": "L217"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "orderemailservice_sendpodorderemails",
       "label": "sendPODOrderEmails()",
@@ -42133,7 +42073,7 @@
       "source_location": "L96"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "orderemailservice_shouldsendtoadmins",
       "label": "shouldSendToAdmins()",
@@ -42142,7 +42082,7 @@
       "source_location": "L42"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
       "label": "orderEmailService.ts",
@@ -42151,97 +42091,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1060,
+      "community": 1050,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_test_tsx",
-      "label": "WorkflowTraceLink.test.tsx",
-      "norm_label": "workflowtracelink.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/WorkflowTraceLink.test.tsx",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
+      "label": "SessionManager.tsx",
+      "norm_label": "sessionmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1051,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
+      "label": "TotalsDisplay.test.tsx",
+      "norm_label": "totalsdisplay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1052,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
-      "label": "ProcurementView.test.tsx",
-      "norm_label": "procurementview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
+      "label": "ExpenseReportView.tsx",
+      "norm_label": "expensereportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1053,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
-      "label": "ReceivingView.test.tsx",
-      "norm_label": "receivingview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
+      "label": "expenseReportColumns.tsx",
+      "norm_label": "expensereportcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1054,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "label": "AnalyticsInsights.tsx",
-      "norm_label": "analyticsinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
+      "label": "POSRegisterView.test.tsx",
+      "norm_label": "posregisterview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1055,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
-      "label": "AttributesView.tsx",
-      "norm_label": "attributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1056,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
-      "label": "DetailsView.tsx",
-      "norm_label": "detailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
+      "label": "RegisterActionBar.tsx",
+      "norm_label": "registeractionbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1057,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
+      "label": "RegisterCheckoutPanel.tsx",
+      "norm_label": "registercheckoutpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1058,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "label": "ProductStatus.tsx",
-      "norm_label": "productstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
+      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
+      "label": "HeldSessionsList.test.tsx",
+      "norm_label": "heldsessionslist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1059,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "label": "CategoryListView.tsx",
-      "norm_label": "categorylistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
+      "label": "TransactionView.test.tsx",
+      "norm_label": "transactionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
       "label": "purchaseOrders.ts",
@@ -42250,7 +42190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
       "label": "assertValidPurchaseOrderStatusTransition()",
@@ -42259,7 +42199,7 @@
       "source_location": "L57"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "purchaseorders_buildpurchaseordernumber",
       "label": "buildPurchaseOrderNumber()",
@@ -42268,7 +42208,7 @@
       "source_location": "L72"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "purchaseorders_calculatepurchaseordertotals",
       "label": "calculatePurchaseOrderTotals()",
@@ -42277,7 +42217,7 @@
       "source_location": "L26"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "purchaseorders_getoperationalworkitemstatus",
       "label": "getOperationalWorkItemStatus()",
@@ -42286,7 +42226,7 @@
       "source_location": "L76"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "purchaseorders_trimoptional",
       "label": "trimOptional()",
@@ -42295,97 +42235,97 @@
       "source_location": "L21"
     },
     {
-      "community": 1070,
+      "community": 1060,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
-      "label": "ProductSubcategoryToggleGroup.tsx",
-      "norm_label": "productsubcategorytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1061,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
+      "label": "TransactionsView.test.tsx",
+      "norm_label": "transactionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1062,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
-      "label": "StoreProducts.tsx",
-      "norm_label": "storeproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
+      "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_test_tsx",
+      "label": "WorkflowTraceLink.test.tsx",
+      "norm_label": "workflowtracelink.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/WorkflowTraceLink.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1063,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "label": "UnresolvedProducts.tsx",
-      "norm_label": "unresolvedproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
+      "id": "packages_athena_webapp_src_components_pos_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1064,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
-      "label": "ComplimentaryProducts.tsx",
-      "norm_label": "complimentaryproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
+      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
+      "label": "ProcurementView.test.tsx",
+      "norm_label": "procurementview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1065,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
-      "label": "complimentaryProductsColumn.tsx",
-      "norm_label": "complimentaryproductscolumn.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
+      "label": "ReceivingView.test.tsx",
+      "norm_label": "receivingview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1066,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
+      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
+      "label": "AnalyticsInsights.tsx",
+      "norm_label": "analyticsinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1067,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
+      "label": "AttributesView.tsx",
+      "norm_label": "attributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1068,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
+      "label": "DetailsView.tsx",
+      "norm_label": "detailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 1069,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "analytics_extractpromocodeid",
       "label": "extractPromoCodeId()",
@@ -42394,7 +42334,7 @@
       "source_location": "L19"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "analytics_getanalyticsbystoreandactionquery",
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -42403,7 +42343,7 @@
       "source_location": "L124"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "analytics_getanalyticsbystorequery",
       "label": "getAnalyticsByStoreQuery()",
@@ -42412,7 +42352,7 @@
       "source_location": "L29"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "analytics_getcompletedordersquery",
       "label": "getCompletedOrdersQuery()",
@@ -42421,7 +42361,7 @@
       "source_location": "L77"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "analytics_getskumapforproducts",
       "label": "getSkuMapForProducts()",
@@ -42430,7 +42370,7 @@
       "source_location": "L182"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -42439,7 +42379,169 @@
       "source_location": "L1"
     },
     {
+      "community": 1070,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
+      "label": "ProductStatus.tsx",
+      "norm_label": "productstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
+      "label": "CategoryListView.tsx",
+      "norm_label": "categorylistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
+      "label": "ProductSubcategoryToggleGroup.tsx",
+      "norm_label": "productsubcategorytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1073,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1074,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
+      "label": "StoreProducts.tsx",
+      "norm_label": "storeproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1075,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
+      "label": "UnresolvedProducts.tsx",
+      "norm_label": "unresolvedproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1076,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
+      "label": "ComplimentaryProducts.tsx",
+      "norm_label": "complimentaryproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1077,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
+      "label": "complimentaryProductsColumn.tsx",
+      "norm_label": "complimentaryproductscolumn.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1078,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1079,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
+    },
+    {
       "community": 1080,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42448,7 +42550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -42457,7 +42559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -42466,7 +42568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -42475,7 +42577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -42484,7 +42586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -42493,7 +42595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -42502,30 +42604,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
       "norm_label": "promocodemoney.test.ts",
       "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -42585,6 +42669,24 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -42592,7 +42694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42601,7 +42703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42610,7 +42712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42619,7 +42721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -42628,7 +42730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -42637,7 +42739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42646,30 +42748,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
       "source_location": "L1"
     },
     {
@@ -42909,6 +42993,24 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -42916,7 +43018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -42925,7 +43027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -42934,7 +43036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -42943,7 +43045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -42952,7 +43054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -42961,7 +43063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -42970,30 +43072,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
       "norm_label": "maintenanceview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
-      "label": "MtnMomoView.test.tsx",
-      "norm_label": "mtnmomoview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
-      "label": "useStoreConfigUpdate.test.tsx",
-      "norm_label": "usestoreconfigupdate.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43053,6 +43137,24 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
+      "label": "MtnMomoView.test.tsx",
+      "norm_label": "mtnmomoview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
+      "label": "useStoreConfigUpdate.test.tsx",
+      "norm_label": "usestoreconfigupdate.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -43060,7 +43162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -43069,7 +43171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -43078,7 +43180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -43087,7 +43189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -43096,7 +43198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -43105,7 +43207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -43114,30 +43216,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
-      "label": "collapsible.tsx",
-      "norm_label": "collapsible.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
       "source_location": "L1"
     },
     {
@@ -43197,6 +43281,24 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
+      "label": "collapsible.tsx",
+      "norm_label": "collapsible.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
@@ -43204,7 +43306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -43213,7 +43315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -43222,7 +43324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -43231,7 +43333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -43240,7 +43342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -43249,7 +43351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -43258,30 +43360,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
-      "label": "primitives.test.tsx",
-      "norm_label": "primitives.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43341,6 +43425,24 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
+      "label": "primitives.test.tsx",
+      "norm_label": "primitives.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
@@ -43348,7 +43450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -43357,7 +43459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -43366,7 +43468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -43375,7 +43477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -43384,7 +43486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -43393,7 +43495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -43402,7 +43504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -43411,7 +43513,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 114,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1140,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -43420,7 +43576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1139,
+      "community": 1141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -43429,61 +43585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 1140,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -43492,7 +43594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -43501,7 +43603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -43510,7 +43612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -43519,7 +43621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -43528,7 +43630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -43537,7 +43639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43546,7 +43648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43555,7 +43657,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 1150,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43564,7 +43720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1149,
+      "community": 1151,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -43573,61 +43729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 1150,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -43636,7 +43738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -43645,7 +43747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -43654,7 +43756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -43663,7 +43765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43672,7 +43774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43681,7 +43783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -43690,7 +43792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43699,7 +43801,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 116,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 1160,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -43708,7 +43864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 1161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -43717,61 +43873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 1160,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -43780,7 +43882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -43789,7 +43891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -43798,7 +43900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -43807,7 +43909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -43816,7 +43918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -43825,7 +43927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -43834,7 +43936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -43843,7 +43945,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 117,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 1170,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -43852,7 +44008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -43861,61 +44017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1170,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -43924,7 +44026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -43933,7 +44035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -43942,7 +44044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -43951,7 +44053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -43960,7 +44062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -43969,7 +44071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -43978,7 +44080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -43987,7 +44089,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 118,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1180,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -43996,7 +44152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -44005,61 +44161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 1180,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -44068,7 +44170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -44077,7 +44179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -44086,7 +44188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -44095,7 +44197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -44104,7 +44206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -44113,7 +44215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -44122,7 +44224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -44131,7 +44233,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 1190,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -44140,7 +44296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -44149,61 +44305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 1190,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -44212,7 +44314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -44221,7 +44323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -44230,7 +44332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -44239,7 +44341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -44248,7 +44350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -44257,7 +44359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -44266,30 +44368,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
       "source_location": "L1"
     },
     {
@@ -44475,59 +44559,77 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L27"
     },
     {
-      "community": 120,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L48"
-    },
-    {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -44536,7 +44638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -44545,7 +44647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -44554,7 +44656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -44563,7 +44665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -44572,7 +44674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -44581,7 +44683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -44590,7 +44692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -44599,7 +44701,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 1210,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -44608,7 +44764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -44617,61 +44773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
-      "label": "useRegisterViewModel.ts",
-      "norm_label": "useregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useregisterviewmodel_createpaymentid",
-      "label": "createPaymentId()",
-      "norm_label": "createpaymentid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useregisterviewmodel_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useregisterviewmodel_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useregisterviewmodel_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useregisterviewmodel_useregisterviewmodel",
-      "label": "useRegisterViewModel()",
-      "norm_label": "useregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 1210,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -44680,7 +44782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -44689,7 +44791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -44698,7 +44800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -44707,7 +44809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -44716,7 +44818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -44725,7 +44827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -44734,7 +44836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -44743,7 +44845,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "label": "useRegisterViewModel.ts",
+      "norm_label": "useregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useregisterviewmodel_createpaymentid",
+      "label": "createPaymentId()",
+      "norm_label": "createpaymentid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useregisterviewmodel_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useregisterviewmodel_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useregisterviewmodel_useregisterviewmodel",
+      "label": "useRegisterViewModel()",
+      "norm_label": "useregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 1220,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -44752,7 +44908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -44761,61 +44917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 1220,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -44824,7 +44926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -44833,7 +44935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -44842,7 +44944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -44851,7 +44953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -44860,7 +44962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -44869,7 +44971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -44878,7 +44980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -44887,7 +44989,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 1230,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -44896,7 +45052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1229,
+      "community": 1231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -44905,61 +45061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 1230,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -44968,7 +45070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -44977,7 +45079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -44986,7 +45088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -44995,7 +45097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -45004,7 +45106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -45013,7 +45115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -45022,7 +45124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -45031,7 +45133,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 1240,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -45040,7 +45196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1239,
+      "community": 1241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -45049,61 +45205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
-      "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1240,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -45112,7 +45214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -45121,7 +45223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -45130,7 +45232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -45139,7 +45241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -45148,7 +45250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -45157,7 +45259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -45166,7 +45268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -45175,7 +45277,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 125,
+      "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1250,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -45184,7 +45340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1249,
+      "community": 1251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -45193,61 +45349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 1250,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -45256,7 +45358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -45265,7 +45367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -45274,7 +45376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -45283,7 +45385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -45292,7 +45394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -45301,7 +45403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -45310,7 +45412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -45319,7 +45421,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 1260,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -45328,7 +45484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -45337,61 +45493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 1260,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -45400,7 +45502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -45409,7 +45511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -45418,7 +45520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -45427,7 +45529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -45436,7 +45538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -45445,7 +45547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -45454,7 +45556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -45463,7 +45565,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 1270,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -45472,7 +45628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 1271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -45481,61 +45637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 1270,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -45544,7 +45646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -45553,7 +45655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -45562,7 +45664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -45571,7 +45673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -45580,7 +45682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -45589,7 +45691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -45598,7 +45700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -45607,7 +45709,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1280,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -45616,7 +45772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1279,
+      "community": 1281,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -45625,61 +45781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 128,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1280,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -45688,7 +45790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -45697,7 +45799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -45706,7 +45808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -45715,7 +45817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -45724,7 +45826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -45733,7 +45835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -45742,7 +45844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -45751,7 +45853,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 129,
+      "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1290,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -45760,7 +45916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1289,
+      "community": 1291,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -45769,61 +45925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 129,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1290,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -45832,7 +45934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -45841,7 +45943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -45850,7 +45952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -45859,7 +45961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -45868,7 +45970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -45877,7 +45979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -45886,30 +45988,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
       "norm_label": "deliveryfees.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "label": "deriveCheckoutState.test.ts",
-      "norm_label": "derivecheckoutstate.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1"
     },
     {
@@ -45919,7 +46003,7 @@
       "label": "buildCompleteTransactionResult()",
       "norm_label": "buildcompletetransactionresult()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L51"
+      "source_location": "L52"
     },
     {
       "community": 13,
@@ -45928,7 +46012,7 @@
       "label": "buildPosSaleTraceEvent()",
       "norm_label": "buildpossaletraceevent()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L151"
+      "source_location": "L152"
     },
     {
       "community": 13,
@@ -45937,7 +46021,7 @@
       "label": "buildPosSaleTraceRecord()",
       "norm_label": "buildpossaletracerecord()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L130"
+      "source_location": "L131"
     },
     {
       "community": 13,
@@ -45946,7 +46030,7 @@
       "label": "calculateTotalPaid()",
       "norm_label": "calculatetotalpaid()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L72"
+      "source_location": "L73"
     },
     {
       "community": 13,
@@ -45964,7 +46048,7 @@
       "label": "createTransactionFromSessionHandler()",
       "norm_label": "createtransactionfromsessionhandler()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L647"
+      "source_location": "L648"
     },
     {
       "community": 13,
@@ -45973,7 +46057,7 @@
       "label": "isUsableRegisterSession()",
       "norm_label": "isusableregistersession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L115"
+      "source_location": "L116"
     },
     {
       "community": 13,
@@ -45982,7 +46066,7 @@
       "label": "normalizeRegisterNumber()",
       "norm_label": "normalizeregisternumber()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L76"
+      "source_location": "L77"
     },
     {
       "community": 13,
@@ -45991,7 +46075,7 @@
       "label": "persistWorkflowTraceIdBestEffort()",
       "norm_label": "persistworkflowtraceidbesteffort()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L227"
+      "source_location": "L228"
     },
     {
       "community": 13,
@@ -46000,7 +46084,7 @@
       "label": "recordPosSaleTraceBestEffort()",
       "norm_label": "recordpossaletracebesteffort()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L191"
+      "source_location": "L192"
     },
     {
       "community": 13,
@@ -46009,7 +46093,7 @@
       "label": "recordRegisterSessionSale()",
       "norm_label": "recordregistersessionsale()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L294"
+      "source_location": "L295"
     },
     {
       "community": 13,
@@ -46018,7 +46102,7 @@
       "label": "recordRegisterSessionVoid()",
       "norm_label": "recordregistersessionvoid()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L319"
+      "source_location": "L320"
     },
     {
       "community": 13,
@@ -46027,7 +46111,7 @@
       "label": "registerSessionMatchesIdentity()",
       "norm_label": "registersessionmatchesidentity()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L81"
+      "source_location": "L82"
     },
     {
       "community": 13,
@@ -46036,7 +46120,7 @@
       "label": "resolveSessionRegisterSessionId()",
       "norm_label": "resolvesessionregistersessionid()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L246"
+      "source_location": "L247"
     },
     {
       "community": 13,
@@ -46045,7 +46129,7 @@
       "label": "safeTraceWrite()",
       "norm_label": "safetracewrite()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L119"
+      "source_location": "L120"
     },
     {
       "community": 13,
@@ -46054,7 +46138,7 @@
       "label": "updateInventory()",
       "norm_label": "updateinventory()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L344"
+      "source_location": "L345"
     },
     {
       "community": 13,
@@ -46063,7 +46147,7 @@
       "label": "voidTransaction()",
       "norm_label": "voidtransaction()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L578"
+      "source_location": "L579"
     },
     {
       "community": 13,
@@ -46086,59 +46170,77 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
       "community": 1300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
+      "label": "deriveCheckoutState.test.ts",
+      "norm_label": "derivecheckoutstate.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -46147,7 +46249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -46156,7 +46258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -46165,7 +46267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -46174,7 +46276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -46183,7 +46285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -46192,7 +46294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -46201,30 +46303,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
       "norm_label": "bestsellerssection.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1308,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "label": "HomeHero.tsx",
-      "norm_label": "homehero.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1"
     },
     {
@@ -46284,6 +46368,24 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
+      "label": "HomeHero.tsx",
+      "norm_label": "homehero.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1312,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
       "norm_label": "homepagecontent.test.ts",
@@ -46291,7 +46393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -46300,7 +46402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -46309,7 +46411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -46318,7 +46420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -46327,7 +46429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -46336,7 +46438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -46345,30 +46447,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
       "norm_label": "productinfo.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "label": "ProductReviews.tsx",
-      "norm_label": "productreviews.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1"
     },
     {
@@ -46428,6 +46512,24 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
+      "label": "ProductReviews.tsx",
+      "norm_label": "productreviews.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1322,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
       "norm_label": "errormessage.tsx",
@@ -46435,7 +46537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -46444,7 +46546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -46453,7 +46555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -46462,7 +46564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -46471,7 +46573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -46480,7 +46582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -46489,30 +46591,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
       "norm_label": "carticon.tsx",
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1328,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
@@ -46572,6 +46656,24 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1332,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
       "norm_label": "maintenance.tsx",
@@ -46579,7 +46681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -46588,7 +46690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -46597,7 +46699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -46606,7 +46708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -46615,7 +46717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -46624,7 +46726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -46633,30 +46735,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1338,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -46716,6 +46800,24 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1342,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
@@ -46723,7 +46825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -46732,7 +46834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -46741,7 +46843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -46750,7 +46852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -46759,7 +46861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -46768,7 +46870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -46777,7 +46879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -46786,7 +46888,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 1350,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -46795,7 +46942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1349,
+      "community": 1351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -46804,52 +46951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 1350,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -46858,7 +46960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -46867,7 +46969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -46876,7 +46978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -46885,7 +46987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -46894,7 +46996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -46903,7 +47005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -46912,7 +47014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -46921,7 +47023,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 136,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 1360,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -46930,7 +47077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1359,
+      "community": 1361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -46939,52 +47086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "label": "validateExpenseItemBelongsToSession()",
-      "norm_label": "validateexpenseitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionactive",
-      "label": "validateExpenseSessionActive()",
-      "norm_label": "validateexpensesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionexists",
-      "label": "validateExpenseSessionExists()",
-      "norm_label": "validateexpensesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "label": "validateExpenseSessionModifiable()",
-      "norm_label": "validateexpensesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "label": "expenseSessionValidation.ts",
-      "norm_label": "expensesessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1360,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -46993,7 +47095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -47002,7 +47104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -47011,7 +47113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -47020,7 +47122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -47029,7 +47131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -47038,7 +47140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -47047,7 +47149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -47056,7 +47158,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 137,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
+      "label": "validateExpenseItemBelongsToSession()",
+      "norm_label": "validateexpenseitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionactive",
+      "label": "validateExpenseSessionActive()",
+      "norm_label": "validateexpensesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionexists",
+      "label": "validateExpenseSessionExists()",
+      "norm_label": "validateexpensesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
+      "label": "validateExpenseSessionModifiable()",
+      "norm_label": "validateexpensesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
+      "label": "expenseSessionValidation.ts",
+      "norm_label": "expensesessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1370,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -47065,7 +47212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1369,
+      "community": 1371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -47074,52 +47221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 1370,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -47128,7 +47230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -47137,7 +47239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -47146,7 +47248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -47155,7 +47257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -47164,7 +47266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -47173,7 +47275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -47182,7 +47284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -47191,7 +47293,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 1380,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -47200,7 +47347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1379,
+      "community": 1381,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -47209,52 +47356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 138,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
-      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
-      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
-      "label": "decideApprovalRequestAsCommandWithCtx()",
-      "norm_label": "decideapprovalrequestascommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestwithctx",
-      "label": "decideApprovalRequestWithCtx()",
-      "norm_label": "decideapprovalrequestwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "approvalrequests_mapdecideapprovalrequesterror",
-      "label": "mapDecideApprovalRequestError()",
-      "norm_label": "mapdecideapprovalrequesterror()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
-      "label": "approvalRequests.ts",
-      "norm_label": "approvalrequests.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1380,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -47263,7 +47365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -47272,7 +47374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -47281,7 +47383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -47290,7 +47392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -47299,7 +47401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -47308,7 +47410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -47317,7 +47419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -47326,7 +47428,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 139,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
+      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
+      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
+      "label": "decideApprovalRequestAsCommandWithCtx()",
+      "norm_label": "decideapprovalrequestascommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestwithctx",
+      "label": "decideApprovalRequestWithCtx()",
+      "norm_label": "decideapprovalrequestwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "approvalrequests_mapdecideapprovalrequesterror",
+      "label": "mapDecideApprovalRequestError()",
+      "norm_label": "mapdecideapprovalrequesterror()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
+      "label": "approvalRequests.ts",
+      "norm_label": "approvalrequests.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1390,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -47335,7 +47482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1389,
+      "community": 1391,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -47344,52 +47491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 139,
-      "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1390,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -47398,7 +47500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -47407,7 +47509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -47416,7 +47518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -47425,7 +47527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -47434,7 +47536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -47443,7 +47545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -47452,30 +47554,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1398,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "label": "rewards.index.tsx",
-      "norm_label": "rewards.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "label": "shop.saved.index.tsx",
-      "norm_label": "shop.saved.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1"
     },
     {
@@ -47652,50 +47736,68 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
       "source_location": "L1"
     },
     {
       "community": 1400,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
+      "label": "rewards.index.tsx",
+      "norm_label": "rewards.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
+      "label": "shop.saved.index.tsx",
+      "norm_label": "shop.saved.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -47704,7 +47806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -47713,7 +47815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -47722,7 +47824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -47731,7 +47833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -47740,7 +47842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -47749,7 +47851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -47758,7 +47860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -47767,7 +47869,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 141,
+      "file_type": "code",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1410,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -47776,7 +47923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1409,
+      "community": 1411,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -47785,52 +47932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 1410,
+      "community": 1412,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -47839,7 +47941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1413,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -47848,7 +47950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1414,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -47859,6 +47961,51 @@
     {
       "community": 142,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
       "norm_label": "serviceintake.test.ts",
@@ -47866,7 +48013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -47875,7 +48022,7 @@
       "source_location": "L16"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -47884,7 +48031,7 @@
       "source_location": "L29"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -47893,7 +48040,7 @@
       "source_location": "L12"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -47902,7 +48049,7 @@
       "source_location": "L8"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -47911,7 +48058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -47920,7 +48067,7 @@
       "source_location": "L11"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -47929,7 +48076,7 @@
       "source_location": "L21"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -47938,7 +48085,7 @@
       "source_location": "L87"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -47947,7 +48094,7 @@
       "source_location": "L65"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -47956,7 +48103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -47965,7 +48112,7 @@
       "source_location": "L115"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -47974,7 +48121,7 @@
       "source_location": "L90"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -47983,7 +48130,7 @@
       "source_location": "L74"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -47992,7 +48139,7 @@
       "source_location": "L70"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -48001,7 +48148,7 @@
       "source_location": "L89"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -48010,7 +48157,7 @@
       "source_location": "L765"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -48019,7 +48166,7 @@
       "source_location": "L37"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -48028,7 +48175,7 @@
       "source_location": "L60"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -48037,7 +48184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -48046,7 +48193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -48055,7 +48202,7 @@
       "source_location": "L124"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -48064,7 +48211,7 @@
       "source_location": "L67"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -48073,7 +48220,7 @@
       "source_location": "L106"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -48082,7 +48229,7 @@
       "source_location": "L73"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -48091,7 +48238,7 @@
       "source_location": "L61"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -48100,7 +48247,7 @@
       "source_location": "L75"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -48109,7 +48256,7 @@
       "source_location": "L116"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -48118,7 +48265,7 @@
       "source_location": "L20"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -48127,7 +48274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -48136,7 +48283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -48145,7 +48292,7 @@
       "source_location": "L286"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -48154,7 +48301,7 @@
       "source_location": "L203"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -48163,58 +48310,13 @@
       "source_location": "L243"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
       "norm_label": "setinitialselectedoption()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 15,
@@ -48705,6 +48807,51 @@
     {
       "community": 157,
       "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
       "norm_label": "paymentview.tsx",
@@ -48712,7 +48859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -48721,7 +48868,7 @@
       "source_location": "L189"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -48730,7 +48877,7 @@
       "source_location": "L252"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -48739,7 +48886,7 @@
       "source_location": "L234"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "paymentview_handleclearall",
       "label": "handleClearAll()",
@@ -48748,7 +48895,7 @@
       "source_location": "L227"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "label": "PaymentsAddedList.tsx",
@@ -48757,7 +48904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
       "label": "getPaymentMethodLabel()",
@@ -48766,7 +48913,7 @@
       "source_location": "L27"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "paymentsaddedlist_handlecanceledit",
       "label": "handleCancelEdit()",
@@ -48775,7 +48922,7 @@
       "source_location": "L104"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "paymentsaddedlist_handlesaveedit",
       "label": "handleSaveEdit()",
@@ -48784,58 +48931,13 @@
       "source_location": "L72"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "paymentsaddedlist_handlestartedit",
       "label": "handleStartEdit()",
       "norm_label": "handlestartedit()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L67"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
-      "label": "ReceivingView.tsx",
-      "norm_label": "receivingview.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "receivingview_builddefaultreceivedquantities",
-      "label": "buildDefaultReceivedQuantities()",
-      "norm_label": "builddefaultreceivedquantities()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "receivingview_buildreceivedquantitiesaftersubmission",
-      "label": "buildReceivedQuantitiesAfterSubmission()",
-      "norm_label": "buildreceivedquantitiesaftersubmission()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "receivingview_buildsubmissionkey",
-      "label": "buildSubmissionKey()",
-      "norm_label": "buildsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "receivingview_receivingview",
-      "label": "ReceivingView()",
-      "norm_label": "receivingview()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L72"
     },
     {
       "community": 16,
@@ -49002,6 +49104,51 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
+      "label": "ReceivingView.tsx",
+      "norm_label": "receivingview.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "receivingview_builddefaultreceivedquantities",
+      "label": "buildDefaultReceivedQuantities()",
+      "norm_label": "builddefaultreceivedquantities()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "receivingview_buildreceivedquantitiesaftersubmission",
+      "label": "buildReceivedQuantitiesAfterSubmission()",
+      "norm_label": "buildreceivedquantitiesaftersubmission()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "receivingview_buildsubmissionkey",
+      "label": "buildSubmissionKey()",
+      "norm_label": "buildsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "receivingview_receivingview",
+      "label": "ReceivingView()",
+      "norm_label": "receivingview()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
       "norm_label": "promocodeview.tsx",
@@ -49009,7 +49156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -49018,7 +49165,7 @@
       "source_location": "L157"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -49027,7 +49174,7 @@
       "source_location": "L230"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -49036,7 +49183,7 @@
       "source_location": "L322"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -49045,7 +49192,7 @@
       "source_location": "L377"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -49054,7 +49201,7 @@
       "source_location": "L99"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -49063,7 +49210,7 @@
       "source_location": "L53"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -49072,7 +49219,7 @@
       "source_location": "L75"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -49081,7 +49228,7 @@
       "source_location": "L63"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -49090,7 +49237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -49099,7 +49246,7 @@
       "source_location": "L7"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -49108,7 +49255,7 @@
       "source_location": "L69"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -49117,7 +49264,7 @@
       "source_location": "L44"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -49126,7 +49273,7 @@
       "source_location": "L103"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -49135,7 +49282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -49144,7 +49291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -49153,7 +49300,7 @@
       "source_location": "L16"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -49162,7 +49309,7 @@
       "source_location": "L23"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -49171,7 +49318,7 @@
       "source_location": "L9"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -49180,7 +49327,7 @@
       "source_location": "L30"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -49189,7 +49336,7 @@
       "source_location": "L18"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -49198,7 +49345,7 @@
       "source_location": "L23"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -49207,7 +49354,7 @@
       "source_location": "L65"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -49216,7 +49363,7 @@
       "source_location": "L45"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -49225,7 +49372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -49234,7 +49381,7 @@
       "source_location": "L78"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -49243,7 +49390,7 @@
       "source_location": "L74"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -49252,7 +49399,7 @@
       "source_location": "L103"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -49261,7 +49408,7 @@
       "source_location": "L109"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -49270,7 +49417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -49279,7 +49426,7 @@
       "source_location": "L75"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -49288,7 +49435,7 @@
       "source_location": "L26"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -49297,7 +49444,7 @@
       "source_location": "L38"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -49306,7 +49453,7 @@
       "source_location": "L4"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -49315,7 +49462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -49324,7 +49471,7 @@
       "source_location": "L3"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -49333,7 +49480,7 @@
       "source_location": "L29"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -49342,7 +49489,7 @@
       "source_location": "L33"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -49351,7 +49498,7 @@
       "source_location": "L40"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -49360,7 +49507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "cataloggateway_mapproductbyidresult",
       "label": "mapProductByIdResult()",
@@ -49369,7 +49516,7 @@
       "source_location": "L38"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "cataloggateway_useconvexbarcodelookup",
       "label": "useConvexBarcodeLookup()",
@@ -49378,7 +49525,7 @@
       "source_location": "L85"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductidlookup",
       "label": "useConvexProductIdLookup()",
@@ -49387,7 +49534,7 @@
       "source_location": "L96"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductsearch",
       "label": "useConvexProductSearch()",
@@ -49396,58 +49543,13 @@
       "source_location": "L67"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
       "label": "catalogGateway.ts",
       "norm_label": "cataloggateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
-      "label": "registerGateway.ts",
-      "norm_label": "registergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "registergateway_mapregisterstatedto",
-      "label": "mapRegisterStateDto()",
-      "norm_label": "mapregisterstatedto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "registergateway_mapterminaldto",
-      "label": "mapTerminalDto()",
-      "norm_label": "mapterminaldto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "registergateway_useconvexregisterstate",
-      "label": "useConvexRegisterState()",
-      "norm_label": "useconvexregisterstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "registergateway_useconvexterminalbyfingerprint",
-      "label": "useConvexTerminalByFingerprint()",
-      "norm_label": "useconvexterminalbyfingerprint()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L55"
     },
     {
       "community": 17,
@@ -49614,6 +49716,51 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
+      "label": "registerGateway.ts",
+      "norm_label": "registergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "registergateway_mapregisterstatedto",
+      "label": "mapRegisterStateDto()",
+      "norm_label": "mapregisterstatedto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "registergateway_mapterminaldto",
+      "label": "mapTerminalDto()",
+      "norm_label": "mapterminaldto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "registergateway_useconvexregisterstate",
+      "label": "useConvexRegisterState()",
+      "norm_label": "useconvexregisterstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "registergateway_useconvexterminalbyfingerprint",
+      "label": "useConvexTerminalByFingerprint()",
+      "norm_label": "useconvexterminalbyfingerprint()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
       "norm_label": "transactionutils.ts",
@@ -49621,7 +49768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -49630,7 +49777,7 @@
       "source_location": "L42"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -49639,7 +49786,7 @@
       "source_location": "L29"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -49648,7 +49795,7 @@
       "source_location": "L49"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -49657,7 +49804,7 @@
       "source_location": "L14"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -49666,7 +49813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -49675,7 +49822,7 @@
       "source_location": "L184"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -49684,7 +49831,7 @@
       "source_location": "L200"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -49693,7 +49840,7 @@
       "source_location": "L244"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -49702,7 +49849,7 @@
       "source_location": "L206"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -49711,7 +49858,7 @@
       "source_location": "L93"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -49720,7 +49867,7 @@
       "source_location": "L75"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -49729,7 +49876,7 @@
       "source_location": "L4"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -49738,7 +49885,7 @@
       "source_location": "L47"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -49747,7 +49894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -49756,7 +49903,7 @@
       "source_location": "L11"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -49765,7 +49912,7 @@
       "source_location": "L25"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -49774,7 +49921,7 @@
       "source_location": "L9"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -49783,7 +49930,7 @@
       "source_location": "L39"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -49792,7 +49939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -49801,7 +49948,7 @@
       "source_location": "L4"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -49810,7 +49957,7 @@
       "source_location": "L24"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -49819,7 +49966,7 @@
       "source_location": "L6"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -49828,7 +49975,7 @@
       "source_location": "L42"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -49837,7 +49984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -49846,7 +49993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -49855,7 +50002,7 @@
       "source_location": "L28"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -49864,7 +50011,7 @@
       "source_location": "L5"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -49873,7 +50020,7 @@
       "source_location": "L7"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -49882,7 +50029,7 @@
       "source_location": "L46"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -49891,7 +50038,7 @@
       "source_location": "L147"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -49900,7 +50047,7 @@
       "source_location": "L185"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -49909,7 +50056,7 @@
       "source_location": "L115"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -49918,7 +50065,7 @@
       "source_location": "L31"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -49927,7 +50074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -49936,7 +50083,7 @@
       "source_location": "L14"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -49945,7 +50092,7 @@
       "source_location": "L22"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -49954,7 +50101,7 @@
       "source_location": "L30"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -49963,7 +50110,7 @@
       "source_location": "L3"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -49972,7 +50119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -49981,7 +50128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -49990,7 +50137,7 @@
       "source_location": "L136"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -49999,7 +50146,7 @@
       "source_location": "L154"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -50008,58 +50155,13 @@
       "source_location": "L25"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
       "norm_label": "normalizestorefronterror()",
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "harness_repo_validation_collectharnessrepovalidationselection",
-      "label": "collectHarnessRepoValidationSelection()",
-      "norm_label": "collectharnessrepovalidationselection()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
-      "label": "matchesHarnessRepoValidationPath()",
-      "norm_label": "matchesharnessrepovalidationpath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "harness_repo_validation_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "harness_repo_validation_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "scripts_harness_repo_validation_ts",
-      "label": "harness-repo-validation.ts",
-      "norm_label": "harness-repo-validation.ts",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L1"
     },
     {
       "community": 18,
@@ -50217,6 +50319,51 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "harness_repo_validation_collectharnessrepovalidationselection",
+      "label": "collectHarnessRepoValidationSelection()",
+      "norm_label": "collectharnessrepovalidationselection()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
+      "label": "matchesHarnessRepoValidationPath()",
+      "norm_label": "matchesharnessrepovalidationpath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "harness_repo_validation_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "harness_repo_validation_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "scripts_harness_repo_validation_ts",
+      "label": "harness-repo-validation.ts",
+      "norm_label": "harness-repo-validation.ts",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
       "norm_label": "registersessiontracelifecycle.test.ts",
@@ -50224,7 +50371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -50233,7 +50380,7 @@
       "source_location": "L63"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -50242,7 +50389,7 @@
       "source_location": "L79"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -50251,7 +50398,7 @@
       "source_location": "L206"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -50260,7 +50407,7 @@
       "source_location": "L109"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -50269,7 +50416,7 @@
       "source_location": "L84"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -50278,7 +50425,7 @@
       "source_location": "L95"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -50287,7 +50434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -50296,7 +50443,7 @@
       "source_location": "L70"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -50305,7 +50452,7 @@
       "source_location": "L29"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -50314,7 +50461,7 @@
       "source_location": "L80"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -50323,7 +50470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -50332,7 +50479,7 @@
       "source_location": "L21"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -50341,7 +50488,7 @@
       "source_location": "L35"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -50350,7 +50497,7 @@
       "source_location": "L45"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -50359,7 +50506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -50368,7 +50515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -50377,7 +50524,7 @@
       "source_location": "L21"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -50386,7 +50533,7 @@
       "source_location": "L35"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -50395,7 +50542,7 @@
       "source_location": "L45"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -50404,7 +50551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -50413,7 +50560,7 @@
       "source_location": "L210"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -50422,49 +50569,13 @@
       "source_location": "L89"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
       "source_location": "L227"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
     },
     {
       "community": 187,
@@ -50815,7 +50926,7 @@
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L26"
+      "source_location": "L30"
     },
     {
       "community": 192,
@@ -50824,7 +50935,7 @@
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L43"
+      "source_location": "L47"
     },
     {
       "community": 192,
@@ -50833,7 +50944,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L107"
+      "source_location": "L130"
     },
     {
       "community": 193,
@@ -53367,6 +53478,42 @@
     {
       "community": 238,
       "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
       "norm_label": "_shoplayout.tsx",
@@ -53374,7 +53521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -53383,7 +53530,7 @@
       "source_location": "L115"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -53392,7 +53539,7 @@
       "source_location": "L105"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -53401,1357 +53548,7 @@
       "source_location": "L110"
     },
     {
-      "community": 239,
-      "file_type": "code",
-      "id": "index_cancelorder",
-      "label": "cancelOrder()",
-      "norm_label": "cancelorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "index_geterrormessage",
-      "label": "getErrorMessage()",
-      "norm_label": "geterrormessage()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "index_placeorder",
-      "label": "placeOrder()",
-      "norm_label": "placeorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_assertvalidonlineorderstatustransition",
-      "label": "assertValidOnlineOrderStatusTransition()",
-      "norm_label": "assertvalidonlineorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentamount",
-      "label": "getOnlineOrderPaymentAmount()",
-      "norm_label": "getonlineorderpaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentmethodlabel",
-      "label": "getOnlineOrderPaymentMethodLabel()",
-      "norm_label": "getonlineorderpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderstatuseventtype",
-      "label": "getOnlineOrderStatusEventType()",
-      "norm_label": "getonlineorderstatuseventtype()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_ispaymentondeliveryorder",
-      "label": "isPaymentOnDeliveryOrder()",
-      "norm_label": "ispaymentondeliveryorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineordercreatedevent",
-      "label": "recordOnlineOrderCreatedEvent()",
-      "norm_label": "recordonlineordercreatedevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderfulfillmentmovement",
-      "label": "recordOnlineOrderFulfillmentMovement()",
-      "norm_label": "recordonlineorderfulfillmentmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L381"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentcollected",
-      "label": "recordOnlineOrderPaymentCollected()",
-      "norm_label": "recordonlineorderpaymentcollected()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentverified",
-      "label": "recordOnlineOrderPaymentVerified()",
-      "norm_label": "recordonlineorderpaymentverified()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrefundallocation",
-      "label": "recordOnlineOrderRefundAllocation()",
-      "norm_label": "recordonlineorderrefundallocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrestockmovement",
-      "label": "recordOnlineOrderRestockMovement()",
-      "norm_label": "recordonlineorderrestockmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderstatusevent",
-      "label": "recordOnlineOrderStatusEvent()",
-      "norm_label": "recordonlineorderstatusevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
-      "label": "resolveCustomerProfileForStoreFrontActor()",
-      "norm_label": "resolvecustomerprofileforstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_resolveonlineordercontext",
-      "label": "resolveOnlineOrderContext()",
-      "norm_label": "resolveonlineordercontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
-      "label": "orderOperations.ts",
-      "norm_label": "orderoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "bootstrap_bootstrapcheckout",
-      "label": "bootstrapCheckout()",
-      "norm_label": "bootstrapcheckout()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "bootstrap_createbootstraptoken",
-      "label": "createBootstrapToken()",
-      "norm_label": "createbootstraptoken()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "bootstrap_createmarker",
-      "label": "createMarker()",
-      "norm_label": "createmarker()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "label": "bootstrap.ts",
-      "norm_label": "bootstrap.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "app_test_createinmemoryredis",
-      "label": "createInMemoryRedis()",
-      "norm_label": "createinmemoryredis()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L33"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "app_test_createresponserecorder",
-      "label": "createResponseRecorder()",
-      "norm_label": "createresponserecorder()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L6"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "app_test_createsilentlogger",
-      "label": "createSilentLogger()",
-      "norm_label": "createsilentlogger()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L25"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_app_test_js",
-      "label": "app.test.js",
-      "norm_label": "app.test.js",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "graphify_check_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "graphify_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "graphify_check_test_writegraphifywikiartifacts",
-      "label": "writeGraphifyWikiArtifacts()",
-      "norm_label": "writegraphifywikiartifacts()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "scripts_graphify_check_test_ts",
-      "label": "graphify-check.test.ts",
-      "norm_label": "graphify-check.test.ts",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_test_ts",
-      "label": "graphify-rebuild.test.ts",
-      "norm_label": "graphify-rebuild.test.ts",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpaths",
-      "label": "buildHarnessDocPaths()",
-      "norm_label": "buildharnessdocpaths()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
-      "label": "buildHarnessDocPathsForArchetype()",
-      "norm_label": "buildharnessdocpathsforarchetype()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "harness_app_registry_getharnesspackageregistration",
-      "label": "getHarnessPackageRegistration()",
-      "norm_label": "getharnesspackageregistration()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L871"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_ts",
-      "label": "harness-app-registry.ts",
-      "norm_label": "harness-app-registry.ts",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
-      "label": "valkey-runtime-app.ts",
-      "norm_label": "valkey-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "valkey_runtime_app_createvalkeyruntimeserver",
-      "label": "createValkeyRuntimeServer()",
-      "norm_label": "createvalkeyruntimeserver()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "valkey_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "valkey_runtime_app_stopvalkeyruntimeserver",
-      "label": "stopValkeyRuntimeServer()",
-      "norm_label": "stopvalkeyruntimeserver()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_scorecard_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_scorecard_test_createinferentialartifact",
-      "label": "createInferentialArtifact()",
-      "norm_label": "createinferentialartifact()",
-      "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_scorecard_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "scripts_harness_scorecard_test_ts",
-      "label": "harness-scorecard.test.ts",
-      "norm_label": "harness-scorecard.test.ts",
-      "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "harness_test_collectharnesstesttargets",
-      "label": "collectHarnessTestTargets()",
-      "norm_label": "collectharnesstesttargets()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "harness_test_parseharnesstestcliargs",
-      "label": "parseHarnessTestCliArgs()",
-      "norm_label": "parseharnesstestcliargs()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "harness_test_runharnesstest",
-      "label": "runHarnessTest()",
-      "norm_label": "runharnesstest()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "scripts_harness_test_ts",
-      "label": "harness-test.ts",
-      "norm_label": "harness-test.ts",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "pre_push_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "pre_push_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "pre_push_review_test_warn",
-      "label": "warn()",
-      "norm_label": "warn()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "scripts_pre_push_review_test_ts",
-      "label": "pre-push-review.test.ts",
-      "norm_label": "pre-push-review.test.ts",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "discountcode_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "discountcode_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "label": "DiscountCode.tsx",
-      "norm_label": "discountcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror",
-      "label": "CheckoutSessionError",
-      "norm_label": "checkoutsessionerror",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_createcheckoutsession",
-      "label": "createCheckoutSession()",
-      "norm_label": "createcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_defaultcheckoutactionmessage",
-      "label": "defaultCheckoutActionMessage()",
-      "norm_label": "defaultcheckoutactionmessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_getactivecheckoutsession",
-      "label": "getActiveCheckoutSession()",
-      "norm_label": "getactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutactionerrormessage",
-      "label": "getCheckoutActionErrorMessage()",
-      "norm_label": "getcheckoutactionerrormessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "label": "getCheckoutErrorMessageFromPayload()",
-      "norm_label": "getcheckouterrormessagefrompayload()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutsession",
-      "label": "getCheckoutSession()",
-      "norm_label": "getcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_getpendingcheckoutsessions",
-      "label": "getPendingCheckoutSessions()",
-      "norm_label": "getpendingcheckoutsessions()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_parsecheckoutresponse",
-      "label": "parseCheckoutResponse()",
-      "norm_label": "parsecheckoutresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_parsejson",
-      "label": "parseJson()",
-      "norm_label": "parsejson()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_updatecheckoutsession",
-      "label": "updateCheckoutSession()",
-      "norm_label": "updatecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "checkoutsession_verifycheckoutsessionpayment",
-      "label": "verifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L274"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "discountreminder_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "discountreminder_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "label": "DiscountReminder.tsx",
-      "norm_label": "discountreminder.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "utils_getstoredatafromrequest",
-      "label": "getStoreDataFromRequest()",
-      "norm_label": "getstoredatafromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "utils_getstorefrontuserfromrequest",
-      "label": "getStorefrontUserFromRequest()",
-      "norm_label": "getstorefrontuserfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "expensesessionitems_expenseitemerror",
-      "label": "expenseItemError()",
-      "norm_label": "expenseitemerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "expensesessionitems_mapexpensevalidationerror",
-      "label": "mapExpenseValidationError()",
-      "norm_label": "mapexpensevalidationerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
-      "label": "expenseSessionItems.ts",
-      "norm_label": "expensesessionitems.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "expensetransactions_createexpensetransactionfromsessionhandler",
-      "label": "createExpenseTransactionFromSessionHandler()",
-      "norm_label": "createexpensetransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "expensetransactions_expensetransactionerror",
-      "label": "expenseTransactionError()",
-      "norm_label": "expensetransactionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "label": "expenseTransactions.ts",
-      "norm_label": "expensetransactions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "analyticsutils_calculateactivitytrend",
-      "label": "calculateActivityTrend()",
-      "norm_label": "calculateactivitytrend()",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "analyticsutils_calculatedevicedistribution",
-      "label": "calculateDeviceDistribution()",
-      "norm_label": "calculatedevicedistribution()",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
-      "label": "analyticsUtils.ts",
-      "norm_label": "analyticsutils.ts",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
-      "label": "staffCredentials.test.ts",
-      "norm_label": "staffcredentials.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
-      "label": "createStaffCredentialsMutationCtx()",
-      "norm_label": "createstaffcredentialsmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "staffcredentials_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "staffprofiles_test_createstaffprofilesmutationctx",
-      "label": "createStaffProfilesMutationCtx()",
-      "norm_label": "createstaffprofilesmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "staffprofiles_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
-      "label": "staffRoles.ts",
-      "norm_label": "staffroles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "staffroles_derivedefaultoperationalroles",
-      "label": "deriveDefaultOperationalRoles()",
-      "norm_label": "derivedefaultoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "staffroles_uniqueoperationalroles",
-      "label": "uniqueOperationalRoles()",
-      "norm_label": "uniqueoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "index_listtransactions",
-      "label": "listTransactions()",
-      "norm_label": "listtransactions()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "index_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
-      "label": "register.ts",
-      "norm_label": "register.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "register_mapopendrawerusererror",
-      "label": "mapOpenDrawerUserError()",
-      "norm_label": "mapopendrawerusererror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "register_opendrawer",
-      "label": "openDrawer()",
-      "norm_label": "opendrawer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_hascustomersnapshotvalue",
-      "label": "hasCustomerSnapshotValue()",
-      "norm_label": "hascustomersnapshotvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L321"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L219"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_normalizecustomersnapshot",
-      "label": "normalizeCustomerSnapshot()",
-      "norm_label": "normalizecustomersnapshot()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L306"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_persistsessionworkflowtraceidbesteffort",
-      "label": "persistSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistsessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_recordsessionlifecycletracebesteffort",
-      "label": "recordSessionLifecycleTraceBestEffort()",
-      "norm_label": "recordsessionlifecycletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L266"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_resolvecustomertracestage",
-      "label": "resolveCustomerTraceStage()",
-      "norm_label": "resolvecustomertracestage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L330"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_usererrorfromsessioncommandfailure",
-      "label": "userErrorFromSessionCommandFailure()",
-      "norm_label": "usererrorfromsessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_usererrorfromvalidationmessage",
-      "label": "userErrorFromValidationMessage()",
-      "norm_label": "usererrorfromvalidationmessage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "possessions_validatesessiondrawerbinding",
-      "label": "validateSessionDrawerBinding()",
-      "norm_label": "validatesessiondrawerbinding()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "getregisterstate_buildregisterstate",
-      "label": "buildRegisterState()",
-      "norm_label": "buildregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "getregisterstate_getregisterstate",
-      "label": "getRegisterState()",
-      "norm_label": "getregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
-      "label": "getRegisterState.ts",
-      "norm_label": "getregisterstate.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/terminals.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "terminals_getterminalbyfingerprint",
-      "label": "getTerminalByFingerprint()",
-      "norm_label": "getterminalbyfingerprint()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/terminals.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "terminals_listterminals",
-      "label": "listTerminals()",
-      "norm_label": "listterminals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/terminals.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "errors_posservererror",
-      "label": "PosServerError",
-      "norm_label": "posservererror",
-      "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "errors_posservererror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
-      "label": "errors.ts",
-      "norm_label": "errors.ts",
-      "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
-      "label": "sessionRules.ts",
-      "norm_label": "sessionrules.ts",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "sessionrules_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "sessionrules_selectresumablesession",
-      "label": "selectResumableSession()",
-      "norm_label": "selectresumablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
-      "label": "paymentAllocationService.ts",
-      "norm_label": "paymentallocationservice.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailsalepaymentallocations",
-      "label": "recordRetailSalePaymentAllocations()",
-      "norm_label": "recordretailsalepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
-      "label": "recordRetailVoidPaymentAllocations()",
-      "norm_label": "recordretailvoidpaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 265,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
-      "label": "registerSessionRepository.ts",
-      "norm_label": "registersessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 265,
-      "file_type": "code",
-      "id": "registersessionrepository_getactiveregistersessionforregisterstate",
-      "label": "getActiveRegisterSessionForRegisterState()",
-      "norm_label": "getactiveregistersessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 265,
-      "file_type": "code",
-      "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
-      "label": "mapRegisterSessionToCashDrawerSummary()",
-      "norm_label": "mapregistersessiontocashdrawersummary()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
-      "label": "transactions.test.ts",
-      "norm_label": "transactions.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "transactions_test_exportreturns",
-      "label": "exportReturns()",
-      "norm_label": "exportreturns()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "transactions_test_parsevalidator",
-      "label": "parseValidator()",
-      "norm_label": "parsevalidator()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "appointments_buildserviceappointment",
-      "label": "buildServiceAppointment()",
-      "norm_label": "buildserviceappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "appointments_findoverlappingappointment",
-      "label": "findOverlappingAppointment()",
-      "norm_label": "findoverlappingappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
-      "label": "appointments.ts",
-      "norm_label": "appointments.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
-      "label": "serviceCases.test.ts",
-      "norm_label": "servicecases.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "servicecases_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "servicecases_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
-      "label": "receiving.test.ts",
-      "norm_label": "receiving.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "receiving_test_createreceivingmutationctx",
-      "label": "createReceivingMutationCtx()",
-      "norm_label": "createreceivingmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "receiving_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 27,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_ts",
       "label": "registerSessions.ts",
@@ -54760,133 +53557,1492 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_assertregistersessionidentity",
       "label": "assertRegisterSessionIdentity()",
       "norm_label": "assertregistersessionidentity()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L54"
+      "source_location": "L61"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_assertregistersessionmatchestransaction",
       "label": "assertRegisterSessionMatchesTransaction()",
       "norm_label": "assertregistersessionmatchestransaction()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L64"
+      "source_location": "L71"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_assertvalidregistersessiontransition",
       "label": "assertValidRegisterSessionTransition()",
       "norm_label": "assertvalidregistersessiontransition()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L135"
+      "source_location": "L142"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_buildclosedregistersessionpatch",
       "label": "buildClosedRegisterSessionPatch()",
       "norm_label": "buildclosedregistersessionpatch()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L250"
+      "source_location": "L257"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L100"
+      "source_location": "L107"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_buildregistersessioncloseoutpatch",
       "label": "buildRegisterSessionCloseoutPatch()",
       "norm_label": "buildregistersessioncloseoutpatch()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L195"
+      "source_location": "L202"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_buildregistersessiondepositpatch",
       "label": "buildRegisterSessionDepositPatch()",
       "norm_label": "buildregistersessiondepositpatch()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L221"
+      "source_location": "L228"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_buildregistersessiontransactionpatch",
       "label": "buildRegisterSessionTransactionPatch()",
       "norm_label": "buildregistersessiontransactionpatch()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L154"
+      "source_location": "L161"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_calculateregistersessioncashdelta",
       "label": "calculateRegisterSessionCashDelta()",
       "norm_label": "calculateregistersessioncashdelta()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L122"
+      "source_location": "L129"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_findconflictingregistersession",
       "label": "findConflictingRegisterSession()",
       "norm_label": "findconflictingregistersession()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L276"
+      "source_location": "L283"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_normalizeregistersessionidentity",
       "label": "normalizeRegisterSessionIdentity()",
       "norm_label": "normalizeregistersessionidentity()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L47"
+      "source_location": "L54"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
       "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
       "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L25"
+      "source_location": "L32"
     },
     {
-      "community": 27,
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_recordregistersessiondepositwithctx",
       "label": "recordRegisterSessionDepositWithCtx()",
       "norm_label": "recordregistersessiondepositwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L490"
+      "source_location": "L505"
     },
     {
-      "community": 27,
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_registersessionstatusset",
+      "label": "registerSessionStatusSet()",
+      "norm_label": "registersessionstatusset()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 24,
       "file_type": "code",
       "id": "registersessions_trimoptional",
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "index_cancelorder",
+      "label": "cancelOrder()",
+      "norm_label": "cancelorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "index_geterrormessage",
+      "label": "getErrorMessage()",
+      "norm_label": "geterrormessage()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "index_placeorder",
+      "label": "placeOrder()",
+      "norm_label": "placeorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "bootstrap_bootstrapcheckout",
+      "label": "bootstrapCheckout()",
+      "norm_label": "bootstrapcheckout()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "bootstrap_createbootstraptoken",
+      "label": "createBootstrapToken()",
+      "norm_label": "createbootstraptoken()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "bootstrap_createmarker",
+      "label": "createMarker()",
+      "norm_label": "createmarker()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
+      "label": "bootstrap.ts",
+      "norm_label": "bootstrap.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "app_test_createinmemoryredis",
+      "label": "createInMemoryRedis()",
+      "norm_label": "createinmemoryredis()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L33"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "app_test_createresponserecorder",
+      "label": "createResponseRecorder()",
+      "norm_label": "createresponserecorder()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L6"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "app_test_createsilentlogger",
+      "label": "createSilentLogger()",
+      "norm_label": "createsilentlogger()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L25"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_app_test_js",
+      "label": "app.test.js",
+      "norm_label": "app.test.js",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "graphify_check_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "graphify_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "graphify_check_test_writegraphifywikiartifacts",
+      "label": "writeGraphifyWikiArtifacts()",
+      "norm_label": "writegraphifywikiartifacts()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "scripts_graphify_check_test_ts",
+      "label": "graphify-check.test.ts",
+      "norm_label": "graphify-check.test.ts",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_test_ts",
+      "label": "graphify-rebuild.test.ts",
+      "norm_label": "graphify-rebuild.test.ts",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpaths",
+      "label": "buildHarnessDocPaths()",
+      "norm_label": "buildharnessdocpaths()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
+      "label": "buildHarnessDocPathsForArchetype()",
+      "norm_label": "buildharnessdocpathsforarchetype()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "harness_app_registry_getharnesspackageregistration",
+      "label": "getHarnessPackageRegistration()",
+      "norm_label": "getharnesspackageregistration()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L871"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_ts",
+      "label": "harness-app-registry.ts",
+      "norm_label": "harness-app-registry.ts",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
+      "label": "valkey-runtime-app.ts",
+      "norm_label": "valkey-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "valkey_runtime_app_createvalkeyruntimeserver",
+      "label": "createValkeyRuntimeServer()",
+      "norm_label": "createvalkeyruntimeserver()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "valkey_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "valkey_runtime_app_stopvalkeyruntimeserver",
+      "label": "stopValkeyRuntimeServer()",
+      "norm_label": "stopvalkeyruntimeserver()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_scorecard_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-scorecard.test.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_scorecard_test_createinferentialartifact",
+      "label": "createInferentialArtifact()",
+      "norm_label": "createinferentialartifact()",
+      "source_file": "scripts/harness-scorecard.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_scorecard_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-scorecard.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "scripts_harness_scorecard_test_ts",
+      "label": "harness-scorecard.test.ts",
+      "norm_label": "harness-scorecard.test.ts",
+      "source_file": "scripts/harness-scorecard.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "harness_test_collectharnesstesttargets",
+      "label": "collectHarnessTestTargets()",
+      "norm_label": "collectharnesstesttargets()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "harness_test_parseharnesstestcliargs",
+      "label": "parseHarnessTestCliArgs()",
+      "norm_label": "parseharnesstestcliargs()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "harness_test_runharnesstest",
+      "label": "runHarnessTest()",
+      "norm_label": "runharnesstest()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "scripts_harness_test_ts",
+      "label": "harness-test.ts",
+      "norm_label": "harness-test.ts",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "pre_push_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "pre_push_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "pre_push_review_test_warn",
+      "label": "warn()",
+      "norm_label": "warn()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_test_ts",
+      "label": "pre-push-review.test.ts",
+      "norm_label": "pre-push-review.test.ts",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_assertvalidonlineorderstatustransition",
+      "label": "assertValidOnlineOrderStatusTransition()",
+      "norm_label": "assertvalidonlineorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentamount",
+      "label": "getOnlineOrderPaymentAmount()",
+      "norm_label": "getonlineorderpaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentmethodlabel",
+      "label": "getOnlineOrderPaymentMethodLabel()",
+      "norm_label": "getonlineorderpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderstatuseventtype",
+      "label": "getOnlineOrderStatusEventType()",
+      "norm_label": "getonlineorderstatuseventtype()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_ispaymentondeliveryorder",
+      "label": "isPaymentOnDeliveryOrder()",
+      "norm_label": "ispaymentondeliveryorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineordercreatedevent",
+      "label": "recordOnlineOrderCreatedEvent()",
+      "norm_label": "recordonlineordercreatedevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderfulfillmentmovement",
+      "label": "recordOnlineOrderFulfillmentMovement()",
+      "norm_label": "recordonlineorderfulfillmentmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentcollected",
+      "label": "recordOnlineOrderPaymentCollected()",
+      "norm_label": "recordonlineorderpaymentcollected()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentverified",
+      "label": "recordOnlineOrderPaymentVerified()",
+      "norm_label": "recordonlineorderpaymentverified()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrefundallocation",
+      "label": "recordOnlineOrderRefundAllocation()",
+      "norm_label": "recordonlineorderrefundallocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrestockmovement",
+      "label": "recordOnlineOrderRestockMovement()",
+      "norm_label": "recordonlineorderrestockmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderstatusevent",
+      "label": "recordOnlineOrderStatusEvent()",
+      "norm_label": "recordonlineorderstatusevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
+      "label": "resolveCustomerProfileForStoreFrontActor()",
+      "norm_label": "resolvecustomerprofileforstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_resolveonlineordercontext",
+      "label": "resolveOnlineOrderContext()",
+      "norm_label": "resolveonlineordercontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
+      "label": "orderOperations.ts",
+      "norm_label": "orderoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "discountcode_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "discountcode_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
+      "label": "DiscountCode.tsx",
+      "norm_label": "discountcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "discountreminder_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "discountreminder_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
+      "label": "DiscountReminder.tsx",
+      "norm_label": "discountreminder.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "utils_getstoredatafromrequest",
+      "label": "getStoreDataFromRequest()",
+      "norm_label": "getstoredatafromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "utils_getstorefrontuserfromrequest",
+      "label": "getStorefrontUserFromRequest()",
+      "norm_label": "getstorefrontuserfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "expensesessionitems_expenseitemerror",
+      "label": "expenseItemError()",
+      "norm_label": "expenseitemerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "expensesessionitems_mapexpensevalidationerror",
+      "label": "mapExpenseValidationError()",
+      "norm_label": "mapexpensevalidationerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
+      "label": "expenseSessionItems.ts",
+      "norm_label": "expensesessionitems.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "expensetransactions_createexpensetransactionfromsessionhandler",
+      "label": "createExpenseTransactionFromSessionHandler()",
+      "norm_label": "createexpensetransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "expensetransactions_expensetransactionerror",
+      "label": "expenseTransactionError()",
+      "norm_label": "expensetransactionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
+      "label": "expenseTransactions.ts",
+      "norm_label": "expensetransactions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "analyticsutils_calculateactivitytrend",
+      "label": "calculateActivityTrend()",
+      "norm_label": "calculateactivitytrend()",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "analyticsutils_calculatedevicedistribution",
+      "label": "calculateDeviceDistribution()",
+      "norm_label": "calculatedevicedistribution()",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
+      "label": "analyticsUtils.ts",
+      "norm_label": "analyticsutils.ts",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
+      "label": "staffCredentials.test.ts",
+      "norm_label": "staffcredentials.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
+      "label": "createStaffCredentialsMutationCtx()",
+      "norm_label": "createstaffcredentialsmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "staffcredentials_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "staffprofiles_test_createstaffprofilesmutationctx",
+      "label": "createStaffProfilesMutationCtx()",
+      "norm_label": "createstaffprofilesmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "staffprofiles_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
+      "label": "staffRoles.ts",
+      "norm_label": "staffroles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "staffroles_derivedefaultoperationalroles",
+      "label": "deriveDefaultOperationalRoles()",
+      "norm_label": "derivedefaultoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "staffroles_uniqueoperationalroles",
+      "label": "uniqueOperationalRoles()",
+      "norm_label": "uniqueoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "index_listtransactions",
+      "label": "listTransactions()",
+      "norm_label": "listtransactions()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "index_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_paystack_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_checkoutsessionerror",
+      "label": "CheckoutSessionError",
+      "norm_label": "checkoutsessionerror",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_checkoutsessionerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_createcheckoutsession",
+      "label": "createCheckoutSession()",
+      "norm_label": "createcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_defaultcheckoutactionmessage",
+      "label": "defaultCheckoutActionMessage()",
+      "norm_label": "defaultcheckoutactionmessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_getactivecheckoutsession",
+      "label": "getActiveCheckoutSession()",
+      "norm_label": "getactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckoutactionerrormessage",
+      "label": "getCheckoutActionErrorMessage()",
+      "norm_label": "getcheckoutactionerrormessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckouterrormessagefrompayload",
+      "label": "getCheckoutErrorMessageFromPayload()",
+      "norm_label": "getcheckouterrormessagefrompayload()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckoutsession",
+      "label": "getCheckoutSession()",
+      "norm_label": "getcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_getpendingcheckoutsessions",
+      "label": "getPendingCheckoutSessions()",
+      "norm_label": "getpendingcheckoutsessions()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_parsecheckoutresponse",
+      "label": "parseCheckoutResponse()",
+      "norm_label": "parsecheckoutresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_parsejson",
+      "label": "parseJson()",
+      "norm_label": "parsejson()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_updatecheckoutsession",
+      "label": "updateCheckoutSession()",
+      "norm_label": "updatecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "checkoutsession_verifycheckoutsessionpayment",
+      "label": "verifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
+      "label": "register.ts",
+      "norm_label": "register.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "register_mapopendrawerusererror",
+      "label": "mapOpenDrawerUserError()",
+      "norm_label": "mapopendrawerusererror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "register_opendrawer",
+      "label": "openDrawer()",
+      "norm_label": "opendrawer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "getregisterstate_buildregisterstate",
+      "label": "buildRegisterState()",
+      "norm_label": "buildregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "getregisterstate_getregisterstate",
+      "label": "getRegisterState()",
+      "norm_label": "getregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
+      "label": "getRegisterState.ts",
+      "norm_label": "getregisterstate.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/terminals.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "terminals_getterminalbyfingerprint",
+      "label": "getTerminalByFingerprint()",
+      "norm_label": "getterminalbyfingerprint()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/terminals.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "terminals_listterminals",
+      "label": "listTerminals()",
+      "norm_label": "listterminals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/terminals.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "errors_posservererror",
+      "label": "PosServerError",
+      "norm_label": "posservererror",
+      "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "errors_posservererror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
+      "label": "errors.ts",
+      "norm_label": "errors.ts",
+      "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
+      "label": "sessionRules.ts",
+      "norm_label": "sessionrules.ts",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "sessionrules_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "sessionrules_selectresumablesession",
+      "label": "selectResumableSession()",
+      "norm_label": "selectresumablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 265,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
+      "label": "paymentAllocationService.ts",
+      "norm_label": "paymentallocationservice.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 265,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailsalepaymentallocations",
+      "label": "recordRetailSalePaymentAllocations()",
+      "norm_label": "recordretailsalepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 265,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
+      "label": "recordRetailVoidPaymentAllocations()",
+      "norm_label": "recordretailvoidpaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
+      "label": "registerSessionRepository.ts",
+      "norm_label": "registersessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "registersessionrepository_getactiveregistersessionforregisterstate",
+      "label": "getActiveRegisterSessionForRegisterState()",
+      "norm_label": "getactiveregistersessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
+      "label": "mapRegisterSessionToCashDrawerSummary()",
+      "norm_label": "mapregistersessiontocashdrawersummary()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
+      "label": "transactions.test.ts",
+      "norm_label": "transactions.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "transactions_test_exportreturns",
+      "label": "exportReturns()",
+      "norm_label": "exportreturns()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "transactions_test_parsevalidator",
+      "label": "parseValidator()",
+      "norm_label": "parsevalidator()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "appointments_buildserviceappointment",
+      "label": "buildServiceAppointment()",
+      "norm_label": "buildserviceappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "appointments_findoverlappingappointment",
+      "label": "findOverlappingAppointment()",
+      "norm_label": "findoverlappingappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
+      "label": "appointments.ts",
+      "norm_label": "appointments.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
+      "label": "serviceCases.test.ts",
+      "norm_label": "servicecases.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "servicecases_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "servicecases_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_hascustomersnapshotvalue",
+      "label": "hasCustomerSnapshotValue()",
+      "norm_label": "hascustomersnapshotvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L322"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L194"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_normalizecustomersnapshot",
+      "label": "normalizeCustomerSnapshot()",
+      "norm_label": "normalizecustomersnapshot()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_persistsessionworkflowtraceidbesteffort",
+      "label": "persistSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistsessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_recordsessionlifecycletracebesteffort",
+      "label": "recordSessionLifecycleTraceBestEffort()",
+      "norm_label": "recordsessionlifecycletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_resolvecustomertracestage",
+      "label": "resolveCustomerTraceStage()",
+      "norm_label": "resolvecustomertracestage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L331"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_usererrorfromsessioncommandfailure",
+      "label": "userErrorFromSessionCommandFailure()",
+      "norm_label": "usererrorfromsessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_usererrorfromvalidationmessage",
+      "label": "userErrorFromValidationMessage()",
+      "norm_label": "usererrorfromvalidationmessage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "possessions_validatesessiondrawerbinding",
+      "label": "validateSessionDrawerBinding()",
+      "norm_label": "validatesessiondrawerbinding()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
+      "label": "receiving.test.ts",
+      "norm_label": "receiving.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "receiving_test_createreceivingmutationctx",
+      "label": "createReceivingMutationCtx()",
+      "norm_label": "createreceivingmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
       "source_location": "L20"
     },
     {
       "community": 270,
+      "file_type": "code",
+      "id": "receiving_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -54895,7 +55051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -54904,7 +55060,7 @@
       "source_location": "L12"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -54913,7 +55069,7 @@
       "source_location": "L7"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -54922,7 +55078,7 @@
       "source_location": "L25"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -54931,7 +55087,7 @@
       "source_location": "L21"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -54940,7 +55096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -54949,7 +55105,7 @@
       "source_location": "L7"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -54958,7 +55114,7 @@
       "source_location": "L14"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -54967,7 +55123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -54976,7 +55132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -54985,7 +55141,7 @@
       "source_location": "L45"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -54994,7 +55150,7 @@
       "source_location": "L37"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -55003,7 +55159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -55012,7 +55168,7 @@
       "source_location": "L10"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -55021,7 +55177,7 @@
       "source_location": "L44"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -55030,7 +55186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -55039,7 +55195,7 @@
       "source_location": "L86"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -55048,7 +55204,7 @@
       "source_location": "L102"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -55057,7 +55213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -55066,7 +55222,7 @@
       "source_location": "L35"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -55075,7 +55231,7 @@
       "source_location": "L25"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -55084,7 +55240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -55093,7 +55249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -55102,7 +55258,7 @@
       "source_location": "L4"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -55111,7 +55267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -55120,40 +55276,13 @@
       "source_location": "L18"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
       "norm_label": "productavailabilityview()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "label": "SheetProvider.tsx",
-      "norm_label": "sheetprovider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "sheetprovider_sheetprovider",
-      "label": "SheetProvider()",
-      "norm_label": "sheetprovider()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "sheetprovider_usesheet",
-      "label": "useSheet()",
-      "norm_label": "usesheet()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L11"
     },
     {
       "community": 28,
@@ -55293,6 +55422,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
+      "label": "SheetProvider.tsx",
+      "norm_label": "sheetprovider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "sheetprovider_sheetprovider",
+      "label": "SheetProvider()",
+      "norm_label": "sheetprovider()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "sheetprovider_usesheet",
+      "label": "useSheet()",
+      "norm_label": "usesheet()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
       "norm_label": "wigtype.tsx",
@@ -55300,7 +55456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -55309,7 +55465,7 @@
       "source_location": "L21"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -55318,7 +55474,7 @@
       "source_location": "L8"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -55327,7 +55483,7 @@
       "source_location": "L21"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -55336,7 +55492,7 @@
       "source_location": "L13"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -55345,7 +55501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -55354,7 +55510,7 @@
       "source_location": "L100"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -55363,7 +55519,7 @@
       "source_location": "L10"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -55372,7 +55528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -55381,7 +55537,7 @@
       "source_location": "L100"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -55390,7 +55546,7 @@
       "source_location": "L10"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -55399,7 +55555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -55408,7 +55564,7 @@
       "source_location": "L15"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -55417,7 +55573,7 @@
       "source_location": "L39"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -55426,7 +55582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -55435,7 +55591,7 @@
       "source_location": "L43"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -55444,7 +55600,7 @@
       "source_location": "L51"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -55453,7 +55609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -55462,7 +55618,7 @@
       "source_location": "L3"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -55471,7 +55627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -55480,7 +55636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -55489,7 +55645,7 @@
       "source_location": "L53"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -55498,7 +55654,7 @@
       "source_location": "L65"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -55507,7 +55663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -55516,7 +55672,7 @@
       "source_location": "L47"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -55525,40 +55681,13 @@
       "source_location": "L53"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
       "norm_label": "featuredsection.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "videoplayer_videoplayer",
-      "label": "VideoPlayer()",
-      "norm_label": "videoplayer()",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L9"
     },
     {
       "community": 29,
@@ -55698,6 +55827,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "videoplayer_videoplayer",
+      "label": "VideoPlayer()",
+      "norm_label": "videoplayer()",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
       "norm_label": "handledecideapprovalrequest()",
@@ -55705,7 +55861,7 @@
       "source_location": "L301"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -55714,7 +55870,7 @@
       "source_location": "L291"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -55723,7 +55879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -55732,7 +55888,7 @@
       "source_location": "L70"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -55741,7 +55897,7 @@
       "source_location": "L227"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -55750,7 +55906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -55759,7 +55915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -55768,7 +55924,7 @@
       "source_location": "L67"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -55777,7 +55933,7 @@
       "source_location": "L9"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -55786,7 +55942,7 @@
       "source_location": "L100"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -55795,7 +55951,7 @@
       "source_location": "L95"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -55804,7 +55960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -55813,7 +55969,7 @@
       "source_location": "L36"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -55822,7 +55978,7 @@
       "source_location": "L32"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -55831,7 +55987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -55840,7 +55996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -55849,7 +56005,7 @@
       "source_location": "L20"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -55858,7 +56014,7 @@
       "source_location": "L26"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_tsx",
       "label": "WorkflowTraceLink.tsx",
@@ -55867,7 +56023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "workflowtracelink_getworkflowtracelinktarget",
       "label": "getWorkflowTraceLinkTarget()",
@@ -55876,7 +56032,7 @@
       "source_location": "L25"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "workflowtracelink_workflowtracelink",
       "label": "WorkflowTraceLink()",
@@ -55885,7 +56041,7 @@
       "source_location": "L36"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -55894,7 +56050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -55903,7 +56059,7 @@
       "source_location": "L65"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -55912,7 +56068,7 @@
       "source_location": "L20"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -55921,7 +56077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -55930,40 +56086,13 @@
       "source_location": "L16"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
       "norm_label": "useproductstablestate()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L60"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
-      "label": "StoreProductsView.tsx",
-      "norm_label": "storeproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "storeproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "storeproductsview_productactionstogglegroup",
-      "label": "ProductActionsToggleGroup()",
-      "norm_label": "productactionstogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
-      "source_location": "L19"
     },
     {
       "community": 3,
@@ -56251,7 +56380,7 @@
       "label": "buildCashControlsDashboardSnapshot()",
       "norm_label": "buildcashcontrolsdashboardsnapshot()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L199"
+      "source_location": "L200"
     },
     {
       "community": 30,
@@ -56260,7 +56389,7 @@
       "label": "buildRegisterSessionDepositTargetId()",
       "norm_label": "buildregistersessiondeposittargetid()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L164"
+      "source_location": "L165"
     },
     {
       "community": 30,
@@ -56269,7 +56398,7 @@
       "label": "buildRegisterSessionSummary()",
       "norm_label": "buildregistersessionsummary()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L171"
+      "source_location": "L172"
     },
     {
       "community": 30,
@@ -56278,7 +56407,7 @@
       "label": "collectStaffProfileIds()",
       "norm_label": "collectstaffprofileids()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L329"
+      "source_location": "L330"
     },
     {
       "community": 30,
@@ -56287,7 +56416,7 @@
       "label": "isCashControlDepositAllocation()",
       "norm_label": "iscashcontroldepositallocation()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L121"
+      "source_location": "L122"
     },
     {
       "community": 30,
@@ -56296,7 +56425,7 @@
       "label": "listRegisterSessionsForDashboard()",
       "norm_label": "listregistersessionsfordashboard()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L260"
+      "source_location": "L261"
     },
     {
       "community": 30,
@@ -56305,7 +56434,7 @@
       "label": "listRegisterSessionTimeline()",
       "norm_label": "listregistersessiontimeline()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L316"
+      "source_location": "L317"
     },
     {
       "community": 30,
@@ -56314,7 +56443,7 @@
       "label": "listSessionDeposits()",
       "norm_label": "listsessiondeposits()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L302"
+      "source_location": "L303"
     },
     {
       "community": 30,
@@ -56323,7 +56452,7 @@
       "label": "listStaffNames()",
       "norm_label": "liststaffnames()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L131"
+      "source_location": "L132"
     },
     {
       "community": 30,
@@ -56332,7 +56461,7 @@
       "label": "listStoreDeposits()",
       "norm_label": "liststoredeposits()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L288"
+      "source_location": "L289"
     },
     {
       "community": 30,
@@ -56341,7 +56470,7 @@
       "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
       "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L99"
+      "source_location": "L100"
     },
     {
       "community": 30,
@@ -56350,7 +56479,7 @@
       "label": "sumDepositsBySession()",
       "norm_label": "sumdepositsbysession()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L147"
+      "source_location": "L148"
     },
     {
       "community": 30,
@@ -56359,7 +56488,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L94"
+      "source_location": "L95"
     },
     {
       "community": 30,
@@ -56373,6 +56502,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
+      "label": "StoreProductsView.tsx",
+      "norm_label": "storeproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "storeproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "storeproductsview_productactionstogglegroup",
+      "label": "ProductActionsToggleGroup()",
+      "norm_label": "productactionstogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
       "norm_label": "addcomplimentaryproduct()",
@@ -56380,7 +56536,7 @@
       "source_location": "L128"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -56389,7 +56545,7 @@
       "source_location": "L40"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -56398,7 +56554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -56407,7 +56563,7 @@
       "source_location": "L24"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -56416,7 +56572,7 @@
       "source_location": "L20"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -56425,7 +56581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -56434,7 +56590,7 @@
       "source_location": "L25"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -56443,7 +56599,7 @@
       "source_location": "L17"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -56452,7 +56608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -56461,7 +56617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -56470,7 +56626,7 @@
       "source_location": "L59"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -56479,7 +56635,7 @@
       "source_location": "L50"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -56488,7 +56644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -56497,7 +56653,7 @@
       "source_location": "L225"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -56506,7 +56662,7 @@
       "source_location": "L80"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -56515,7 +56671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -56524,7 +56680,7 @@
       "source_location": "L127"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -56533,7 +56689,7 @@
       "source_location": "L71"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -56542,7 +56698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -56551,7 +56707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -56560,7 +56716,7 @@
       "source_location": "L3"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -56569,7 +56725,7 @@
       "source_location": "L9"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -56578,7 +56734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -56587,7 +56743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -56596,7 +56752,7 @@
       "source_location": "L3"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -56605,39 +56761,12 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
       "norm_label": "app-skeleton.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "dashboard_skeleton_dashboardskeleton",
-      "label": "DashboardSkeleton()",
-      "norm_label": "dashboardskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "label": "dashboard-skeleton.tsx",
-      "norm_label": "dashboard-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "label": "dashboard-skeleton.tsx",
-      "norm_label": "dashboard-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1"
     },
     {
@@ -56769,6 +56898,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "dashboard_skeleton_dashboardskeleton",
+      "label": "DashboardSkeleton()",
+      "norm_label": "dashboardskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
+      "label": "dashboard-skeleton.tsx",
+      "norm_label": "dashboard-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
+      "label": "dashboard-skeleton.tsx",
+      "norm_label": "dashboard-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
       "norm_label": "table-skeleton.tsx",
@@ -56776,7 +56932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -56785,7 +56941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -56794,7 +56950,7 @@
       "source_location": "L3"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -56803,7 +56959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -56812,7 +56968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -56821,7 +56977,7 @@
       "source_location": "L3"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -56830,7 +56986,7 @@
       "source_location": "L4"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -56839,7 +56995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -56848,7 +57004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -56857,7 +57013,7 @@
       "source_location": "L120"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -56866,7 +57022,7 @@
       "source_location": "L36"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -56875,7 +57031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -56884,7 +57040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -56893,7 +57049,7 @@
       "source_location": "L23"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -56902,7 +57058,7 @@
       "source_location": "L41"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -56911,7 +57067,7 @@
       "source_location": "L20"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -56920,7 +57076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -56929,7 +57085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -56938,7 +57094,7 @@
       "source_location": "L30"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -56947,7 +57103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -56956,7 +57112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -56965,7 +57121,7 @@
       "source_location": "L9"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -56974,7 +57130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -56983,7 +57139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -56992,7 +57148,7 @@
       "source_location": "L38"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -57001,39 +57157,12 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
       "norm_label": "modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "alert_modal_alertmodal",
-      "label": "AlertModal()",
-      "norm_label": "alertmodal()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
-      "label": "alert-modal.tsx",
-      "norm_label": "alert-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
-      "label": "alert-modal.tsx",
-      "norm_label": "alert-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -57165,6 +57294,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "alert_modal_alertmodal",
+      "label": "AlertModal()",
+      "norm_label": "alertmodal()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
+      "label": "alert-modal.tsx",
+      "norm_label": "alert-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
+      "label": "alert-modal.tsx",
+      "norm_label": "alert-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
       "norm_label": "overlaymodal()",
@@ -57172,7 +57328,7 @@
       "source_location": "L12"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -57181,7 +57337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -57190,7 +57346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -57199,7 +57355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -57208,7 +57364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -57217,7 +57373,7 @@
       "source_location": "L3"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -57226,7 +57382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -57235,7 +57391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -57244,7 +57400,7 @@
       "source_location": "L6"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -57253,7 +57409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -57262,7 +57418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -57271,7 +57427,7 @@
       "source_location": "L3"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -57280,7 +57436,7 @@
       "source_location": "L44"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -57289,7 +57445,7 @@
       "source_location": "L19"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -57298,7 +57454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -57307,7 +57463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -57316,7 +57472,7 @@
       "source_location": "L159"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -57325,7 +57481,7 @@
       "source_location": "L195"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -57334,7 +57490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -57343,7 +57499,7 @@
       "source_location": "L22"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -57352,7 +57508,7 @@
       "source_location": "L45"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -57361,7 +57517,7 @@
       "source_location": "L24"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -57370,7 +57526,7 @@
       "source_location": "L38"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -57379,7 +57535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -57388,7 +57544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -57397,40 +57553,13 @@
       "source_location": "L23"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
       "norm_label": "usepermissionscontext()",
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "label": "ProductContext.tsx",
-      "norm_label": "productcontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "productcontext_productprovider",
-      "label": "ProductProvider()",
-      "norm_label": "productprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "productcontext_useproduct",
-      "label": "useProduct()",
-      "norm_label": "useproduct()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L282"
     },
     {
       "community": 33,
@@ -57552,6 +57681,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
+      "label": "ProductContext.tsx",
+      "norm_label": "productcontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "productcontext_productprovider",
+      "label": "ProductProvider()",
+      "norm_label": "productprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "productcontext_useproduct",
+      "label": "useProduct()",
+      "norm_label": "useproduct()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
       "norm_label": "usercontext.tsx",
@@ -57559,7 +57715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -57568,7 +57724,7 @@
       "source_location": "L12"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -57577,7 +57733,7 @@
       "source_location": "L37"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -57586,7 +57742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -57595,7 +57751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -57604,7 +57760,7 @@
       "source_location": "L4"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -57613,7 +57769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -57622,7 +57778,7 @@
       "source_location": "L9"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -57631,7 +57787,7 @@
       "source_location": "L50"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -57640,7 +57796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -57649,7 +57805,7 @@
       "source_location": "L6"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -57658,7 +57814,7 @@
       "source_location": "L31"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -57667,7 +57823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -57676,7 +57832,7 @@
       "source_location": "L5"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -57685,7 +57841,7 @@
       "source_location": "L31"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -57694,7 +57850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -57703,7 +57859,7 @@
       "source_location": "L19"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -57712,7 +57868,7 @@
       "source_location": "L33"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -57721,7 +57877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -57730,7 +57886,7 @@
       "source_location": "L18"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -57739,7 +57895,7 @@
       "source_location": "L26"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -57748,7 +57904,7 @@
       "source_location": "L7"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -57757,7 +57913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -57766,7 +57922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -57775,7 +57931,7 @@
       "source_location": "L3"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -57784,39 +57940,12 @@
       "source_location": "L10"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
       "norm_label": "displayamounts.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "commandgateway_useconvexcommandgateway",
-      "label": "useConvexCommandGateway()",
-      "norm_label": "useconvexcommandgateway()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "commandgateway_useconvexdirecttransactionmutation",
-      "label": "useConvexDirectTransactionMutation()",
-      "norm_label": "useconvexdirecttransactionmutation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
-      "label": "commandGateway.ts",
-      "norm_label": "commandgateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
       "source_location": "L1"
     },
     {
@@ -57939,6 +58068,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "commandgateway_useconvexcommandgateway",
+      "label": "useConvexCommandGateway()",
+      "norm_label": "useconvexcommandgateway()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "commandgateway_useconvexdirecttransactionmutation",
+      "label": "useConvexDirectTransactionMutation()",
+      "norm_label": "useconvexdirecttransactionmutation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
+      "label": "commandGateway.ts",
+      "norm_label": "commandgateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "main_app",
       "label": "App()",
       "norm_label": "app()",
@@ -57946,7 +58102,7 @@
       "source_location": "L31"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -57955,7 +58111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -57964,7 +58120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -57973,7 +58129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -57982,7 +58138,7 @@
       "source_location": "L28"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -57991,7 +58147,7 @@
       "source_location": "L46"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -58000,7 +58156,7 @@
       "source_location": "L18"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -58009,7 +58165,7 @@
       "source_location": "L28"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -58018,7 +58174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -58027,7 +58183,7 @@
       "source_location": "L127"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -58036,7 +58192,7 @@
       "source_location": "L106"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -58045,7 +58201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -58054,7 +58210,7 @@
       "source_location": "L66"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -58063,7 +58219,7 @@
       "source_location": "L20"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -58072,7 +58228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -58081,7 +58237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -58090,7 +58246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -58099,7 +58255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -58108,7 +58264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -58117,7 +58273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -58126,7 +58282,7 @@
       "source_location": "L16"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -58135,7 +58291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -58144,7 +58300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -58153,7 +58309,7 @@
       "source_location": "L19"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -58162,7 +58318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -58171,40 +58327,13 @@
       "source_location": "L23"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
       "norm_label": "pointerreleasestub()",
       "source_file": "packages/athena-webapp/vitest.setup.ts",
       "source_location": "L24"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "auth_logout",
-      "label": "logout()",
-      "norm_label": "logout()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "auth_verifyuseraccount",
-      "label": "verifyUserAccount()",
-      "norm_label": "verifyuseraccount()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L1"
     },
     {
       "community": 35,
@@ -58326,6 +58455,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "auth_logout",
+      "label": "logout()",
+      "norm_label": "logout()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "auth_verifyuseraccount",
+      "label": "verifyUserAccount()",
+      "norm_label": "verifyuseraccount()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
       "norm_label": "getallcolors()",
@@ -58333,7 +58489,7 @@
       "source_location": "L7"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -58342,7 +58498,7 @@
       "source_location": "L5"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -58351,7 +58507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -58360,7 +58516,7 @@
       "source_location": "L6"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -58369,7 +58525,7 @@
       "source_location": "L18"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -58378,7 +58534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -58387,7 +58543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -58396,7 +58552,7 @@
       "source_location": "L3"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -58405,7 +58561,7 @@
       "source_location": "L5"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -58414,7 +58570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -58423,7 +58579,7 @@
       "source_location": "L18"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -58432,7 +58588,7 @@
       "source_location": "L23"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -58441,7 +58597,7 @@
       "source_location": "L22"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -58450,7 +58606,7 @@
       "source_location": "L55"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -58459,7 +58615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -58468,7 +58624,7 @@
       "source_location": "L77"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -58477,7 +58633,7 @@
       "source_location": "L11"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -58486,7 +58642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -58495,7 +58651,7 @@
       "source_location": "L11"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -58504,7 +58660,7 @@
       "source_location": "L22"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -58513,7 +58669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -58522,7 +58678,7 @@
       "source_location": "L110"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -58531,7 +58687,7 @@
       "source_location": "L89"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -58540,7 +58696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -58549,7 +58705,7 @@
       "source_location": "L4"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -58558,39 +58714,12 @@
       "source_location": "L24"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
       "norm_label": "checkoutstorage.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "footer_enablecategories",
-      "label": "enableCategories()",
-      "norm_label": "enablecategories()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "footer_linkgroup",
-      "label": "LinkGroup()",
-      "norm_label": "linkgroup()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "label": "Footer.tsx",
-      "norm_label": "footer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1"
     },
     {
@@ -58713,6 +58842,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "footer_enablecategories",
+      "label": "enableCategories()",
+      "norm_label": "enablecategories()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "footer_linkgroup",
+      "label": "LinkGroup()",
+      "norm_label": "linkgroup()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
+      "label": "Footer.tsx",
+      "norm_label": "footer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
       "norm_label": "featuredproductssection()",
@@ -58720,7 +58876,7 @@
       "source_location": "L20"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -58729,7 +58885,7 @@
       "source_location": "L46"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -58738,7 +58894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -58747,7 +58903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -58756,7 +58912,7 @@
       "source_location": "L20"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -58765,7 +58921,7 @@
       "source_location": "L59"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -58774,7 +58930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -58783,7 +58939,7 @@
       "source_location": "L25"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -58792,7 +58948,7 @@
       "source_location": "L20"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -58801,7 +58957,7 @@
       "source_location": "L30"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -58810,7 +58966,7 @@
       "source_location": "L95"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -58819,7 +58975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -58828,7 +58984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -58837,7 +58993,7 @@
       "source_location": "L61"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -58846,7 +59002,7 @@
       "source_location": "L65"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -58855,7 +59011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -58864,7 +59020,7 @@
       "source_location": "L150"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -58873,7 +59029,7 @@
       "source_location": "L157"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -58882,7 +59038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -58891,7 +59047,7 @@
       "source_location": "L63"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -58900,7 +59056,7 @@
       "source_location": "L48"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -58909,7 +59065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -58918,7 +59074,7 @@
       "source_location": "L63"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -58927,7 +59083,7 @@
       "source_location": "L76"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -58936,7 +59092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -58945,40 +59101,13 @@
       "source_location": "L51"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "navigationbarprovider_navigationbarprovider",
-      "label": "NavigationBarProvider()",
-      "norm_label": "navigationbarprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "navigationbarprovider_usenavigationbarcontext",
-      "label": "useNavigationBarContext()",
-      "norm_label": "usenavigationbarcontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "label": "NavigationBarProvider.tsx",
-      "norm_label": "navigationbarprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L1"
     },
     {
       "community": 37,
@@ -59100,6 +59229,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "navigationbarprovider_navigationbarprovider",
+      "label": "NavigationBarProvider()",
+      "norm_label": "navigationbarprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "navigationbarprovider_usenavigationbarcontext",
+      "label": "useNavigationBarContext()",
+      "norm_label": "usenavigationbarcontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
+      "label": "NavigationBarProvider.tsx",
+      "norm_label": "navigationbarprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
       "norm_label": "storecontext.tsx",
@@ -59107,7 +59263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -59116,7 +59272,7 @@
       "source_location": "L25"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -59125,7 +59281,7 @@
       "source_location": "L82"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -59134,7 +59290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -59143,7 +59299,7 @@
       "source_location": "L20"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -59152,7 +59308,7 @@
       "source_location": "L55"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -59161,7 +59317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -59170,7 +59326,7 @@
       "source_location": "L107"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -59179,7 +59335,7 @@
       "source_location": "L25"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -59188,7 +59344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -59197,7 +59353,7 @@
       "source_location": "L556"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -59206,7 +59362,7 @@
       "source_location": "L52"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -59215,7 +59371,7 @@
       "source_location": "L429"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -59224,7 +59380,7 @@
       "source_location": "L102"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -59233,7 +59389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -59242,7 +59398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -59251,7 +59407,7 @@
       "source_location": "L250"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -59260,7 +59416,7 @@
       "source_location": "L46"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -59269,7 +59425,7 @@
       "source_location": "L17"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -59278,7 +59434,7 @@
       "source_location": "L63"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -59287,7 +59443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -59296,7 +59452,7 @@
       "source_location": "L47"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -59305,7 +59461,7 @@
       "source_location": "L141"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -59314,7 +59470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -59323,7 +59479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -59332,40 +59488,13 @@
       "source_location": "L21"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
       "norm_label": "verifycheckoutsessionpayment()",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "label": "signup.tsx",
-      "norm_label": "signup.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "signup_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "signup_signupbeforeload",
-      "label": "signupBeforeLoad()",
-      "norm_label": "signupbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L66"
     },
     {
       "community": 38,
@@ -59478,6 +59607,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_signup_tsx",
+      "label": "signup.tsx",
+      "norm_label": "signup.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "signup_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "signup_signupbeforeload",
+      "label": "signupBeforeLoad()",
+      "norm_label": "signupbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
       "norm_label": "optionalnumberenv()",
@@ -59485,7 +59641,7 @@
       "source_location": "L11"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -59494,7 +59650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -59503,7 +59659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -59512,7 +59668,7 @@
       "source_location": "L16"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -59521,7 +59677,7 @@
       "source_location": "L10"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -59530,7 +59686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59539,7 +59695,7 @@
       "source_location": "L17"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -59548,7 +59704,7 @@
       "source_location": "L11"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -59557,7 +59713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -59566,7 +59722,7 @@
       "source_location": "L21"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -59575,7 +59731,7 @@
       "source_location": "L15"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -59584,7 +59740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59593,7 +59749,7 @@
       "source_location": "L48"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -59602,7 +59758,7 @@
       "source_location": "L42"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -59611,7 +59767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59620,7 +59776,7 @@
       "source_location": "L16"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -59629,7 +59785,7 @@
       "source_location": "L10"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -59638,7 +59794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59647,7 +59803,7 @@
       "source_location": "L19"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -59656,7 +59812,7 @@
       "source_location": "L13"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -59665,7 +59821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59674,7 +59830,7 @@
       "source_location": "L16"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -59683,7 +59839,7 @@
       "source_location": "L10"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -59692,7 +59848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -59701,7 +59857,7 @@
       "source_location": "L20"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -59710,39 +59866,12 @@
       "source_location": "L14"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
       "source_location": "L1"
     },
     {
@@ -59856,6 +59985,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
       "norm_label": "runprecommitgeneratedartifacts()",
@@ -59863,7 +60019,7 @@
       "source_location": "L45"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -59872,7 +60028,7 @@
       "source_location": "L20"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -59881,7 +60037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -59890,7 +60046,7 @@
       "source_location": "L8"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -59899,7 +60055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -59908,7 +60064,7 @@
       "source_location": "L9"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -59917,7 +60073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -59926,7 +60082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -59935,7 +60091,7 @@
       "source_location": "L12"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -59944,7 +60100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -59953,7 +60109,7 @@
       "source_location": "L8"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -59962,7 +60118,7 @@
       "source_location": "L10"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -59971,7 +60127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -59980,7 +60136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -59989,7 +60145,7 @@
       "source_location": "L18"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -59998,7 +60154,7 @@
       "source_location": "L10"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -60007,7 +60163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -60016,31 +60172,13 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "auth_mapathenaauthsyncerror",
-      "label": "mapAthenaAuthSyncError()",
-      "norm_label": "mapathenaauthsyncerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -60396,6 +60534,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "auth_mapathenaauthsyncerror",
+      "label": "mapAthenaAuthSyncError()",
+      "norm_label": "mapathenaauthsyncerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
       "norm_label": "posquerycleanup.test.ts",
@@ -60403,7 +60559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60412,7 +60568,7 @@
       "source_location": "L8"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -60421,7 +60577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -60430,7 +60586,7 @@
       "source_location": "L22"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -60439,7 +60595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60448,7 +60604,7 @@
       "source_location": "L6"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -60457,7 +60613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -60466,7 +60622,7 @@
       "source_location": "L29"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -60475,7 +60631,7 @@
       "source_location": "L22"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -60484,7 +60640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -60493,7 +60649,7 @@
       "source_location": "L4"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -60502,7 +60658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -60511,7 +60667,7 @@
       "source_location": "L3"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -60520,7 +60676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -60529,7 +60685,7 @@
       "source_location": "L3"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -60538,7 +60694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60547,30 +60703,12 @@
       "source_location": "L6"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
       "norm_label": "foundation.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "approvalrequesthelpers_buildapprovalrequest",
-      "label": "buildApprovalRequest()",
-      "norm_label": "buildapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
-      "label": "approvalRequestHelpers.ts",
-      "norm_label": "approvalrequesthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
       "source_location": "L1"
     },
     {
@@ -60675,6 +60813,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "approvalrequesthelpers_buildapprovalrequest",
+      "label": "buildApprovalRequest()",
+      "norm_label": "buildapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
+      "label": "approvalRequestHelpers.ts",
+      "norm_label": "approvalrequesthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
       "norm_label": "createapprovalrequestmutationctx()",
@@ -60682,7 +60838,7 @@
       "source_location": "L19"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -60691,7 +60847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -60700,7 +60856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -60709,7 +60865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -60718,7 +60874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -60727,7 +60883,7 @@
       "source_location": "L17"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -60736,7 +60892,7 @@
       "source_location": "L9"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -60745,7 +60901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -60754,7 +60910,7 @@
       "source_location": "L31"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -60763,7 +60919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -60772,7 +60928,7 @@
       "source_location": "L6"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -60781,7 +60937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -60790,7 +60946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -60799,7 +60955,7 @@
       "source_location": "L88"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -60808,7 +60964,7 @@
       "source_location": "L9"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -60817,7 +60973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -60826,30 +60982,12 @@
       "source_location": "L4"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
       "norm_label": "modulewiring.test.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "access_test_createstockopsaccessqueryctx",
-      "label": "createStockOpsAccessQueryCtx()",
-      "norm_label": "createstockopsaccessqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
-      "label": "access.test.ts",
-      "norm_label": "access.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
       "source_location": "L1"
     },
     {
@@ -60954,6 +61092,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "access_test_createstockopsaccessqueryctx",
+      "label": "createStockOpsAccessQueryCtx()",
+      "norm_label": "createstockopsaccessqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
+      "label": "access.test.ts",
+      "norm_label": "access.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
       "norm_label": "requirestorefulladminaccess()",
@@ -60961,7 +61117,7 @@
       "source_location": "L7"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -60970,7 +61126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -60979,7 +61135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -60988,7 +61144,7 @@
       "source_location": "L8"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -60997,7 +61153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -61006,7 +61162,7 @@
       "source_location": "L5"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -61015,7 +61171,7 @@
       "source_location": "L15"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -61024,7 +61180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -61033,7 +61189,7 @@
       "source_location": "L8"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -61042,7 +61198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -61051,7 +61207,7 @@
       "source_location": "L17"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -61060,7 +61216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61069,7 +61225,7 @@
       "source_location": "L6"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -61078,7 +61234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -61087,7 +61243,7 @@
       "source_location": "L5"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -61096,7 +61252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -61105,31 +61261,13 @@
       "source_location": "L25"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "reviews_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L19"
     },
     {
       "community": 43,
@@ -61233,6 +61371,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "reviews_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -61240,7 +61396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -61249,7 +61405,7 @@
       "source_location": "L7"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -61258,7 +61414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -61267,7 +61423,7 @@
       "source_location": "L14"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -61276,7 +61432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -61285,7 +61441,7 @@
       "source_location": "L8"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -61294,7 +61450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -61303,7 +61459,7 @@
       "source_location": "L3"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -61312,7 +61468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -61321,7 +61477,7 @@
       "source_location": "L5"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -61330,7 +61486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -61339,7 +61495,7 @@
       "source_location": "L16"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -61348,7 +61504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -61357,7 +61513,7 @@
       "source_location": "L30"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_ts",
       "label": "posSale.ts",
@@ -61366,7 +61522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "possale_buildpossaletraceseed",
       "label": "buildPosSaleTraceSeed()",
@@ -61375,7 +61531,7 @@
       "source_location": "L43"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -61384,31 +61540,13 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
       "norm_label": "buildpossessiontraceseed()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
       "source_location": "L43"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
-      "label": "presentation.ts",
-      "norm_label": "presentation.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "presentation_buildworkflowtraceviewmodel",
-      "label": "buildWorkflowTraceViewModel()",
-      "norm_label": "buildworkflowtraceviewmodel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L31"
     },
     {
       "community": 44,
@@ -61512,6 +61650,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "label": "presentation.ts",
+      "norm_label": "presentation.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "presentation_buildworkflowtraceviewmodel",
+      "label": "buildWorkflowTraceViewModel()",
+      "norm_label": "buildworkflowtraceviewmodel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
       "norm_label": "schemaindexes.test.ts",
@@ -61519,7 +61675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -61528,7 +61684,7 @@
       "source_location": "L5"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -61537,7 +61693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -61546,7 +61702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -61555,7 +61711,7 @@
       "source_location": "L7"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -61564,7 +61720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -61573,7 +61729,7 @@
       "source_location": "L12"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -61582,7 +61738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -61591,7 +61747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -61600,7 +61756,7 @@
       "source_location": "L11"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -61609,7 +61765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -61618,7 +61774,7 @@
       "source_location": "L11"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -61627,7 +61783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -61636,7 +61792,7 @@
       "source_location": "L3"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -61645,7 +61801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -61654,7 +61810,7 @@
       "source_location": "L12"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -61663,31 +61819,13 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
       "norm_label": "storedropdown()",
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
     },
     {
       "community": 45,
@@ -61791,6 +61929,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
       "norm_label": "storesdropdown.tsx",
@@ -61798,7 +61954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -61807,7 +61963,7 @@
       "source_location": "L42"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -61816,7 +61972,7 @@
       "source_location": "L31"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -61825,7 +61981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -61834,7 +61990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -61843,7 +61999,7 @@
       "source_location": "L10"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -61852,7 +62008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -61861,7 +62017,7 @@
       "source_location": "L14"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -61870,7 +62026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -61879,7 +62035,7 @@
       "source_location": "L5"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -61888,7 +62044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -61897,7 +62053,7 @@
       "source_location": "L10"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -61906,7 +62062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -61915,7 +62071,7 @@
       "source_location": "L15"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -61924,7 +62080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -61933,7 +62089,7 @@
       "source_location": "L13"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -61942,31 +62098,13 @@
       "source_location": "L116"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
       "norm_label": "copyimagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
     },
     {
       "community": 46,
@@ -62061,6 +62199,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
       "norm_label": "capitalizefirstletter()",
@@ -62068,7 +62224,7 @@
       "source_location": "L151"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -62077,7 +62233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -62086,7 +62242,7 @@
       "source_location": "L6"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -62095,7 +62251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -62104,7 +62260,7 @@
       "source_location": "L19"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -62113,7 +62269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -62122,7 +62278,7 @@
       "source_location": "L7"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -62131,7 +62287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -62140,7 +62296,7 @@
       "source_location": "L42"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -62149,7 +62305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -62158,7 +62314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -62167,7 +62323,7 @@
       "source_location": "L66"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -62176,7 +62332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -62185,7 +62341,7 @@
       "source_location": "L18"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -62194,7 +62350,7 @@
       "source_location": "L6"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -62203,7 +62359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -62212,30 +62368,12 @@
       "source_location": "L10"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1"
     },
     {
@@ -62331,6 +62469,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
       "norm_label": "useloadlogitems.ts",
@@ -62338,7 +62494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -62347,7 +62503,7 @@
       "source_location": "L12"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -62356,7 +62512,7 @@
       "source_location": "L3"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -62365,7 +62521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -62374,7 +62530,7 @@
       "source_location": "L5"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -62383,7 +62539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -62392,7 +62548,7 @@
       "source_location": "L49"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -62401,7 +62557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -62410,7 +62566,7 @@
       "source_location": "L23"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -62419,7 +62575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -62428,7 +62584,7 @@
       "source_location": "L50"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -62437,7 +62593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -62446,7 +62602,7 @@
       "source_location": "L13"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -62455,7 +62611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -62464,7 +62620,7 @@
       "source_location": "L11"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -62473,7 +62629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -62482,30 +62638,12 @@
       "source_location": "L31"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
       "norm_label": "expensecompletion.tsx",
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "bestsellersdialog_handleaddbestseller",
-      "label": "handleAddBestSeller()",
-      "norm_label": "handleaddbestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "label": "BestSellersDialog.tsx",
-      "norm_label": "bestsellersdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L1"
     },
     {
@@ -62601,6 +62739,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "bestsellersdialog_handleaddbestseller",
+      "label": "handleAddBestSeller()",
+      "norm_label": "handleaddbestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
+      "label": "BestSellersDialog.tsx",
+      "norm_label": "bestsellersdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
       "norm_label": "handleaddfeatureditem()",
@@ -62608,7 +62764,7 @@
       "source_location": "L37"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -62617,7 +62773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -62626,7 +62782,7 @@
       "source_location": "L25"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -62635,7 +62791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -62644,7 +62800,7 @@
       "source_location": "L83"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -62653,7 +62809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -62662,7 +62818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -62671,7 +62827,7 @@
       "source_location": "L35"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -62680,7 +62836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -62689,7 +62845,7 @@
       "source_location": "L28"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -62698,7 +62854,7 @@
       "source_location": "L12"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -62707,7 +62863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -62716,7 +62872,7 @@
       "source_location": "L13"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -62725,7 +62881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -62734,7 +62890,7 @@
       "source_location": "L43"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -62743,7 +62899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -62752,30 +62908,12 @@
       "source_location": "L33"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
       "norm_label": "ordermetricspanel.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
     },
     {
@@ -62871,6 +63009,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
       "norm_label": "refundsview.tsx",
@@ -62878,7 +63034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -62887,7 +63043,7 @@
       "source_location": "L81"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -62896,7 +63052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -62905,7 +63061,7 @@
       "source_location": "L6"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -62914,7 +63070,7 @@
       "source_location": "L34"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -62923,7 +63079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -62932,7 +63088,7 @@
       "source_location": "L89"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -62941,7 +63097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -62950,7 +63106,7 @@
       "source_location": "L8"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -62959,7 +63115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -62968,7 +63124,7 @@
       "source_location": "L5"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -62977,7 +63133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -62986,7 +63142,7 @@
       "source_location": "L7"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -62995,7 +63151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -63004,7 +63160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -63013,7 +63169,7 @@
       "source_location": "L13"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -63022,31 +63178,13 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L35"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
     },
     {
       "community": 5,
@@ -63393,6 +63531,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
       "norm_label": "productcard.tsx",
@@ -63400,7 +63556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -63409,7 +63565,7 @@
       "source_location": "L14"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -63418,7 +63574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -63427,7 +63583,7 @@
       "source_location": "L86"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -63436,7 +63592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -63445,7 +63601,7 @@
       "source_location": "L15"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -63454,7 +63610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -63463,7 +63619,7 @@
       "source_location": "L14"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -63472,7 +63628,7 @@
       "source_location": "L18"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -63481,7 +63637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -63490,7 +63646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -63499,7 +63655,7 @@
       "source_location": "L8"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -63508,7 +63664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "registerdrawergate_registerdrawergate",
       "label": "RegisterDrawerGate()",
@@ -63517,7 +63673,7 @@
       "source_location": "L11"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -63526,7 +63682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -63535,7 +63691,7 @@
       "source_location": "L8"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -63544,31 +63700,13 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
       "norm_label": "rendertransactioncell()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
       "source_location": "L46"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L27"
     },
     {
       "community": 51,
@@ -63663,6 +63801,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -63670,7 +63826,7 @@
       "source_location": "L14"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -63679,7 +63835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -63688,7 +63844,7 @@
       "source_location": "L6"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -63697,7 +63853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -63706,7 +63862,7 @@
       "source_location": "L38"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -63715,7 +63871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -63724,7 +63880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -63733,7 +63889,7 @@
       "source_location": "L10"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -63742,7 +63898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -63751,7 +63907,7 @@
       "source_location": "L6"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -63760,7 +63916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -63769,7 +63925,7 @@
       "source_location": "L5"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -63778,7 +63934,7 @@
       "source_location": "L17"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -63787,7 +63943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -63796,7 +63952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -63805,7 +63961,7 @@
       "source_location": "L4"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -63814,31 +63970,13 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
       "norm_label": "togglediscounttype()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L23"
     },
     {
       "community": 52,
@@ -63933,6 +64071,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
       "norm_label": "promocodepreview.tsx",
@@ -63940,7 +64096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -63949,7 +64105,7 @@
       "source_location": "L37"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -63958,7 +64114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -63967,7 +64123,7 @@
       "source_location": "L9"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -63976,7 +64132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -63985,7 +64141,7 @@
       "source_location": "L23"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -63994,7 +64150,7 @@
       "source_location": "L5"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -64003,7 +64159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -64012,7 +64168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -64021,7 +64177,7 @@
       "source_location": "L4"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -64030,7 +64186,7 @@
       "source_location": "L13"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -64039,7 +64195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -64048,7 +64204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -64057,7 +64213,7 @@
       "source_location": "L29"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -64066,7 +64222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -64075,7 +64231,7 @@
       "source_location": "L20"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -64084,31 +64240,13 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
       "source_location": "L63"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
-      "label": "ServiceCatalogView.test.tsx",
-      "norm_label": "servicecatalogview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "servicecatalogview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L30"
     },
     {
       "community": 53,
@@ -64203,6 +64341,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "label": "ServiceCatalogView.test.tsx",
+      "norm_label": "servicecatalogview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "servicecatalogview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
       "norm_label": "serviceintakeform.tsx",
@@ -64210,7 +64366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -64219,7 +64375,7 @@
       "source_location": "L59"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -64228,7 +64384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -64237,7 +64393,7 @@
       "source_location": "L45"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -64246,7 +64402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -64255,7 +64411,7 @@
       "source_location": "L47"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -64264,7 +64420,7 @@
       "source_location": "L29"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -64273,7 +64429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -64282,7 +64438,7 @@
       "source_location": "L3"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -64291,7 +64447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -64300,7 +64456,7 @@
       "source_location": "L4"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -64309,7 +64465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -64318,7 +64474,7 @@
       "source_location": "L4"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -64327,7 +64483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -64336,7 +64492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -64345,7 +64501,7 @@
       "source_location": "L9"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -64354,30 +64510,12 @@
       "source_location": "L9"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
       "norm_label": "contactview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1"
     },
     {
@@ -64464,6 +64602,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
       "norm_label": "maintenanceview()",
@@ -64471,7 +64627,7 @@
       "source_location": "L11"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -64480,7 +64636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -64489,7 +64645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -64498,7 +64654,7 @@
       "source_location": "L25"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -64507,7 +64663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -64516,7 +64672,7 @@
       "source_location": "L21"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -64525,7 +64681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -64534,7 +64690,7 @@
       "source_location": "L63"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -64543,7 +64699,7 @@
       "source_location": "L7"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -64552,7 +64708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -64561,7 +64717,7 @@
       "source_location": "L25"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -64570,7 +64726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -64579,7 +64735,7 @@
       "source_location": "L15"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -64588,7 +64744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -64597,7 +64753,7 @@
       "source_location": "L21"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -64606,7 +64762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -64615,30 +64771,12 @@
       "source_location": "L6"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
       "norm_label": "label.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -64725,6 +64863,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
@@ -64732,7 +64888,7 @@
       "source_location": "L49"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -64741,7 +64897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -64750,7 +64906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -64759,7 +64915,7 @@
       "source_location": "L63"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -64768,7 +64924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -64777,7 +64933,7 @@
       "source_location": "L5"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -64786,7 +64942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -64795,7 +64951,7 @@
       "source_location": "L12"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -64804,7 +64960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -64813,7 +64969,7 @@
       "source_location": "L15"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -64822,7 +64978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -64831,7 +64987,7 @@
       "source_location": "L3"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -64840,7 +64996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -64849,7 +65005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -64858,7 +65014,7 @@
       "source_location": "L5"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -64867,7 +65023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -64876,30 +65032,12 @@
       "source_location": "L11"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
       "norm_label": "bagitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1"
     },
     {
@@ -64986,6 +65124,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
       "norm_label": "string()",
@@ -64993,7 +65149,7 @@
       "source_location": "L110"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -65002,7 +65158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -65011,7 +65167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -65020,7 +65176,7 @@
       "source_location": "L13"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -65029,7 +65185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -65038,7 +65194,7 @@
       "source_location": "L7"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -65047,7 +65203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -65056,7 +65212,7 @@
       "source_location": "L11"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -65065,7 +65221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -65074,7 +65230,7 @@
       "source_location": "L7"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -65083,7 +65239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -65092,7 +65248,7 @@
       "source_location": "L45"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -65101,7 +65257,7 @@
       "source_location": "L13"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -65110,7 +65266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -65119,7 +65275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -65128,7 +65284,7 @@
       "source_location": "L7"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -65137,30 +65293,12 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
       "norm_label": "useismobile()",
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5"
     },
     {
@@ -65247,6 +65385,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
       "norm_label": "use-navigation-keyboard-shortcuts.ts",
@@ -65254,7 +65410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -65263,7 +65419,7 @@
       "source_location": "L7"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -65272,7 +65428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -65281,7 +65437,7 @@
       "source_location": "L9"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -65290,7 +65446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -65299,7 +65455,7 @@
       "source_location": "L6"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -65308,7 +65464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -65317,7 +65473,7 @@
       "source_location": "L168"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -65326,7 +65482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -65335,7 +65491,7 @@
       "source_location": "L5"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -65344,7 +65500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -65353,7 +65509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -65362,7 +65518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -65371,7 +65527,7 @@
       "source_location": "L6"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -65380,7 +65536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -65389,7 +65545,7 @@
       "source_location": "L12"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -65398,31 +65554,13 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
       "norm_label": "useexpenseoperations()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L24"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 58,
@@ -65508,6 +65646,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
       "norm_label": "usegetautheduser.ts",
@@ -65515,7 +65671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -65524,7 +65680,7 @@
       "source_location": "L4"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -65533,7 +65689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -65542,7 +65698,7 @@
       "source_location": "L5"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -65551,7 +65707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -65560,7 +65716,7 @@
       "source_location": "L5"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -65569,7 +65725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -65578,7 +65734,7 @@
       "source_location": "L4"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -65587,7 +65743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -65596,7 +65752,7 @@
       "source_location": "L5"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -65605,7 +65761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -65614,7 +65770,7 @@
       "source_location": "L5"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -65623,7 +65779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -65632,7 +65788,7 @@
       "source_location": "L8"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -65641,7 +65797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -65650,7 +65806,7 @@
       "source_location": "L13"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -65659,31 +65815,13 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
       "norm_label": "useprint()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L26"
     },
     {
       "community": 59,
@@ -65769,6 +65907,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
       "norm_label": "useproductwithnoimagesnotification.tsx",
@@ -65776,7 +65932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -65785,7 +65941,7 @@
       "source_location": "L7"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -65794,7 +65950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -65803,7 +65959,7 @@
       "source_location": "L5"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -65812,7 +65968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -65821,7 +65977,7 @@
       "source_location": "L12"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -65830,7 +65986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -65839,7 +65995,7 @@
       "source_location": "L12"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -65848,7 +66004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -65857,7 +66013,7 @@
       "source_location": "L5"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -65866,7 +66022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -65875,7 +66031,7 @@
       "source_location": "L5"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -65884,7 +66040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -65893,7 +66049,7 @@
       "source_location": "L7"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -65902,7 +66058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -65911,7 +66067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -65920,30 +66076,12 @@
       "source_location": "L5"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
       "norm_label": "additem.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "bootstrapregister_bootstrapregister",
-      "label": "bootstrapRegister()",
-      "norm_label": "bootstrapregister()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
-      "label": "bootstrapRegister.ts",
-      "norm_label": "bootstrapregister.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
       "source_location": "L1"
     },
     {
@@ -66264,6 +66402,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "bootstrapregister_bootstrapregister",
+      "label": "bootstrapRegister()",
+      "norm_label": "bootstrapregister()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
+      "label": "bootstrapRegister.ts",
+      "norm_label": "bootstrapregister.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
       "norm_label": "holdsession()",
@@ -66271,7 +66427,7 @@
       "source_location": "L5"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -66280,7 +66436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -66289,7 +66445,7 @@
       "source_location": "L5"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -66298,7 +66454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -66307,7 +66463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -66316,7 +66472,7 @@
       "source_location": "L5"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -66325,7 +66481,7 @@
       "source_location": "L10"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -66334,7 +66490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -66343,7 +66499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -66352,7 +66508,7 @@
       "source_location": "L12"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -66361,7 +66517,7 @@
       "source_location": "L10"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -66370,7 +66526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -66379,7 +66535,7 @@
       "source_location": "L6"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -66388,7 +66544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -66397,7 +66553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -66406,7 +66562,7 @@
       "source_location": "L6"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -66415,31 +66571,13 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
       "norm_label": "hasorgnotfoundpayload()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 61,
@@ -66525,6 +66663,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
       "norm_label": "published.index.tsx",
@@ -66532,7 +66688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -66541,7 +66697,7 @@
       "source_location": "L9"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -66550,7 +66706,7 @@
       "source_location": "L13"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -66559,7 +66715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -66568,7 +66724,7 @@
       "source_location": "L4"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -66577,7 +66733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -66586,7 +66742,7 @@
       "source_location": "L13"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -66595,7 +66751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -66604,7 +66760,7 @@
       "source_location": "L5"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -66613,7 +66769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -66622,7 +66778,7 @@
       "source_location": "L17"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -66631,7 +66787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -66640,7 +66796,7 @@
       "source_location": "L15"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -66649,7 +66805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -66658,7 +66814,7 @@
       "source_location": "L12"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -66667,7 +66823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -66676,31 +66832,13 @@
       "source_location": "L5"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
-      "label": "Popover.stories.tsx",
-      "norm_label": "popover.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "popover_stories_popovershowcase",
-      "label": "PopoverShowcase()",
-      "norm_label": "popovershowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L13"
     },
     {
       "community": 62,
@@ -66786,6 +66924,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
+      "label": "Popover.stories.tsx",
+      "norm_label": "popover.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "popover_stories_popovershowcase",
+      "label": "PopoverShowcase()",
+      "norm_label": "popovershowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
       "norm_label": "sheet.stories.tsx",
@@ -66793,7 +66949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -66802,7 +66958,7 @@
       "source_location": "L14"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -66811,7 +66967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -66820,7 +66976,7 @@
       "source_location": "L13"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -66829,7 +66985,7 @@
       "source_location": "L5"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -66838,7 +66994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -66847,7 +67003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -66856,7 +67012,7 @@
       "source_location": "L17"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -66865,7 +67021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -66874,7 +67030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -66883,7 +67039,7 @@
       "source_location": "L4"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -66892,7 +67048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -66901,7 +67057,7 @@
       "source_location": "L27"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -66910,7 +67066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -66919,7 +67075,7 @@
       "source_location": "L4"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -66928,7 +67084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -66937,31 +67093,13 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "entitypage_entitypage",
-      "label": "EntityPage()",
-      "norm_label": "entitypage()",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "label": "EntityPage.tsx",
-      "norm_label": "entitypage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
     },
     {
       "community": 63,
@@ -67038,6 +67176,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "entitypage_entitypage",
+      "label": "EntityPage()",
+      "norm_label": "entitypage()",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
+      "label": "EntityPage.tsx",
+      "norm_label": "entitypage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
       "norm_label": "productspage.tsx",
@@ -67045,7 +67201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -67054,7 +67210,7 @@
       "source_location": "L10"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -67063,7 +67219,7 @@
       "source_location": "L4"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -67072,7 +67228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -67081,7 +67237,7 @@
       "source_location": "L39"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -67090,7 +67246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -67099,7 +67255,7 @@
       "source_location": "L18"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -67108,7 +67264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -67117,7 +67273,7 @@
       "source_location": "L71"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -67126,7 +67282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -67135,7 +67291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -67144,7 +67300,7 @@
       "source_location": "L12"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -67153,7 +67309,7 @@
       "source_location": "L6"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -67162,7 +67318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -67171,7 +67327,7 @@
       "source_location": "L18"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -67180,7 +67336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -67189,7 +67345,7 @@
       "source_location": "L10"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -67198,781 +67354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "label": "PaymentMethodSection.tsx",
-      "norm_label": "paymentmethodsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "paymentmethodsection_paymentmethodsection",
-      "label": "PaymentMethodSection()",
-      "norm_label": "paymentmethodsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L8"
-    },
-    {
       "community": 64,
-      "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "label": "PaymentSection.tsx",
-      "norm_label": "paymentsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "paymentsection_paymentsection",
-      "label": "PaymentSection()",
-      "norm_label": "paymentsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 641,
-      "file_type": "code",
-      "id": "deliveryfees_calculatedeliveryfee",
-      "label": "calculateDeliveryFee()",
-      "norm_label": "calculatedeliveryfee()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 641,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "label": "deliveryFees.ts",
-      "norm_label": "deliveryfees.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 642,
-      "file_type": "code",
-      "id": "derivecheckoutstate_derivecheckoutstate",
-      "label": "deriveCheckoutState()",
-      "norm_label": "derivecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 642,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "label": "deriveCheckoutState.ts",
-      "norm_label": "derivecheckoutstate.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 643,
-      "file_type": "code",
-      "id": "checkoutschemas_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 643,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
-      "label": "checkoutSchemas.test.ts",
-      "norm_label": "checkoutschemas.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 644,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
-      "label": "webOrderSchema.test.ts",
-      "norm_label": "weborderschema.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 644,
-      "file_type": "code",
-      "id": "weborderschema_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 645,
-      "file_type": "code",
-      "id": "customerdetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 645,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
-      "label": "CustomerDetailsForm.tsx",
-      "norm_label": "customerdetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 646,
-      "file_type": "code",
-      "id": "deliverydetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 646,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "label": "DeliveryDetailsForm.tsx",
-      "norm_label": "deliverydetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "hooks_usecountdown",
-      "label": "useCountdown()",
-      "norm_label": "usecountdown()",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "label": "TrustSignals.tsx",
-      "norm_label": "trustsignals.tsx",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "trustsignals_trustsignals",
-      "label": "TrustSignals()",
-      "norm_label": "trustsignals()",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "label": "ProductFilter.tsx",
-      "norm_label": "productfilter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "productfilter_productfilter",
-      "label": "ProductFilter()",
-      "norm_label": "productfilter()",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
-    },
-    {
-      "community": 650,
-      "file_type": "code",
-      "id": "filter_handlecheckboxchange",
-      "label": "handleCheckboxChange()",
-      "norm_label": "handlecheckboxchange()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 650,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "label": "Filter.tsx",
-      "norm_label": "filter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 651,
-      "file_type": "code",
-      "id": "bestsellerssection_bestsellerssection",
-      "label": "BestSellersSection()",
-      "norm_label": "bestsellerssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 651,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "label": "BestSellersSection.tsx",
-      "norm_label": "bestsellerssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 652,
-      "file_type": "code",
-      "id": "homepagecontent_resolvehomepagecontent",
-      "label": "resolveHomepageContent()",
-      "norm_label": "resolvehomepagecontent()",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 652,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
-      "label": "homePageContent.ts",
-      "norm_label": "homepagecontent.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 653,
-      "file_type": "code",
-      "id": "bagmenu_handleonlinkclick",
-      "label": "handleOnLinkClick()",
-      "norm_label": "handleonlinkclick()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 653,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "label": "BagMenu.tsx",
-      "norm_label": "bagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 654,
-      "file_type": "code",
-      "id": "mobilebagmenu_mobilebagmenu",
-      "label": "MobileBagMenu()",
-      "norm_label": "mobilebagmenu()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 654,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
-      "label": "MobileBagMenu.tsx",
-      "norm_label": "mobilebagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
-      "label": "SiteBanner.tsx",
-      "norm_label": "sitebanner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "sitebanner_sitebanner",
-      "label": "SiteBanner()",
-      "norm_label": "sitebanner()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "dimensionbar_mapvaluetolabelindex",
-      "label": "mapValueToLabelIndex()",
-      "norm_label": "mapvaluetolabelindex()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "label": "DimensionBar.tsx",
-      "norm_label": "dimensionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "discountbadge_discountbadge",
-      "label": "DiscountBadge()",
-      "norm_label": "discountbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "label": "DiscountBadge.tsx",
-      "norm_label": "discountbadge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "galleryviewer_handleclickonpreview",
-      "label": "handleClickOnPreview()",
-      "norm_label": "handleclickonpreview()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "label": "GalleryViewer.tsx",
-      "norm_label": "galleryviewer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1439"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1433"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1429"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1449"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1209"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1286"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1191"
-    },
-    {
-      "community": 660,
-      "file_type": "code",
-      "id": "onsaleproduct_onsaleproduct",
-      "label": "OnsaleProduct()",
-      "norm_label": "onsaleproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 660,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "label": "OnSaleProduct.tsx",
-      "norm_label": "onsaleproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 661,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "label": "ProductActions.tsx",
-      "norm_label": "productactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 661,
-      "file_type": "code",
-      "id": "productactions_productactions",
-      "label": "ProductActions()",
-      "norm_label": "productactions()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 662,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 662,
-      "file_type": "code",
-      "id": "productattributes_productattributes",
-      "label": "ProductAttributes()",
-      "norm_label": "productattributes()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 663,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
-      "label": "ProductPage.tsx",
-      "norm_label": "productpage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 663,
-      "file_type": "code",
-      "id": "productpage_showshippingpolicy",
-      "label": "showShippingPolicy()",
-      "norm_label": "showshippingpolicy()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L78"
-    },
-    {
-      "community": 664,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
-      "label": "ProductReview.tsx",
-      "norm_label": "productreview.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 664,
-      "file_type": "code",
-      "id": "productreview_handlehelpful",
-      "label": "handleHelpful()",
-      "norm_label": "handlehelpful()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 665,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "label": "ReviewSummary.tsx",
-      "norm_label": "reviewsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 665,
-      "file_type": "code",
-      "id": "reviewsummary_reviewsummary",
-      "label": "ReviewSummary()",
-      "norm_label": "reviewsummary()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 666,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 666,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "label": "RatingSelector.tsx",
-      "norm_label": "ratingselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "ratingselector_ratingselector",
-      "label": "RatingSelector()",
-      "norm_label": "ratingselector()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "guestrewardsprompt_guestrewardsprompt",
-      "label": "GuestRewardsPrompt()",
-      "norm_label": "guestrewardsprompt()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "label": "GuestRewardsPrompt.tsx",
-      "norm_label": "guestrewardsprompt.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "orderpointsdisplay_orderpointsdisplay",
-      "label": "OrderPointsDisplay()",
-      "norm_label": "orderpointsdisplay()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "label": "OrderPointsDisplay.tsx",
-      "norm_label": "orderpointsdisplay.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 67,
       "file_type": "code",
       "id": "index_senddiscountcodeemail",
       "label": "sendDiscountCodeEmail()",
@@ -67981,7 +67363,7 @@
       "source_location": "L255"
     },
     {
-      "community": 67,
+      "community": 64,
       "file_type": "code",
       "id": "index_senddiscountreminderemail",
       "label": "sendDiscountReminderEmail()",
@@ -67990,7 +67372,7 @@
       "source_location": "L334"
     },
     {
-      "community": 67,
+      "community": 64,
       "file_type": "code",
       "id": "index_sendfeedbackrequestemail",
       "label": "sendFeedbackRequestEmail()",
@@ -67999,7 +67381,7 @@
       "source_location": "L167"
     },
     {
-      "community": 67,
+      "community": 64,
       "file_type": "code",
       "id": "index_sendneworderemail",
       "label": "sendNewOrderEmail()",
@@ -68008,7 +67390,7 @@
       "source_location": "L117"
     },
     {
-      "community": 67,
+      "community": 64,
       "file_type": "code",
       "id": "index_sendorderemail",
       "label": "sendOrderEmail()",
@@ -68017,7 +67399,7 @@
       "source_location": "L43"
     },
     {
-      "community": 67,
+      "community": 64,
       "file_type": "code",
       "id": "index_sendverificationcode",
       "label": "sendVerificationCode()",
@@ -68026,7 +67408,7 @@
       "source_location": "L3"
     },
     {
-      "community": 67,
+      "community": 64,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mailersend_index_tsx",
       "label": "index.tsx",
@@ -68035,7 +67417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 67,
+      "community": 64,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
       "label": "index.tsx",
@@ -68044,7 +67426,781 @@
       "source_location": "L1"
     },
     {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
+      "label": "PaymentMethodSection.tsx",
+      "norm_label": "paymentmethodsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "paymentmethodsection_paymentmethodsection",
+      "label": "PaymentMethodSection()",
+      "norm_label": "paymentmethodsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
+      "label": "PaymentSection.tsx",
+      "norm_label": "paymentsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "paymentsection_paymentsection",
+      "label": "PaymentSection()",
+      "norm_label": "paymentsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "deliveryfees_calculatedeliveryfee",
+      "label": "calculateDeliveryFee()",
+      "norm_label": "calculatedeliveryfee()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
+      "label": "deliveryFees.ts",
+      "norm_label": "deliveryfees.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
+      "id": "derivecheckoutstate_derivecheckoutstate",
+      "label": "deriveCheckoutState()",
+      "norm_label": "derivecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
+      "label": "deriveCheckoutState.ts",
+      "norm_label": "derivecheckoutstate.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "checkoutschemas_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
+      "label": "checkoutSchemas.test.ts",
+      "norm_label": "checkoutschemas.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
+      "label": "webOrderSchema.test.ts",
+      "norm_label": "weborderschema.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "weborderschema_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 646,
+      "file_type": "code",
+      "id": "customerdetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 646,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
+      "label": "CustomerDetailsForm.tsx",
+      "norm_label": "customerdetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 647,
+      "file_type": "code",
+      "id": "deliverydetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 647,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
+      "label": "DeliveryDetailsForm.tsx",
+      "norm_label": "deliverydetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 648,
+      "file_type": "code",
+      "id": "hooks_usecountdown",
+      "label": "useCountdown()",
+      "norm_label": "usecountdown()",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 648,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 649,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
+      "label": "TrustSignals.tsx",
+      "norm_label": "trustsignals.tsx",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 649,
+      "file_type": "code",
+      "id": "trustsignals_trustsignals",
+      "label": "TrustSignals()",
+      "norm_label": "trustsignals()",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
+      "label": "ProductFilter.tsx",
+      "norm_label": "productfilter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "productfilter_productfilter",
+      "label": "ProductFilter()",
+      "norm_label": "productfilter()",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "filter_handlecheckboxchange",
+      "label": "handleCheckboxChange()",
+      "norm_label": "handlecheckboxchange()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
+      "label": "Filter.tsx",
+      "norm_label": "filter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "bestsellerssection_bestsellerssection",
+      "label": "BestSellersSection()",
+      "norm_label": "bestsellerssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
+      "label": "BestSellersSection.tsx",
+      "norm_label": "bestsellerssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
+      "id": "homepagecontent_resolvehomepagecontent",
+      "label": "resolveHomepageContent()",
+      "norm_label": "resolvehomepagecontent()",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
+      "label": "homePageContent.ts",
+      "norm_label": "homepagecontent.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 654,
+      "file_type": "code",
+      "id": "bagmenu_handleonlinkclick",
+      "label": "handleOnLinkClick()",
+      "norm_label": "handleonlinkclick()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 654,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
+      "label": "BagMenu.tsx",
+      "norm_label": "bagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "mobilebagmenu_mobilebagmenu",
+      "label": "MobileBagMenu()",
+      "norm_label": "mobilebagmenu()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
+      "label": "MobileBagMenu.tsx",
+      "norm_label": "mobilebagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 656,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
+      "label": "SiteBanner.tsx",
+      "norm_label": "sitebanner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 656,
+      "file_type": "code",
+      "id": "sitebanner_sitebanner",
+      "label": "SiteBanner()",
+      "norm_label": "sitebanner()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 657,
+      "file_type": "code",
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 657,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 658,
+      "file_type": "code",
+      "id": "dimensionbar_mapvaluetolabelindex",
+      "label": "mapValueToLabelIndex()",
+      "norm_label": "mapvaluetolabelindex()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 658,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
+      "label": "DimensionBar.tsx",
+      "norm_label": "dimensionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "discountbadge_discountbadge",
+      "label": "DiscountBadge()",
+      "norm_label": "discountbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
+      "label": "DiscountBadge.tsx",
+      "norm_label": "discountbadge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "galleryviewer_handleclickonpreview",
+      "label": "handleClickOnPreview()",
+      "norm_label": "handleclickonpreview()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
+      "label": "GalleryViewer.tsx",
+      "norm_label": "galleryviewer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "onsaleproduct_onsaleproduct",
+      "label": "OnsaleProduct()",
+      "norm_label": "onsaleproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
+      "label": "OnSaleProduct.tsx",
+      "norm_label": "onsaleproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
+      "label": "ProductActions.tsx",
+      "norm_label": "productactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "productactions_productactions",
+      "label": "ProductActions()",
+      "norm_label": "productactions()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
+      "id": "productattributes_productattributes",
+      "label": "ProductAttributes()",
+      "norm_label": "productattributes()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 664,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
+      "label": "ProductPage.tsx",
+      "norm_label": "productpage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 664,
+      "file_type": "code",
+      "id": "productpage_showshippingpolicy",
+      "label": "showShippingPolicy()",
+      "norm_label": "showshippingpolicy()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L78"
+    },
+    {
+      "community": 665,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
+      "label": "ProductReview.tsx",
+      "norm_label": "productreview.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 665,
+      "file_type": "code",
+      "id": "productreview_handlehelpful",
+      "label": "handleHelpful()",
+      "norm_label": "handlehelpful()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 666,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
+      "label": "ReviewSummary.tsx",
+      "norm_label": "reviewsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 666,
+      "file_type": "code",
+      "id": "reviewsummary_reviewsummary",
+      "label": "ReviewSummary()",
+      "norm_label": "reviewsummary()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 667,
+      "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 667,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 668,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
+      "label": "RatingSelector.tsx",
+      "norm_label": "ratingselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 668,
+      "file_type": "code",
+      "id": "ratingselector_ratingselector",
+      "label": "RatingSelector()",
+      "norm_label": "ratingselector()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 669,
+      "file_type": "code",
+      "id": "guestrewardsprompt_guestrewardsprompt",
+      "label": "GuestRewardsPrompt()",
+      "norm_label": "guestrewardsprompt()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 669,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
+      "label": "GuestRewardsPrompt.tsx",
+      "norm_label": "guestrewardsprompt.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1474"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1468"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1464"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1484"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1244"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1321"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1226"
+    },
+    {
       "community": 670,
+      "file_type": "code",
+      "id": "orderpointsdisplay_orderpointsdisplay",
+      "label": "OrderPointsDisplay()",
+      "norm_label": "orderpointsdisplay()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
+      "label": "OrderPointsDisplay.tsx",
+      "norm_label": "orderpointsdisplay.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -68053,7 +68209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -68062,7 +68218,7 @@
       "source_location": "L59"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -68071,7 +68227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -68080,7 +68236,7 @@
       "source_location": "L33"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -68089,7 +68245,7 @@
       "source_location": "L19"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -68098,7 +68254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -68107,7 +68263,7 @@
       "source_location": "L4"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -68116,7 +68272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -68125,7 +68281,7 @@
       "source_location": "L22"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -68134,7 +68290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -68143,7 +68299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -68152,7 +68308,7 @@
       "source_location": "L11"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -68161,7 +68317,7 @@
       "source_location": "L3"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -68170,7 +68326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -68179,7 +68335,7 @@
       "source_location": "L3"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -68188,7 +68344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -68197,30 +68353,12 @@
       "source_location": "L9"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
       "norm_label": "ghost-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "leaveareviewmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "label": "LeaveAReviewModal.tsx",
-      "norm_label": "leaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1"
     },
     {
@@ -68298,6 +68436,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "leaveareviewmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
+      "label": "LeaveAReviewModal.tsx",
+      "norm_label": "leaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
       "norm_label": "upsellmodalsuccess.tsx",
@@ -68305,7 +68461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -68314,7 +68470,7 @@
       "source_location": "L19"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -68323,7 +68479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -68332,7 +68488,7 @@
       "source_location": "L13"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -68341,7 +68497,7 @@
       "source_location": "L46"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -68350,7 +68506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -68359,7 +68515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -68368,7 +68524,7 @@
       "source_location": "L46"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -68377,7 +68533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -68386,7 +68542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -68395,7 +68551,7 @@
       "source_location": "L15"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -68404,7 +68560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -68413,7 +68569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -68422,7 +68578,7 @@
       "source_location": "L5"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -68431,7 +68587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -68440,7 +68596,7 @@
       "source_location": "L14"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -68449,31 +68605,13 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
       "norm_label": "useenhancedtracking()",
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "label": "useGetActiveCheckoutSession.tsx",
-      "norm_label": "usegetactivecheckoutsession.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "label": "useGetActiveCheckoutSession()",
-      "norm_label": "usegetactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
     },
     {
       "community": 69,
@@ -68550,6 +68688,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
+      "label": "useGetActiveCheckoutSession.tsx",
+      "norm_label": "usegetactivecheckoutsession.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
+      "label": "useGetActiveCheckoutSession()",
+      "norm_label": "usegetactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
       "norm_label": "usegetproduct.tsx",
@@ -68557,7 +68713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -68566,7 +68722,7 @@
       "source_location": "L5"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -68575,7 +68731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -68584,7 +68740,7 @@
       "source_location": "L3"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -68593,7 +68749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -68602,7 +68758,7 @@
       "source_location": "L4"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -68611,7 +68767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -68620,7 +68776,7 @@
       "source_location": "L4"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -68629,7 +68785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -68638,7 +68794,7 @@
       "source_location": "L9"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -68647,7 +68803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -68656,7 +68812,7 @@
       "source_location": "L17"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -68665,7 +68821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -68674,7 +68830,7 @@
       "source_location": "L5"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -68683,7 +68839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -68692,7 +68848,7 @@
       "source_location": "L15"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -68701,31 +68857,13 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
       "norm_label": "useproductpagelogic()",
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "label": "useProductReminder.tsx",
-      "norm_label": "useproductreminder.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "useproductreminder_useproductreminder",
-      "label": "useProductReminder()",
-      "norm_label": "useproductreminder()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L9"
     },
     {
       "community": 7,
@@ -69027,6 +69165,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
+      "label": "useProductReminder.tsx",
+      "norm_label": "useproductreminder.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "useproductreminder_useproductreminder",
+      "label": "useProductReminder()",
+      "norm_label": "useproductreminder()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
       "norm_label": "usepromoalert.tsx",
@@ -69034,7 +69190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -69043,7 +69199,7 @@
       "source_location": "L16"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -69052,7 +69208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -69061,7 +69217,7 @@
       "source_location": "L4"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -69070,7 +69226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -69079,7 +69235,7 @@
       "source_location": "L11"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -69088,7 +69244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -69097,7 +69253,7 @@
       "source_location": "L3"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -69106,7 +69262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -69115,7 +69271,7 @@
       "source_location": "L7"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -69124,7 +69280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -69133,7 +69289,7 @@
       "source_location": "L4"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -69142,7 +69298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -69151,7 +69307,7 @@
       "source_location": "L14"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -69160,7 +69316,7 @@
       "source_location": "L4"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -69169,7 +69325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -69178,30 +69334,12 @@
       "source_location": "L7"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "bannermessage_usebannermessagequeries",
-      "label": "useBannerMessageQueries()",
-      "norm_label": "usebannermessagequeries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -69279,6 +69417,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "bannermessage_usebannermessagequeries",
+      "label": "useBannerMessageQueries()",
+      "norm_label": "usebannermessagequeries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
       "norm_label": "usecheckoutsessionqueries()",
@@ -69286,7 +69442,7 @@
       "source_location": "L10"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -69295,7 +69451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -69304,7 +69460,7 @@
       "source_location": "L6"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -69313,7 +69469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -69322,7 +69478,7 @@
       "source_location": "L5"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -69331,7 +69487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -69340,7 +69496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -69349,7 +69505,7 @@
       "source_location": "L14"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -69358,7 +69514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -69367,7 +69523,7 @@
       "source_location": "L9"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -69376,7 +69532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -69385,7 +69541,7 @@
       "source_location": "L10"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -69394,7 +69550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -69403,7 +69559,7 @@
       "source_location": "L11"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -69412,7 +69568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -69421,7 +69577,7 @@
       "source_location": "L6"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -69430,31 +69586,13 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
       "norm_label": "useuserqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "useroffers_useuseroffersqueries",
-      "label": "useUserOffersQueries()",
-      "norm_label": "useuseroffersqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L6"
     },
     {
       "community": 72,
@@ -69531,6 +69669,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "useroffers_useuseroffersqueries",
+      "label": "useUserOffersQueries()",
+      "norm_label": "useuseroffersqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
       "norm_label": "storeconfig.test.ts",
@@ -69538,7 +69694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -69547,7 +69703,7 @@
       "source_location": "L10"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -69556,7 +69712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -69565,7 +69721,7 @@
       "source_location": "L15"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -69574,7 +69730,7 @@
       "source_location": "L14"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -69583,7 +69739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -69592,7 +69748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -69601,7 +69757,7 @@
       "source_location": "L6"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -69610,7 +69766,7 @@
       "source_location": "L13"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -69619,7 +69775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -69628,7 +69784,7 @@
       "source_location": "L8"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -69637,7 +69793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -69646,7 +69802,7 @@
       "source_location": "L14"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -69655,7 +69811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -69664,7 +69820,7 @@
       "source_location": "L13"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -69673,7 +69829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -69682,31 +69838,13 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
       "norm_label": "privacypolicy()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "label": "tos.index.tsx",
-      "norm_label": "tos.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "tos_index_tossection",
-      "label": "TosSection()",
-      "norm_label": "tossection()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L15"
     },
     {
       "community": 73,
@@ -69783,6 +69921,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
+      "label": "tos.index.tsx",
+      "norm_label": "tos.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "tos_index_tossection",
+      "label": "TosSection()",
+      "norm_label": "tossection()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
       "norm_label": "shop.product.$productslug.tsx",
@@ -69790,7 +69946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -69799,7 +69955,7 @@
       "source_location": "L16"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -69808,7 +69964,7 @@
       "source_location": "L6"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -69817,7 +69973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -69826,7 +69982,7 @@
       "source_location": "L10"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -69835,7 +69991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -69844,7 +70000,7 @@
       "source_location": "L21"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -69853,7 +70009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -69862,7 +70018,7 @@
       "source_location": "L33"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -69871,7 +70027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -69880,7 +70036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -69889,7 +70045,7 @@
       "source_location": "L193"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -69898,7 +70054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -69907,7 +70063,7 @@
       "source_location": "L7"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -69916,7 +70072,7 @@
       "source_location": "L10"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -69925,7 +70081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -69934,30 +70090,12 @@
       "source_location": "L32"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
       "norm_label": "architecture-boundary-check.ts",
       "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "athena_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "label": "athena-runtime-app.ts",
-      "norm_label": "athena-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
       "source_location": "L1"
     },
     {
@@ -70035,6 +70173,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "athena_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
+      "label": "athena-runtime-app.ts",
+      "norm_label": "athena-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
       "norm_label": "shutdown()",
@@ -70042,7 +70198,7 @@
       "source_location": "L85"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -70051,7 +70207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -70060,7 +70216,7 @@
       "source_location": "L15"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -70069,7 +70225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -70078,7 +70234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -70087,7 +70243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -70096,7 +70252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -70105,7 +70261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -70114,7 +70270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -70123,21 +70279,12 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
       "norm_label": "auth.config.js",
       "source_file": "packages/athena-webapp/convex/auth.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/auth.ts",
       "source_location": "L1"
     },
     {
@@ -70215,6 +70362,15 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
       "norm_label": "registersessions.test.ts",
@@ -70222,7 +70378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -70231,7 +70387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -70240,7 +70396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -70249,7 +70405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -70258,7 +70414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -70267,7 +70423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -70276,7 +70432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -70285,21 +70441,12 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
       "norm_label": "orderemail.tsx",
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "label": "PosReceiptEmail.tsx",
-      "norm_label": "posreceiptemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1"
     },
     {
@@ -70377,6 +70524,15 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
+      "label": "PosReceiptEmail.tsx",
+      "norm_label": "posreceiptemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
       "norm_label": "env.ts",
@@ -70384,7 +70540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -70393,7 +70549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -70402,7 +70558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -70411,7 +70567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -70420,7 +70576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -70429,7 +70585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -70438,7 +70594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -70447,21 +70603,12 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
       "norm_label": "products.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
       "source_location": "L1"
     },
     {
@@ -70530,6 +70677,15 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
@@ -70537,7 +70693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -70546,7 +70702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -70555,7 +70711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -70564,7 +70720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -70573,7 +70729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -70582,7 +70738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -70591,7 +70747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -70600,21 +70756,12 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
       "norm_label": "paystack.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
       "source_location": "L1"
     },
     {
@@ -70683,6 +70830,15 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -70690,7 +70846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -70699,7 +70855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -70708,7 +70864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -70717,7 +70873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -70726,7 +70882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -70735,7 +70891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -70744,7 +70900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -70753,21 +70909,12 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
       "norm_label": "http.ts",
       "source_file": "packages/athena-webapp/convex/http.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
       "source_location": "L1"
     },
     {
@@ -70836,6 +70983,15 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
@@ -70843,7 +70999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -70852,7 +71008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -70861,7 +71017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -70870,7 +71026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -70879,7 +71035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -70888,7 +71044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -70897,7 +71053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -70906,21 +71062,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_pos_ts",
-      "label": "pos.ts",
-      "norm_label": "pos.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1"
     },
     {
@@ -71187,6 +71334,15 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_pos_ts",
+      "label": "pos.ts",
+      "norm_label": "pos.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
       "norm_label": "poscustomers.ts",
@@ -71194,7 +71350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -71203,7 +71359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -71212,7 +71368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -71221,7 +71377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -71230,7 +71386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -71239,7 +71395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -71248,7 +71404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -71257,21 +71413,12 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
       "norm_label": "currency.test.ts",
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
-      "label": "storeInsights.ts",
-      "norm_label": "storeinsights.ts",
-      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
       "source_location": "L1"
     },
     {
@@ -71340,6 +71487,15 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
+      "label": "storeInsights.ts",
+      "norm_label": "storeinsights.ts",
+      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
@@ -71347,7 +71503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -71356,7 +71512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -71365,7 +71521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -71374,7 +71530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -71383,7 +71539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -71392,7 +71548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -71401,7 +71557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -71410,21 +71566,12 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
       "norm_label": "paymentallocations.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
-      "label": "EmailOTP.test.ts",
-      "norm_label": "emailotp.test.ts",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.test.ts",
       "source_location": "L1"
     },
     {
@@ -71493,6 +71640,15 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
+      "label": "EmailOTP.test.ts",
+      "norm_label": "emailotp.test.ts",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
       "norm_label": "completetransaction.test.ts",
@@ -71500,7 +71656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -71509,7 +71665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -71518,7 +71674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -71527,7 +71683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -71536,7 +71692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -71545,7 +71701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -71554,7 +71710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -71563,21 +71719,12 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
-      "label": "customers.ts",
-      "norm_label": "customers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
       "source_location": "L1"
     },
     {
@@ -71646,6 +71793,15 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
+      "label": "customers.ts",
+      "norm_label": "customers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -71653,7 +71809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -71662,7 +71818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -71671,7 +71827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -71680,7 +71836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -71689,7 +71845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -71698,7 +71854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71707,7 +71863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -71716,21 +71872,12 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
       "source_location": "L1"
     },
     {
@@ -71799,6 +71946,15 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -71806,7 +71962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -71815,7 +71971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -71824,7 +71980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -71833,7 +71989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -71842,7 +71998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -71851,7 +72007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -71860,7 +72016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -71869,21 +72025,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
       "norm_label": "redeemedpromocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
       "source_location": "L1"
     },
     {
@@ -71952,6 +72099,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -71959,7 +72115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -71968,7 +72124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -71977,7 +72133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -71986,7 +72142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -71995,7 +72151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -72004,7 +72160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -72013,7 +72169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -72022,21 +72178,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
       "norm_label": "inventorymovement.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
-      "label": "operationalEvent.ts",
-      "norm_label": "operationalevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
       "source_location": "L1"
     },
     {
@@ -72105,6 +72252,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
+      "label": "operationalEvent.ts",
+      "norm_label": "operationalevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
       "norm_label": "operationalworkitem.ts",
@@ -72112,7 +72268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -72121,7 +72277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -72130,7 +72286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -72139,7 +72295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -72148,7 +72304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -72157,7 +72313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -72166,7 +72322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -72175,21 +72331,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
       "norm_label": "expensesession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
-      "label": "expenseSessionItem.ts",
-      "norm_label": "expensesessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
       "source_location": "L1"
     },
     {
@@ -72258,6 +72405,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
+      "label": "expenseSessionItem.ts",
+      "norm_label": "expensesessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
       "norm_label": "expensetransaction.ts",
@@ -72265,7 +72421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -72274,7 +72430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -72283,7 +72439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -72292,7 +72448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -72301,7 +72457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -72310,7 +72466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -72319,7 +72475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -72328,21 +72484,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
-      "label": "serviceAppointment.ts",
-      "norm_label": "serviceappointment.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
       "source_location": "L1"
     },
     {
@@ -72411,6 +72558,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
+      "label": "serviceAppointment.ts",
+      "norm_label": "serviceappointment.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
       "norm_label": "servicecase.ts",
@@ -72418,7 +72574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -72427,7 +72583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -72436,7 +72592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -72445,7 +72601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -72454,7 +72610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -72463,7 +72619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -72472,7 +72628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -72481,21 +72637,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
       "norm_label": "stockadjustmentbatch.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
-      "label": "vendor.ts",
-      "norm_label": "vendor.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
       "source_location": "L1"
     },
     {
@@ -72564,6 +72711,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
+      "label": "vendor.ts",
+      "norm_label": "vendor.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
@@ -72571,7 +72727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -72580,7 +72736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -72589,7 +72745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -72598,7 +72754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -72607,7 +72763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -72616,7 +72772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -72625,7 +72781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -72634,21 +72790,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
       "norm_label": "offer.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -72667,7 +72814,7 @@
       "label": "buildNextSessionNumber()",
       "norm_label": "buildnextsessionnumber()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L692"
+      "source_location": "L693"
     },
     {
       "community": 9,
@@ -72676,7 +72823,7 @@
       "label": "createDefaultSessionCommandService()",
       "norm_label": "createdefaultsessioncommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L650"
+      "source_location": "L651"
     },
     {
       "community": 9,
@@ -72685,7 +72832,7 @@
       "label": "createPosSessionCommandService()",
       "norm_label": "createpossessioncommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L145"
+      "source_location": "L146"
     },
     {
       "community": 9,
@@ -72694,7 +72841,7 @@
       "label": "failure()",
       "norm_label": "failure()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L885"
+      "source_location": "L886"
     },
     {
       "community": 9,
@@ -72703,7 +72850,7 @@
       "label": "isActiveRegisterSession()",
       "norm_label": "isactiveregistersession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L708"
+      "source_location": "L709"
     },
     {
       "community": 9,
@@ -72712,7 +72859,7 @@
       "label": "isSessionExpired()",
       "norm_label": "issessionexpired()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L797"
+      "source_location": "L798"
     },
     {
       "community": 9,
@@ -72721,7 +72868,7 @@
       "label": "normalizeRegisterNumber()",
       "norm_label": "normalizeregisternumber()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L703"
+      "source_location": "L704"
     },
     {
       "community": 9,
@@ -72730,7 +72877,7 @@
       "label": "recordSessionLifecycleBestEffort()",
       "norm_label": "recordsessionlifecyclebesteffort()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L662"
+      "source_location": "L663"
     },
     {
       "community": 9,
@@ -72739,7 +72886,7 @@
       "label": "registerSessionMatchesIdentity()",
       "norm_label": "registersessionmatchesidentity()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L714"
+      "source_location": "L715"
     },
     {
       "community": 9,
@@ -72748,7 +72895,7 @@
       "label": "resolveRegisterSessionBinding()",
       "norm_label": "resolveregistersessionbinding()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L745"
+      "source_location": "L746"
     },
     {
       "community": 9,
@@ -72757,7 +72904,7 @@
       "label": "runBindSessionToRegisterSessionCommand()",
       "norm_label": "runbindsessiontoregistersessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L629"
+      "source_location": "L630"
     },
     {
       "community": 9,
@@ -72766,7 +72913,7 @@
       "label": "runHoldSessionCommand()",
       "norm_label": "runholdsessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L618"
+      "source_location": "L619"
     },
     {
       "community": 9,
@@ -72775,7 +72922,7 @@
       "label": "runRemoveSessionItemCommand()",
       "norm_label": "runremovesessionitemcommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L643"
+      "source_location": "L644"
     },
     {
       "community": 9,
@@ -72784,7 +72931,7 @@
       "label": "runResumeSessionCommand()",
       "norm_label": "runresumesessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L622"
+      "source_location": "L623"
     },
     {
       "community": 9,
@@ -72793,7 +72940,7 @@
       "label": "runStartSessionCommand()",
       "norm_label": "runstartsessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L611"
+      "source_location": "L612"
     },
     {
       "community": 9,
@@ -72802,7 +72949,7 @@
       "label": "runUpsertSessionItemCommand()",
       "norm_label": "runupsertsessionitemcommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L636"
+      "source_location": "L637"
     },
     {
       "community": 9,
@@ -72811,7 +72958,7 @@
       "label": "success()",
       "norm_label": "success()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L878"
+      "source_location": "L879"
     },
     {
       "community": 9,
@@ -72820,7 +72967,7 @@
       "label": "validateActiveSession()",
       "norm_label": "validateactivesession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L801"
+      "source_location": "L802"
     },
     {
       "community": 9,
@@ -72829,7 +72976,7 @@
       "label": "validateActiveSessionRegisterBinding()",
       "norm_label": "validateactivesessionregisterbinding()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L779"
+      "source_location": "L780"
     },
     {
       "community": 9,
@@ -72838,7 +72985,7 @@
       "label": "validateModifiableSession()",
       "norm_label": "validatemodifiablesession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L845"
+      "source_location": "L846"
     },
     {
       "community": 90,
@@ -72906,6 +73053,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
@@ -72913,7 +73069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -72922,7 +73078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -72931,7 +73087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -72940,7 +73096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -72949,7 +73105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -72958,7 +73114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -72967,7 +73123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -72976,21 +73132,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
-      "label": "catalogAppointments.test.ts",
-      "norm_label": "catalogappointments.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts",
       "source_location": "L1"
     },
     {
@@ -73059,6 +73206,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
+      "label": "catalogAppointments.test.ts",
+      "norm_label": "catalogappointments.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
@@ -73066,7 +73222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -73075,7 +73231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -73084,7 +73240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -73093,7 +73249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -73102,7 +73258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -73111,7 +73267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -73120,7 +73276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -73129,21 +73285,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
       "norm_label": "savedbagitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
       "source_location": "L1"
     },
     {
@@ -73212,6 +73359,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
       "norm_label": "users.ts",
@@ -73219,7 +73375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -73228,7 +73384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_test_ts",
       "label": "posSale.test.ts",
@@ -73237,7 +73393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -73246,7 +73402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -73255,7 +73411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -73264,7 +73420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -73273,7 +73429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -73282,21 +73438,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
       "norm_label": "postcss.config.js",
       "source_file": "packages/athena-webapp/postcss.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/shared/auth.ts",
       "source_location": "L1"
     },
     {
@@ -73365,6 +73512,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/shared/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
       "norm_label": "commandresult.test.ts",
@@ -73372,7 +73528,16 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
+      "label": "registerSessionStatus.test.ts",
+      "norm_label": "registersessionstatus.test.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -73381,7 +73546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -73390,7 +73555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -73399,7 +73564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -73408,7 +73573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -73417,7 +73582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -73426,30 +73591,12 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -73518,6 +73665,24 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -73525,7 +73690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -73534,7 +73699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -73543,7 +73708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -73552,7 +73717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -73561,7 +73726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -73570,7 +73735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -73579,30 +73744,12 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -73671,6 +73818,24 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -73678,7 +73843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -73687,7 +73852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -73696,7 +73861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -73705,7 +73870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -73714,7 +73879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -73723,7 +73888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -73732,30 +73897,12 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -73824,6 +73971,24 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -73831,7 +73996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -73840,7 +74005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -73849,7 +74014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -73858,7 +74023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -73867,7 +74032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -73876,7 +74041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -73885,30 +74050,12 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -73977,6 +74124,24 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -73984,7 +74149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -73993,7 +74158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -74002,7 +74167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74011,7 +74176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74020,7 +74185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -74029,7 +74194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74038,30 +74203,12 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
       "norm_label": "app-sidebar.tsx",
       "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
-      "label": "assetsColumns.tsx",
-      "norm_label": "assetscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -74130,6 +74277,24 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
+      "label": "assetsColumns.tsx",
+      "norm_label": "assetscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -74137,7 +74302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74146,7 +74311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74155,7 +74320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -74164,7 +74329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -74173,7 +74338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -74182,7 +74347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -74191,30 +74356,12 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
       "norm_label": "loginform.test.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "label": "LoginForm.tsx",
-      "norm_label": "loginform.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -74283,6 +74430,24 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
+      "label": "LoginForm.tsx",
+      "norm_label": "loginform.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
@@ -74290,7 +74455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74299,7 +74464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74308,7 +74473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -74317,7 +74482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74326,7 +74491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -74335,7 +74500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -74344,30 +74509,12 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1498
-- Graph nodes: 3796
-- Graph edges: 3350
-- Communities: 1413
+- Code files discovered: 1500
+- Graph nodes: 3803
+- Graph edges: 3357
+- Communities: 1415
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 25) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 26) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 241) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 242) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -8,6 +8,7 @@ import { recordRegisterSessionDepositWithCtx } from "../operations/registerSessi
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
 import { toPesewas } from "../lib/currency";
 import { ok, userError, type CommandResult } from "../../shared/commandResult";
+import { isPosUsableRegisterSessionStatus } from "../../shared/registerSessionStatus";
 
 const CASH_DEPOSIT_ALLOCATION_TYPE = "cash_deposit";
 const CASH_DEPOSIT_SUBJECT_TYPE = "register_cash_deposit";
@@ -223,7 +224,7 @@ export function buildCashControlsDashboardSnapshot(args: {
 
   return {
     openSessions: sessionSummaries.filter((registerSession) =>
-      registerSession.status === "open" || registerSession.status === "active"
+      isPosUsableRegisterSessionStatus(registerSession.status)
     ),
     pendingCloseouts: sessionSummaries.filter(
       (registerSession) => registerSession.status === "closing"
@@ -551,7 +552,7 @@ export const recordRegisterSessionDeposit = mutation({
       });
     }
 
-    if (registerSession.status !== "open" && registerSession.status !== "active") {
+    if (!isPosUsableRegisterSessionStatus(registerSession.status)) {
       return userError({
         code: "precondition_failed",
         message: "Register session is not accepting new deposits.",

--- a/packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts
+++ b/packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts
@@ -1,8 +1,12 @@
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import type { RecordPaymentAllocationArgs } from "../operations/paymentAllocations";
+import {
+  isPosUsableRegisterSessionStatus,
+  POS_USABLE_REGISTER_SESSION_STATUSES,
+  type RegisterSessionStatus,
+} from "../../shared/registerSessionStatus";
 
-type RegisterSessionStatus = "open" | "active" | "closing" | "closed";
 type RegisterSessionAttributionCandidate = {
   _id: Id<"registerSession">;
   openedByStaffProfileId?: Id<"staffProfile">;
@@ -14,12 +18,6 @@ type InStorePayment = {
   method: string;
   timestamp: number;
 };
-
-const ACTIVE_REGISTER_SESSION_STATUSES = ["open", "active"] as const;
-
-function isActiveRegisterSessionStatus(status: RegisterSessionStatus) {
-  return status === "open" || status === "active";
-}
 
 export function normalizeInStorePayments(args: {
   changeGiven?: number;
@@ -91,7 +89,7 @@ export function selectRegisterSessionForAttribution(args: {
   }
 
   const activeSessions = args.sessions.filter((session) =>
-    isActiveRegisterSessionStatus(session.status)
+    isPosUsableRegisterSessionStatus(session.status)
   );
 
   if (args.actorStaffProfileId) {
@@ -133,7 +131,7 @@ export async function resolveRegisterSessionForInStoreCollectionWithCtx(
       throw new Error("Register session not found for this store.");
     }
 
-    if (!isActiveRegisterSessionStatus(registerSession.status)) {
+    if (!isPosUsableRegisterSessionStatus(registerSession.status)) {
       throw new Error("Register session is not accepting new collections.");
     }
 
@@ -142,7 +140,7 @@ export async function resolveRegisterSessionForInStoreCollectionWithCtx(
 
   const sessions = (
     await Promise.all(
-      ACTIVE_REGISTER_SESSION_STATUSES.map((status) =>
+      POS_USABLE_REGISTER_SESSION_STATUSES.map((status) =>
         // eslint-disable-next-line @convex-dev/no-collect-in-query -- Store-scoped open/active session attribution needs the complete candidate set to avoid guessing across drawers.
         ctx.db
           .query("registerSession")

--- a/packages/athena-webapp/convex/inventory/posSessions.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.ts
@@ -26,6 +26,7 @@ import {
 import { createTransactionFromSessionHandler, recordRegisterSessionSale } from "./pos";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import { ok, userError } from "../../shared/commandResult";
+import { isPosUsableRegisterSessionStatus } from "../../shared/registerSessionStatus";
 import {
   createPosSessionTraceRecorder,
   type PosSessionTraceStage,
@@ -98,7 +99,7 @@ function normalizeRegisterNumber(registerNumber?: string | null) {
 }
 
 function isUsableRegisterSession(registerSession: { status: string }) {
-  return registerSession.status === "open" || registerSession.status === "active";
+  return isPosUsableRegisterSessionStatus(registerSession.status);
 }
 
 function registerSessionMatchesIdentity(

--- a/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
@@ -8,7 +8,11 @@ vi.mock("./registerSessionTracing", () => ({
   recordRegisterSessionTraceBestEffort: mocks.traceRecord,
 }));
 
-import { openRegisterSession, recordRegisterSessionTransaction } from "./registerSessions";
+import {
+  getOpenRegisterSession,
+  openRegisterSession,
+  recordRegisterSessionTransaction,
+} from "./registerSessions";
 
 type RegisterSessionRecord = {
   _id: string;
@@ -75,7 +79,9 @@ function createMutationCtx(seed?: { sessions?: RegisterSessionRecord[] }) {
       Object.assign(session, patch);
     }),
     query: vi.fn((table: string) => ({
-      withIndex(indexName: string) {
+      withIndex(indexName: string, buildQuery?: (q: {
+        eq: (field: string, value: string) => unknown;
+      }) => unknown) {
         if (table !== "registerSession") {
           throw new Error(`Unsupported query table ${table}`);
         }
@@ -87,10 +93,27 @@ function createMutationCtx(seed?: { sessions?: RegisterSessionRecord[] }) {
           throw new Error(`Unsupported registerSession index ${indexName}`);
         }
 
+        const filters = new Map<string, string>();
+        const queryBuilder = {
+          eq(field: string, value: string) {
+            filters.set(field, value);
+            return queryBuilder;
+          },
+        };
+        buildQuery?.(queryBuilder);
+
         return {
           order() {
             return {
-              first: async () => null,
+              first: async () =>
+                [...sessions]
+                  .reverse()
+                  .find((session) =>
+                    [...filters].every(
+                      ([field, value]) =>
+                        session[field as keyof RegisterSessionRecord] === value,
+                    ),
+                  ) ?? null,
             };
           },
         };
@@ -173,6 +196,63 @@ describe("register session workflow trace handlers", () => {
     expect(ctx.db.patch).not.toHaveBeenCalledWith("registerSession", "session-1", {
       workflowTraceId: "register_session:session-1",
     });
+  });
+
+  it("returns an open register session for POS active drawer lookup", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildRegisterSession({
+          _id: "session-1",
+          status: "open",
+        }),
+      ],
+    });
+
+    const session = await getHandler(getOpenRegisterSession)(ctx as never, {
+      storeId: "store-1",
+      registerNumber: "A1",
+    });
+
+    expect(session).toEqual(expect.objectContaining({ _id: "session-1" }));
+  });
+
+  it("does not return a closing register session for POS active drawer lookup", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildRegisterSession({
+          _id: "session-1",
+          status: "closing",
+        }),
+      ],
+    });
+
+    const session = await getHandler(getOpenRegisterSession)(ctx as never, {
+      storeId: "store-1",
+      registerNumber: "A1",
+    });
+
+    expect(session).toBeNull();
+  });
+
+  it("still blocks opening a duplicate drawer while the latest session is closing", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildRegisterSession({
+          _id: "session-1",
+          status: "closing",
+        }),
+      ],
+    });
+
+    await expect(
+      getHandler(openRegisterSession)(ctx as never, {
+        storeId: "store-1",
+        organizationId: "org-1",
+        terminalId: "terminal-1",
+        registerNumber: "A1",
+        openingFloat: 5_000,
+      }),
+    ).rejects.toThrow("A register session is already open for this register.");
   });
 
   it("records a sale adjustment trace when register-session cash changes", async () => {

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -1,16 +1,23 @@
 import { internalMutation, internalQuery, MutationCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
+import {
+  isPosUsableRegisterSessionStatus,
+  isRegisterSessionConflictBlockingStatus,
+  type RegisterSessionStatus,
+} from "../../shared/registerSessionStatus";
 import { recordRegisterSessionTraceBestEffort } from "./registerSessionTracing";
 
-const REGISTER_SESSION_TRANSITIONS = {
-  active: new Set(["closing"]),
-  closed: new Set<string>(),
-  closing: new Set(["closed"]),
-  open: new Set(["active", "closing"]),
-} as const;
+const registerSessionStatusSet = (
+  ...statuses: RegisterSessionStatus[]
+): ReadonlySet<RegisterSessionStatus> => new Set(statuses);
 
-type RegisterSessionStatus = keyof typeof REGISTER_SESSION_TRANSITIONS;
+const REGISTER_SESSION_TRANSITIONS = {
+  active: registerSessionStatusSet("closing"),
+  closed: registerSessionStatusSet(),
+  closing: registerSessionStatusSet("closed"),
+  open: registerSessionStatusSet("active", "closing"),
+} satisfies Record<RegisterSessionStatus, ReadonlySet<RegisterSessionStatus>>;
 type RegisterSessionIdentity = {
   registerNumber?: string | null;
   terminalId?: Id<"posTerminal">;
@@ -290,7 +297,10 @@ async function findConflictingRegisterSession(
       .order("desc")
       .first();
 
-    if (latestByRegister && latestByRegister.status !== "closed") {
+    if (
+      latestByRegister &&
+      isRegisterSessionConflictBlockingStatus(latestByRegister.status)
+    ) {
       throw new Error("A register session is already open for this register.");
     }
   }
@@ -305,7 +315,10 @@ async function findConflictingRegisterSession(
     .order("desc")
     .first();
 
-  if (latestByTerminal && latestByTerminal.status !== "closed") {
+  if (
+    latestByTerminal &&
+    isRegisterSessionConflictBlockingStatus(latestByTerminal.status)
+  ) {
     throw new Error("A register session is already open for this terminal.");
   }
 }
@@ -374,7 +387,8 @@ export const getOpenRegisterSession = internalQuery({
         .order("desc")
         .first();
 
-      return latestByRegister && latestByRegister.status !== "closed"
+      return latestByRegister &&
+        isPosUsableRegisterSessionStatus(latestByRegister.status)
         ? latestByRegister
         : null;
     }
@@ -389,7 +403,8 @@ export const getOpenRegisterSession = internalQuery({
       .order("desc")
       .first();
 
-    return latestByTerminal && latestByTerminal.status !== "closed"
+    return latestByTerminal &&
+      isPosUsableRegisterSessionStatus(latestByTerminal.status)
       ? latestByTerminal
       : null;
   },

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -31,6 +31,7 @@ import {
   type PosSaleTraceSeed,
 } from "../../../workflowTraces/adapters/posSale";
 import { ok, userError, type CommandResult } from "../../../../shared/commandResult";
+import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 
 type PosPaymentInput = {
   method: string;
@@ -113,7 +114,7 @@ function registerSessionMatchesIdentity(
 }
 
 function isUsableRegisterSession(registerSession: { status: string }) {
-  return registerSession.status === "open" || registerSession.status === "active";
+  return isPosUsableRegisterSessionStatus(registerSession.status);
 }
 
 async function safeTraceWrite(

--- a/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
@@ -16,6 +16,7 @@ import {
   type PosSessionTraceStage,
   type PosSessionTraceableSession,
 } from "./posSessionTracing";
+import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 
 type CommandFailureStatus =
   | "cashierMismatch"
@@ -708,7 +709,7 @@ function normalizeRegisterNumber(registerNumber?: string | null) {
 function isActiveRegisterSession(
   registerSession: Pick<Doc<"registerSession">, "status">,
 ) {
-  return registerSession.status === "open" || registerSession.status === "active";
+  return isPosUsableRegisterSessionStatus(registerSession.status);
 }
 
 function registerSessionMatchesIdentity(

--- a/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
@@ -365,6 +365,41 @@ describe("createPosSessionCommandService", () => {
     expect(repository.sessions).toHaveLength(0);
   });
 
+  it("refuses to start a retail session with an explicitly closing drawer", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "closing",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).startSession({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      staffProfileId: "cashier-1",
+      registerNumber: "1",
+      registerSessionId: "drawer-1",
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message: "Open the cash drawer before starting a sale.",
+    });
+    expect(repository.sessions).toHaveLength(0);
+  });
+
   it("binds an active same-terminal session to an open drawer without holding or clearing it", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -14,7 +14,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 40 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 5 file(s); key children: OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx, ThemeContext.tsx, UserContext.tsx.
 - [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 74 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
-- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 6 file(s); key children: auth.ts, commandResult.test.ts, commandResult.ts, serviceIntake.ts, stockAdjustment.ts.
+- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 8 file(s); key children: auth.ts, commandResult.test.ts, commandResult.ts, registerSessionStatus.test.ts, registerSessionStatus.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 
 ## Backend and test surfaces

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -84,6 +84,7 @@ This index enumerates the current automated test files and ties them back to the
 ## Section `shared`
 
 - [`shared/commandResult.test.ts`](../../shared/commandResult.test.ts)
+- [`shared/registerSessionStatus.test.ts`](../../shared/registerSessionStatus.test.ts)
 
 ## Section `src`
 

--- a/packages/athena-webapp/shared/registerSessionStatus.test.ts
+++ b/packages/athena-webapp/shared/registerSessionStatus.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isCashControlVisibleRegisterSessionStatus,
+  isPosUsableRegisterSessionStatus,
+  isRegisterSessionConflictBlockingStatus,
+} from "./registerSessionStatus";
+
+describe("register session status policies", () => {
+  it.each([
+    ["open", true],
+    ["active", true],
+    ["closing", false],
+    ["closed", false],
+  ] as const)("classifies %s POS usability as %s", (status, expected) => {
+    expect(isPosUsableRegisterSessionStatus(status)).toBe(expected);
+  });
+
+  it.each([
+    ["open", true],
+    ["active", true],
+    ["closing", true],
+    ["closed", false],
+  ] as const)("classifies %s duplicate-drawer blocking as %s", (status, expected) => {
+    expect(isRegisterSessionConflictBlockingStatus(status)).toBe(expected);
+  });
+
+  it.each([
+    ["open", true],
+    ["active", true],
+    ["closing", true],
+    ["closed", false],
+  ] as const)("classifies %s cash-control visibility as %s", (status, expected) => {
+    expect(isCashControlVisibleRegisterSessionStatus(status)).toBe(expected);
+  });
+});

--- a/packages/athena-webapp/shared/registerSessionStatus.ts
+++ b/packages/athena-webapp/shared/registerSessionStatus.ts
@@ -1,0 +1,62 @@
+export const REGISTER_SESSION_STATUSES = [
+  "open",
+  "active",
+  "closing",
+  "closed",
+] as const;
+
+export type RegisterSessionStatus = (typeof REGISTER_SESSION_STATUSES)[number];
+
+export const POS_USABLE_REGISTER_SESSION_STATUSES = [
+  "open",
+  "active",
+] as const satisfies readonly RegisterSessionStatus[];
+
+export const REGISTER_SESSION_CONFLICT_BLOCKING_STATUSES = [
+  "open",
+  "active",
+  "closing",
+] as const satisfies readonly RegisterSessionStatus[];
+
+export const CASH_CONTROL_VISIBLE_REGISTER_SESSION_STATUSES =
+  REGISTER_SESSION_CONFLICT_BLOCKING_STATUSES;
+
+export function isRegisterSessionStatus(
+  status: unknown,
+): status is RegisterSessionStatus {
+  return (
+    typeof status === "string" &&
+    REGISTER_SESSION_STATUSES.includes(status as RegisterSessionStatus)
+  );
+}
+
+function includesRegisterSessionStatus(
+  statuses: readonly RegisterSessionStatus[],
+  status: unknown,
+) {
+  return (
+    typeof status === "string" &&
+    statuses.includes(status as RegisterSessionStatus)
+  );
+}
+
+export function isPosUsableRegisterSessionStatus(status: unknown): boolean {
+  return includesRegisterSessionStatus(
+    POS_USABLE_REGISTER_SESSION_STATUSES,
+    status,
+  );
+}
+
+export function isRegisterSessionConflictBlockingStatus(status: unknown): boolean {
+  return includesRegisterSessionStatus(
+    REGISTER_SESSION_CONFLICT_BLOCKING_STATUSES,
+    status,
+  );
+}
+
+export function isCashControlVisibleRegisterSessionStatus(status: unknown): boolean {
+  return includesRegisterSessionStatus(
+    CASH_CONTROL_VISIBLE_REGISTER_SESSION_STATUSES,
+    status,
+  );
+}

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -386,6 +386,38 @@ describe("useRegisterViewModel", () => {
     expect(mockStartSession).not.toHaveBeenCalled();
   });
 
+  it("holds bootstrap on a closing drawer and exposes the drawer gate", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closing",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+    });
+
+    expect(result.current.drawerGate).not.toBeNull();
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
   it("gates an active POS session without a register assignment while preserving the sale", async () => {
     mockRegisterState = {
       phase: "active",
@@ -414,6 +446,38 @@ describe("useRegisterViewModel", () => {
     expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
     expect(mockStartSession).not.toHaveBeenCalled();
     expect(mockResumeSession).not.toHaveBeenCalled();
+  });
+
+  it("gates an active POS session assigned to a closing drawer", async () => {
+    mockRegisterState = {
+      phase: "active",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closing",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: { _id: "session-1", sessionNumber: "POS-0001" },
+      resumableSession: null,
+    };
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+    });
+
+    expect(result.current.drawerGate).not.toBeNull();
+    expect(result.current.drawerGate?.mode).toBe("recovery");
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(mockStartSession).not.toHaveBeenCalled();
+    expect(mockBindSessionToRegisterSession).not.toHaveBeenCalled();
   });
 
   it("gates an active POS session assigned to a different open drawer", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -37,6 +37,7 @@ import { parseDisplayAmountInput } from "@/lib/pos/displayAmounts";
 import { logger } from "@/lib/logger";
 import { useConvexCommandGateway } from "@/lib/pos/infrastructure/convex/commandGateway";
 import { useConvexRegisterState } from "@/lib/pos/infrastructure/convex/registerGateway";
+import { isPosUsableRegisterSessionStatus } from "~/shared/registerSessionStatus";
 import {
   useConvexActiveSession,
   useConvexHeldSessions,
@@ -144,12 +145,17 @@ export function useRegisterViewModel(): RegisterViewModel {
     staffProfileId,
     registerNumber: registerNumberOverride,
   });
+  const usableActiveRegisterSession =
+    registerState?.activeRegisterSession &&
+    isPosUsableRegisterSessionStatus(registerState.activeRegisterSession.status)
+      ? registerState.activeRegisterSession
+      : null;
   const activeRegisterNumber =
     activeSession?.registerNumber ??
-    registerState?.activeRegisterSession?.registerNumber ??
+    usableActiveRegisterSession?.registerNumber ??
     registerState?.activeSession?.registerNumber ??
     registerState?.resumableSession?.registerNumber;
-  const activeRegisterSessionId = registerState?.activeRegisterSession?._id as
+  const activeRegisterSessionId = usableActiveRegisterSession?._id as
     | Id<"registerSession">
     | undefined;
   const registerNumber =
@@ -208,11 +214,11 @@ export function useRegisterViewModel(): RegisterViewModel {
     bootstrapState &&
       (bootstrapState.phase === "readyToStart" ||
         bootstrapState.phase === "resumable") &&
-      !bootstrapState.activeRegisterSession,
+      !usableActiveRegisterSession,
   );
   const hasMissingDrawerRecoveryState = Boolean(
     bootstrapState &&
-      !bootstrapState.activeRegisterSession &&
+      !usableActiveRegisterSession &&
       (bootstrapState.phase === "active" ||
         bootstrapState.phase === "resumable" ||
         hasActivePosSession),
@@ -870,9 +876,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           terminalId: terminal._id,
           staffProfileId,
           registerNumber: registerNumberOverride,
-          registerSessionId: bootstrapState.activeRegisterSession?._id as
-            | Id<"registerSession">
-            | undefined,
+          registerSessionId: activeRegisterSessionId,
         },
       });
 
@@ -883,6 +887,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     })();
   }, [
     activeStore?._id,
+    activeRegisterSessionId,
     bootstrapState,
     staffProfileId,
     isTransactionCompleted,


### PR DESCRIPTION
## Summary
- Centralizes register-session status semantics in `shared/registerSessionStatus` so POS usability, duplicate-drawer conflict checks, and cash-control visibility can no longer drift independently.
- Stops POS bootstrap/register lookup from treating `closing` register sessions as usable drawers while preserving duplicate-drawer blocking for `closing` sessions.
- Applies the shared POS-usable policy across session start, checkout sync, transaction completion, deposits, and payment allocation attribution.
- Adds regression coverage for `closing` sessions at the Convex lookup, POS bootstrap/view-model, command boundary, and shared policy levels.

## Linear
- V26-379

## Validation
- `bun run --filter '@athena/webapp' test -- shared/registerSessionStatus.test.ts convex/operations/registerSessions.trace.test.ts convex/pos/application/sessionCommands.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts convex/inventory/posSessions.trace.test.ts convex/pos/application/completeTransaction.test.ts convex/cashControls/paymentAllocationAttribution.test.ts convex/cashControls/deposits.test.ts src/components/cash-controls/CashControlsDashboard.test.tsx`
- `bun run --filter '@athena/webapp' build`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- Pre-push validation suite

## Review Gate
- Local code-review gate completed after implementation. Result: approved, no critical or important findings.
