### PR TITLE
[V26-380/V26-381]: Closeout-block POS drawer gate

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md
+++ b/docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md
@@ -63,10 +63,11 @@ For recovery, bind the preserved session to the newly opened drawer before allow
 
 - Treat UI gates as ergonomics, not authorization or invariant enforcement.
 - Define drawer status semantics once. POS sale mutation may use only `open` or `active`; duplicate drawer checks and cash-control closeout views may still need to include `closing`.
+- When POS can see a register session is already `closing`, render closeout guidance instead of the open-drawer form. The open-drawer command should remain a stale-client fallback, not the primary cashier path.
 - Add command-level tests for missing, closed, and mismatched drawer bindings whenever a POS mutation assumes an open drawer.
 - Reuse the same identity/status validation for start, resume, bind, item mutation, item removal, cart clear, payment sync, and completion flows.
 - Keep recovery flows idempotent: if the session is already bound to the same drawer, return success without mutating unrelated sale state.
 
 ## Related Issues
 
-- Linear: V26-373, V26-374, V26-375, V26-376, V26-377, V26-378, V26-379.
+- Linear: V26-373, V26-374, V26-375, V26-376, V26-377, V26-378, V26-379, V26-380, V26-381.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1500 files · ~0 words
+- 1501 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3803 nodes · 3357 edges · 1415 communities detected
+- 3805 nodes · 3358 edges · 1416 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1425,6 +1425,7 @@
 - [[_COMMUNITY_Community 1412|Community 1412]]
 - [[_COMMUNITY_Community 1413|Community 1413]]
 - [[_COMMUNITY_Community 1414|Community 1414]]
+- [[_COMMUNITY_Community 1415|Community 1415]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1829,16 +1830,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 94 - "Community 94"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 95 - "Community 95"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 96 - "Community 96"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 97 - "Community 97"
 Cohesion: 0.52
@@ -1909,16 +1910,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 114 - "Community 114"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 115 - "Community 115"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 116 - "Community 116"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 117 - "Community 117"
 Cohesion: 0.33
@@ -1929,52 +1930,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 119 - "Community 119"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 120 - "Community 120"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.4
 Nodes (2): hasCustomerDetails(), useRegisterViewModel()
+
+### Community 122 - "Community 122"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 123 - "Community 123"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 124 - "Community 124"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 125 - "Community 125"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 126 - "Community 126"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 127 - "Community 127"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 128 - "Community 128"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 129 - "Community 129"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 131 - "Community 131"
 Cohesion: 0.53
@@ -2641,12 +2642,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 297 - "Community 297"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
-
-### Community 298 - "Community 298"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 298 - "Community 298"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.67
@@ -2682,79 +2683,79 @@ Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 315 - "Community 315"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 316 - "Community 316"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 324 - "Community 324"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 325 - "Community 325"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.67
@@ -2782,11 +2783,11 @@ Nodes (0):
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.67
@@ -2801,16 +2802,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 337 - "Community 337"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 338 - "Community 338"
 Cohesion: 1.0
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 338 - "Community 338"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 339 - "Community 339"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 340 - "Community 340"
 Cohesion: 0.67
@@ -2818,63 +2819,63 @@ Nodes (0):
 
 ### Community 341 - "Community 341"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 343 - "Community 343"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 344 - "Community 344"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 345 - "Community 345"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 346 - "Community 346"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (1): manualChunks()
-
 ### Community 349 - "Community 349"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 351 - "Community 351"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 352 - "Community 352"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 353 - "Community 353"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 354 - "Community 354"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 355 - "Community 355"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.67
@@ -2885,12 +2886,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 358 - "Community 358"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 359 - "Community 359"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.67
@@ -2901,12 +2902,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 362 - "Community 362"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 363 - "Community 363"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 363 - "Community 363"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 364 - "Community 364"
 Cohesion: 0.67
@@ -2985,16 +2986,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 383 - "Community 383"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 384 - "Community 384"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 385 - "Community 385"
+### Community 384 - "Community 384"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 385 - "Community 385"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 1.0
@@ -3009,20 +3010,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 389 - "Community 389"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 392 - "Community 392"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 393 - "Community 393"
 Cohesion: 1.0
@@ -7112,238 +7113,240 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1415 - "Community 1415"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 392`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 393`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 394`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 395`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 396`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 397`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 398`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 399`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 400`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 401`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 402`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 403`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 404`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 405`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 406`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 407`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 408`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 409`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 410`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 411`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 412`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 413`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
+- **Thin community `Community 414`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 415`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 416`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 417`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 418`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 419`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 420`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 421`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 422`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 423`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 424`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 425`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 426`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 427`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 428`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 429`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 430`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 431`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 432`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 433`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 434`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 435`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 436`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 437`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 438`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
+- **Thin community `Community 439`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 440`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 441`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 442`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 443`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 444`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 445`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 446`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 447`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 448`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 449`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 450`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 451`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 452`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 453`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 454`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 455`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 456`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 457`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 458`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 459`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 460`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 461`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 462`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 463`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 464`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 465`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 466`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 467`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 468`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 469`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 470`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 471`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 472`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 473`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 474`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 475`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 476`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 477`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 478`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 479`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 480`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 481`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 482`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 483`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 484`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 485`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 486`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 487`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 488`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 489`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 490`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 491`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 492`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 493`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 494`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 495`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 496`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 497`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 498`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 499`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 500`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 501`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 502`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 503`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 504`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 505`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 506`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
+- **Thin community `Community 507`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 508`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -7985,1179 +7988,1181 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 827`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 828`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `catalog.ts`
+- **Thin community `Community 829`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `customers.ts`
+- **Thin community `Community 830`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `register.ts`
+- **Thin community `Community 831`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `terminals.ts`
+- **Thin community `Community 832`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `transactions.ts`
+- **Thin community `Community 833`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `schema.ts`
+- **Thin community `Community 834`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 835`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 836`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 837`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 838`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `category.ts`
+- **Thin community `Community 839`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `color.ts`
+- **Thin community `Community 840`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 841`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 842`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `index.ts`
+- **Thin community `Community 843`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 844`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `organization.ts`
+- **Thin community `Community 845`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 846`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `product.ts`
+- **Thin community `Community 847`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 848`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 849`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `store.ts`
+- **Thin community `Community 850`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 851`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `index.ts`
+- **Thin community `Community 852`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 853`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 854`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 855`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 856`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 857`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `index.ts`
+- **Thin community `Community 858`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 859`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 860`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 861`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 862`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 863`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 864`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 865`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 866`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 867`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `customer.ts`
+- **Thin community `Community 868`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 869`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 870`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 871`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 872`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `index.ts`
+- **Thin community `Community 873`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `posSession.ts`
+- **Thin community `Community 874`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 875`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 876`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 877`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 878`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `index.ts`
+- **Thin community `Community 879`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 880`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 881`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 882`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 883`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 884`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `index.ts`
+- **Thin community `Community 885`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 886`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 887`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 888`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 889`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `vendor.ts`
+- **Thin community `Community 890`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `analytics.ts`
+- **Thin community `Community 891`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `bag.ts`
+- **Thin community `Community 892`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 893`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 894`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 895`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `customer.ts`
+- **Thin community `Community 896`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `guest.ts`
+- **Thin community `Community 897`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `index.ts`
+- **Thin community `Community 898`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `offer.ts`
+- **Thin community `Community 899`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 900`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 901`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `review.ts`
+- **Thin community `Community 902`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `rewards.ts`
+- **Thin community `Community 903`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 904`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 905`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 906`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 907`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 908`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 909`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 910`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `bag.ts`
+- **Thin community `Community 911`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 912`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `customer.ts`
+- **Thin community `Community 913`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `guest.ts`
+- **Thin community `Community 914`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 915`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 916`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `payment.ts`
+- **Thin community `Community 917`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 918`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 919`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 920`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `users.ts`
+- **Thin community `Community 921`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `payment.ts`
+- **Thin community `Community 922`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `posSale.test.ts`
+- **Thin community `Community 923`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 924`** (1 nodes): `posSale.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 925`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 926`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 927`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `index.ts`
+- **Thin community `Community 928`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 929`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `auth.ts`
+- **Thin community `Community 930`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 931`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 932`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 933`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 934`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 935`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 936`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 937`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 938`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `constants.ts`
+- **Thin community `Community 939`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 940`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 941`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 942`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `types.ts`
+- **Thin community `Community 943`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 944`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 945`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 946`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 947`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 948`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 949`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 950`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 951`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `columns.tsx`
+- **Thin community `Community 952`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 953`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 954`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 955`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 956`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `columns.tsx`
+- **Thin community `Community 957`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 958`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 959`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `chart.tsx`
+- **Thin community `Community 960`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `columns.tsx`
+- **Thin community `Community 961`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 962`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 963`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `columns.tsx`
+- **Thin community `Community 964`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `constants.ts`
+- **Thin community `Community 965`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 966`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 967`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 968`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `data.ts`
+- **Thin community `Community 969`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `columns.tsx`
+- **Thin community `Community 970`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 971`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 972`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `columns.tsx`
+- **Thin community `Community 973`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 974`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 976`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 979`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 980`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `constants.ts`
+- **Thin community `Community 981`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 982`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 984`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data.ts`
+- **Thin community `Community 985`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 986`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 987`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 988`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 989`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 990`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `columns.tsx`
+- **Thin community `Community 991`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 992`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 994`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 995`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 996`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `columns.tsx`
+- **Thin community `Community 997`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `constants.ts`
+- **Thin community `Community 998`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 999`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1000`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1003`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1004`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1005`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1006`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1007`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1008`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1009`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1011`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1012`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1013`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1014`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1015`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1016`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1017`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1018`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1019`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1020`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `constants.ts`
+- **Thin community `Community 1021`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1022`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1023`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1024`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `data.ts`
+- **Thin community `Community 1025`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1026`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `constants.ts`
+- **Thin community `Community 1027`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1028`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1029`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1030`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1031`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `data.ts`
+- **Thin community `Community 1032`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1033`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `constants.ts`
+- **Thin community `Community 1034`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1035`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1036`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1037`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1038`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `data.ts`
+- **Thin community `Community 1039`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1040`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1041`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1042`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1043`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1044`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1045`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1046`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1047`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1048`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1049`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1050`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1051`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1052`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1053`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1054`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1055`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1056`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1057`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1058`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1059`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1060`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1061`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `WorkflowTraceLink.test.tsx`
+- **Thin community `Community 1062`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `types.ts`
+- **Thin community `Community 1063`** (1 nodes): `WorkflowTraceLink.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1064`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1065`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1066`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1067`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1068`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1069`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 1070`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1071`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1072`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1073`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1074`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1075`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1076`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1077`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1078`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1079`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1080`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1081`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1082`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data.ts`
+- **Thin community `Community 1083`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1084`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1085`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1086`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1087`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1088`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1090`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1091`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1092`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1093`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1094`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1095`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1096`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `constants.ts`
+- **Thin community `Community 1097`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1098`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1099`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1100`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `data.ts`
+- **Thin community `Community 1101`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `types.ts`
+- **Thin community `Community 1102`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1103`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1104`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1105`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1106`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `index.tsx`
+- **Thin community `Community 1107`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1108`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1109`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1110`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1111`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `index.tsx`
+- **Thin community `Community 1112`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1113`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1114`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1115`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `button.tsx`
+- **Thin community `Community 1116`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1117`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `card.tsx`
+- **Thin community `Community 1118`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1119`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1120`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `command.tsx`
+- **Thin community `Community 1121`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1122`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1123`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1124`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `form.tsx`
+- **Thin community `Community 1125`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1126`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1127`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `input.tsx`
+- **Thin community `Community 1128`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1129`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1130`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1131`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1132`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1133`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `select.tsx`
+- **Thin community `Community 1134`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1135`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1136`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1137`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `table.tsx`
+- **Thin community `Community 1138`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1139`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1140`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1141`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1142`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1143`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1144`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1145`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1146`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `constants.ts`
+- **Thin community `Community 1147`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1148`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1149`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1150`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `data.ts`
+- **Thin community `Community 1151`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1152`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1153`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1154`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1155`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1156`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1157`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1158`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1159`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1160`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1161`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1162`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1163`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1164`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `index.ts`
+- **Thin community `Community 1165`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `config.ts`
+- **Thin community `Community 1166`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1167`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1168`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1169`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1170`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1171`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `aws.ts`
+- **Thin community `Community 1172`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `constants.ts`
+- **Thin community `Community 1173`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `countries.ts`
+- **Thin community `Community 1174`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1175`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1176`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1177`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1178`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1179`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1180`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `dto.ts`
+- **Thin community `Community 1181`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `ports.ts`
+- **Thin community `Community 1182`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `constants.ts`
+- **Thin community `Community 1183`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1185`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `index.ts`
+- **Thin community `Community 1186`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `types.ts`
+- **Thin community `Community 1188`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1189`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1190`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1191`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1192`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `category.ts`
+- **Thin community `Community 1195`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `product.ts`
+- **Thin community `Community 1196`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `store.ts`
+- **Thin community `Community 1197`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1198`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `user.ts`
+- **Thin community `Community 1199`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1201`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1203`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1204`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `index.tsx`
+- **Thin community `Community 1205`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1206`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1207`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1208`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1209`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1210`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1211`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1212`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `index.tsx`
+- **Thin community `Community 1213`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1214`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1215`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1216`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `home.tsx`
+- **Thin community `Community 1217`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1218`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1219`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1220`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `index.tsx`
+- **Thin community `Community 1221`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1222`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1223`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1224`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1225`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `index.tsx`
+- **Thin community `Community 1226`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1227`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1228`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1229`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1230`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1231`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1233`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `index.tsx`
+- **Thin community `Community 1234`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1235`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1236`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1237`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1238`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1239`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1240`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `index.tsx`
+- **Thin community `Community 1241`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1242`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `new.tsx`
+- **Thin community `Community 1243`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `index.tsx`
+- **Thin community `Community 1244`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `new.tsx`
+- **Thin community `Community 1245`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1246`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1247`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `index.tsx`
+- **Thin community `Community 1248`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `new.tsx`
+- **Thin community `Community 1249`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `index.tsx`
+- **Thin community `Community 1250`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1251`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1252`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1253`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1254`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1255`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1256`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1257`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `index.tsx`
+- **Thin community `Community 1258`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1259`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1260`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1261`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1262`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1263`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1264`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1265`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1266`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1267`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1268`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1269`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1270`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1272`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1273`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1274`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1275`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1276`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `setup.ts`
+- **Thin community `Community 1277`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1278`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1279`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `types.ts`
+- **Thin community `Community 1280`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1281`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1282`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1283`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1284`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `types.ts`
+- **Thin community `Community 1286`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1287`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1288`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1289`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1291`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1292`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1294`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1295`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `schema.ts`
+- **Thin community `Community 1296`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1297`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1301`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1302`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1303`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1304`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1305`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `types.ts`
+- **Thin community `Community 1306`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1307`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1308`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1309`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1310`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1311`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1313`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `constants.ts`
+- **Thin community `Community 1314`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1315`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `About.tsx`
+- **Thin community `Community 1316`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1317`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1319`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1320`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1321`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1322`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1323`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1324`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1325`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `types.ts`
+- **Thin community `Community 1326`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1327`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1328`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1329`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1330`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1331`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1332`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1333`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1334`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1335`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1336`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `button.tsx`
+- **Thin community `Community 1337`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `card.tsx`
+- **Thin community `Community 1338`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1339`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `command.tsx`
+- **Thin community `Community 1340`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1341`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1342`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1343`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `form.tsx`
+- **Thin community `Community 1344`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1345`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1346`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1347`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1348`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `input.tsx`
+- **Thin community `Community 1349`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `label.tsx`
+- **Thin community `Community 1350`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1351`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1352`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1353`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `index.ts`
+- **Thin community `Community 1354`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `types.ts`
+- **Thin community `Community 1355`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1356`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1357`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1358`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1359`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `select.tsx`
+- **Thin community `Community 1360`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1361`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1362`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `table.tsx`
+- **Thin community `Community 1363`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1364`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1365`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1366`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1367`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1368`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `config.ts`
+- **Thin community `Community 1369`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1370`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1371`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1372`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `constants.ts`
+- **Thin community `Community 1373`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `countries.ts`
+- **Thin community `Community 1374`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1375`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1376`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1377`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1378`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `index.ts`
+- **Thin community `Community 1379`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `store.ts`
+- **Thin community `Community 1380`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `bag.ts`
+- **Thin community `Community 1381`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1382`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `category.ts`
+- **Thin community `Community 1383`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `organization.ts`
+- **Thin community `Community 1384`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `product.ts`
+- **Thin community `Community 1385`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `store.ts`
+- **Thin community `Community 1386`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1387`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `user.ts`
+- **Thin community `Community 1388`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `states.ts`
+- **Thin community `Community 1389`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1390`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1391`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1392`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1393`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1394`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1395`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1396`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `index.tsx`
+- **Thin community `Community 1397`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1398`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `index.tsx`
+- **Thin community `Community 1399`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1400`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1401`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1402`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1403`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1404`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `index.tsx`
+- **Thin community `Community 1405`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1406`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1407`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1408`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1409`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `index.js`
+- **Thin community `Community 1410`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1411`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1412`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1413`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1414`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1415`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9635,7 +9635,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L30",
+      "source_location": "L31",
       "target": "registersessions_trace_test_buildregistersession",
       "weight": 1
     },
@@ -9647,7 +9647,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L47",
+      "source_location": "L48",
       "target": "registersessions_trace_test_createmutationctx",
       "weight": 1
     },
@@ -9659,7 +9659,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L130",
+      "source_location": "L131",
       "target": "registersessions_trace_test_gethandler",
       "weight": 1
     },
@@ -9815,7 +9815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessions_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L505",
+      "source_location": "L544",
       "target": "registersessions_recordregistersessiondepositwithctx",
       "weight": 1
     },
@@ -18929,14 +18929,26 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "_tgt": "registerdrawergate_registerdrawergate",
+      "_tgt": "registerdrawergate_cashcontrolsbutton",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
       "source_location": "L11",
-      "target": "registerdrawergate_registerdrawergate",
+      "target": "registerdrawergate_cashcontrolsbutton",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "_tgt": "registerdrawergate_handlesubmit",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L44",
+      "target": "registerdrawergate_handlesubmit",
       "weight": 1
     },
     {
@@ -32279,7 +32291,7 @@
       "relation": "calls",
       "source": "registersessions_buildregistersessiondepositpatch",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L525",
+      "source_location": "L564",
       "target": "registersessions_recordregistersessiondepositwithctx",
       "weight": 1
     },
@@ -40127,7 +40139,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L199",
+      "source_location": "L204",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -41373,6 +41385,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -41380,7 +41401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -41389,7 +41410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -41398,7 +41419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -41407,7 +41428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -41416,7 +41437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -41425,7 +41446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -41434,7 +41455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -41443,21 +41464,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -41517,6 +41529,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -41524,7 +41545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -41533,7 +41554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -41542,7 +41563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -41551,7 +41572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -41560,7 +41581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -41569,7 +41590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -41578,7 +41599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -41587,21 +41608,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1"
     },
     {
@@ -41661,6 +41673,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
       "norm_label": "returnexchangeview.test.tsx",
@@ -41668,7 +41689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -41677,7 +41698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -41686,7 +41707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -41695,7 +41716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -41704,7 +41725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -41713,7 +41734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -41722,7 +41743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -41731,21 +41752,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -41805,6 +41817,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -41812,7 +41833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -41821,7 +41842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -41830,7 +41851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -41839,7 +41860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -41848,7 +41869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -41857,7 +41878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -41866,7 +41887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -41875,21 +41896,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -41949,6 +41961,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
       "norm_label": "memberscolumns.tsx",
@@ -41956,7 +41977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -41965,7 +41986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -41974,7 +41995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -41983,7 +42004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -41992,7 +42013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -42001,7 +42022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -42010,7 +42031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -42019,21 +42040,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
       "norm_label": "searchresultssection.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
-      "label": "SessionManager.test.tsx",
-      "norm_label": "sessionmanager.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
       "source_location": "L1"
     },
     {
@@ -42093,6 +42105,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
+      "label": "SessionManager.test.tsx",
+      "norm_label": "sessionmanager.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
       "norm_label": "sessionmanager.tsx",
@@ -42100,7 +42121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -42109,7 +42130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -42118,7 +42139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -42127,7 +42148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -42136,7 +42157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -42145,7 +42166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -42154,7 +42175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -42163,21 +42184,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
       "norm_label": "heldsessionslist.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
-      "label": "TransactionView.test.tsx",
-      "norm_label": "transactionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -42237,6 +42249,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
+      "label": "TransactionView.test.tsx",
+      "norm_label": "transactionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
       "norm_label": "transactionview.tsx",
@@ -42244,7 +42265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -42253,7 +42274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_test_tsx",
       "label": "WorkflowTraceLink.test.tsx",
@@ -42262,7 +42283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -42271,7 +42292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -42280,7 +42301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -42289,7 +42310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -42298,7 +42319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -42307,21 +42328,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
       "norm_label": "detailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1"
     },
     {
@@ -42381,6 +42393,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
       "norm_label": "productstatus.tsx",
@@ -42388,7 +42409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -42397,7 +42418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -42406,7 +42427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -42415,7 +42436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -42424,7 +42445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -42433,7 +42454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -42442,7 +42463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -42451,21 +42472,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -42525,6 +42537,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -42532,7 +42553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42541,7 +42562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42550,7 +42571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -42559,7 +42580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -42568,7 +42589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -42577,7 +42598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -42586,7 +42607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -42595,21 +42616,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
       "norm_label": "captured-emails-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
-      "label": "promoCodeMoney.test.ts",
-      "norm_label": "promocodemoney.test.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.test.ts",
       "source_location": "L1"
     },
     {
@@ -42669,6 +42681,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
+      "label": "promoCodeMoney.test.ts",
+      "norm_label": "promocodemoney.test.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -42676,7 +42697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -42685,7 +42706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42694,7 +42715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42703,7 +42724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42712,7 +42733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42721,7 +42742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -42730,7 +42751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -42739,21 +42760,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -42993,6 +43005,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -43000,7 +43021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -43009,7 +43030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -43018,7 +43039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -43027,7 +43048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -43036,7 +43057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -43045,7 +43066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -43054,7 +43075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -43063,21 +43084,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
       "norm_label": "fulfillmentview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
-      "label": "MaintenanceView.test.tsx",
-      "norm_label": "maintenanceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43137,6 +43149,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
+      "label": "MaintenanceView.test.tsx",
+      "norm_label": "maintenanceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
       "norm_label": "mtnmomoview.test.tsx",
@@ -43144,7 +43165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -43153,7 +43174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -43162,7 +43183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -43171,7 +43192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -43180,7 +43201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -43189,7 +43210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -43198,7 +43219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -43207,21 +43228,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
@@ -43281,6 +43293,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
       "norm_label": "collapsible.tsx",
@@ -43288,7 +43309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -43297,7 +43318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -43306,7 +43327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -43315,7 +43336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -43324,7 +43345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -43333,7 +43354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -43342,7 +43363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -43351,21 +43372,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
       "norm_label": "input.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -43425,6 +43437,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
       "norm_label": "popover.tsx",
@@ -43432,7 +43453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -43441,7 +43462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -43450,7 +43471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -43459,7 +43480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -43468,7 +43489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -43477,7 +43498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -43486,7 +43507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -43495,7 +43516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -43504,160 +43525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 114,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1140,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1142,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1143,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1144,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "label": "upload-button.tsx",
-      "norm_label": "upload-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1145,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "label": "BagView.tsx",
-      "norm_label": "bagview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1146,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1147,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -43666,7 +43534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -43675,7 +43543,7 @@
       "source_location": "L147"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -43684,7 +43552,7 @@
       "source_location": "L105"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -43693,7 +43561,7 @@
       "source_location": "L224"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -43702,7 +43570,7 @@
       "source_location": "L228"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -43711,97 +43579,97 @@
       "source_location": "L45"
     },
     {
-      "community": 1150,
+      "community": 1140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1144,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1145,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_upload_button_tsx",
+      "label": "upload-button.tsx",
+      "norm_label": "upload-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1146,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
+      "label": "BagView.tsx",
+      "norm_label": "bagview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1147,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1148,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1149,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -43810,7 +43678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -43819,7 +43687,7 @@
       "source_location": "L56"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -43828,7 +43696,7 @@
       "source_location": "L87"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -43837,7 +43705,7 @@
       "source_location": "L101"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -43846,7 +43714,7 @@
       "source_location": "L158"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -43855,97 +43723,97 @@
       "source_location": "L139"
     },
     {
-      "community": 1160,
+      "community": 1150,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "label": "LinkedAccounts.tsx",
-      "norm_label": "linkedaccounts.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1151,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "label": "TimelineEventCard.test.tsx",
-      "norm_label": "timelineeventcard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1153,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1154,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1155,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1156,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1157,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1158,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 1159,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
-      "label": "useAuth.test.tsx",
-      "norm_label": "useauth.test.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -43954,7 +43822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -43963,7 +43831,7 @@
       "source_location": "L42"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -43972,7 +43840,7 @@
       "source_location": "L32"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -43981,7 +43849,7 @@
       "source_location": "L62"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -43990,7 +43858,7 @@
       "source_location": "L101"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -43999,97 +43867,97 @@
       "source_location": "L10"
     },
     {
-      "community": 1170,
+      "community": 1160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
-      "label": "useExpenseSessions.test.ts",
-      "norm_label": "useexpensesessions.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1161,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
+      "label": "LinkedAccounts.tsx",
+      "norm_label": "linkedaccounts.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1162,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
+      "label": "TimelineEventCard.test.tsx",
+      "norm_label": "timelineeventcard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1163,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1164,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/src/lib/countries.ts",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1165,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
-      "label": "presentCommandToast.test.ts",
-      "norm_label": "presentcommandtoast.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1166,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
-      "label": "presentUnexpectedErrorToast.test.ts",
-      "norm_label": "presentunexpectederrortoast.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.test.ts",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1167,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
-      "label": "runCommand.test.ts",
-      "norm_label": "runcommand.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1168,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1169,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -44098,7 +43966,7 @@
       "source_location": "L173"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -44107,7 +43975,7 @@
       "source_location": "L71"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -44116,7 +43984,7 @@
       "source_location": "L251"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -44125,7 +43993,7 @@
       "source_location": "L36"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -44134,7 +44002,7 @@
       "source_location": "L277"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -44143,97 +44011,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1180,
+      "community": 1170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
-      "label": "bootstrapRegister.test.ts",
-      "norm_label": "bootstrapregister.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
+      "label": "useAuth.test.tsx",
+      "norm_label": "useauth.test.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1171,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
+      "label": "useExpenseSessions.test.ts",
+      "norm_label": "useexpensesessions.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1172,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1173,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1174,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1175,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
-      "label": "displayAmounts.test.ts",
-      "norm_label": "displayamounts.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
+      "id": "packages_athena_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/src/lib/countries.ts",
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1176,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
-      "label": "cart.test.ts",
-      "norm_label": "cart.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
+      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
+      "label": "presentCommandToast.test.ts",
+      "norm_label": "presentcommandtoast.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1177,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
+      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
+      "label": "presentUnexpectedErrorToast.test.ts",
+      "norm_label": "presentunexpectederrortoast.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1178,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
-      "label": "session.test.ts",
-      "norm_label": "session.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
+      "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
+      "label": "runCommand.test.ts",
+      "norm_label": "runcommand.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1179,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
       "source_location": "L1"
     },
     {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -44242,7 +44110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -44251,7 +44119,7 @@
       "source_location": "L107"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -44260,7 +44128,7 @@
       "source_location": "L63"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -44269,7 +44137,7 @@
       "source_location": "L80"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -44278,7 +44146,7 @@
       "source_location": "L46"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -44287,7 +44155,160 @@
       "source_location": "L97"
     },
     {
+      "community": 1180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "label": "bootstrapRegister.test.ts",
+      "norm_label": "bootstrapregister.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1185,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1186,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
+      "label": "cart.test.ts",
+      "norm_label": "cart.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
+      "label": "session.test.ts",
+      "norm_label": "session.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
+    },
+    {
       "community": 1190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -44296,7 +44317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -44305,7 +44326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -44314,7 +44335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -44323,7 +44344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -44332,7 +44353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -44341,7 +44362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -44350,7 +44371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -44359,21 +44380,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
@@ -44559,150 +44571,6 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 1200,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1201,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1203,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1204,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1205,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1206,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1207,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "label": "$storeUrlSlug.tsx",
-      "norm_label": "$storeurlslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
       "norm_label": "selectors.ts",
@@ -44710,7 +44578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -44719,7 +44587,7 @@
       "source_location": "L27"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -44728,7 +44596,7 @@
       "source_location": "L36"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -44737,7 +44605,7 @@
       "source_location": "L11"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -44746,7 +44614,7 @@
       "source_location": "L5"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -44755,97 +44623,97 @@
       "source_location": "L48"
     },
     {
-      "community": 1210,
+      "community": 1200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "label": "assets.index.tsx",
-      "norm_label": "assets.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1201,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "label": "bags.$bagId.tsx",
-      "norm_label": "bags.$bagid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1202,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1203,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1205,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1206,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1207,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1208,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1209,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
+      "label": "$storeUrlSlug.tsx",
+      "norm_label": "$storeurlslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1217,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "label": "logs.$logId.tsx",
-      "norm_label": "logs.$logid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "label": "useRegisterViewModel.ts",
@@ -44854,7 +44722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "useregisterviewmodel_createpaymentid",
       "label": "createPaymentId()",
@@ -44863,7 +44731,7 @@
       "source_location": "L85"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "useregisterviewmodel_hascustomerdetails",
       "label": "hasCustomerDetails()",
@@ -44872,7 +44740,7 @@
       "source_location": "L59"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "useregisterviewmodel_mapsessioncustomer",
       "label": "mapSessionCustomer()",
@@ -44881,7 +44749,7 @@
       "source_location": "L72"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "useregisterviewmodel_trimoptional",
       "label": "trimOptional()",
@@ -44890,7 +44758,7 @@
       "source_location": "L92"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "useregisterviewmodel_useregisterviewmodel",
       "label": "useRegisterViewModel()",
@@ -44899,97 +44767,97 @@
       "source_location": "L97"
     },
     {
-      "community": 1220,
+      "community": 1210,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "label": "members.index.tsx",
-      "norm_label": "members.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1211,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
+      "label": "assets.index.tsx",
+      "norm_label": "assets.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
+      "label": "bags.$bagId.tsx",
+      "norm_label": "bags.$bagid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1213,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1214,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1215,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1216,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "label": "all.index.tsx",
-      "norm_label": "all.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1217,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "label": "cancelled.index.tsx",
-      "norm_label": "cancelled.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1218,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1219,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
+      "label": "logs.$logId.tsx",
+      "norm_label": "logs.$logid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -44998,7 +44866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -45007,7 +44875,7 @@
       "source_location": "L171"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -45016,7 +44884,7 @@
       "source_location": "L302"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -45025,7 +44893,7 @@
       "source_location": "L319"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -45034,7 +44902,7 @@
       "source_location": "L312"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -45043,97 +44911,97 @@
       "source_location": "L293"
     },
     {
-      "community": 1230,
+      "community": 1220,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1221,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
+      "label": "members.index.tsx",
+      "norm_label": "members.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1222,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1233,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "label": "expense.index.tsx",
-      "norm_label": "expense.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1234,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1223,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1224,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
+      "label": "all.index.tsx",
+      "norm_label": "all.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1225,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
+      "label": "cancelled.index.tsx",
+      "norm_label": "cancelled.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1226,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1239,
+      "community": 1227,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 124,
+      "community": 1228,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1229,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -45142,7 +45010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -45151,7 +45019,7 @@
       "source_location": "L12"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -45160,7 +45028,7 @@
       "source_location": "L21"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -45169,7 +45037,7 @@
       "source_location": "L101"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -45178,7 +45046,7 @@
       "source_location": "L35"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -45187,97 +45055,97 @@
       "source_location": "L66"
     },
     {
-      "community": 1240,
+      "community": 1230,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1231,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1232,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1233,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1234,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
+      "label": "expense.index.tsx",
+      "norm_label": "expense.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1235,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1236,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1237,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1238,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1239,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1246,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -45286,7 +45154,7 @@
       "source_location": "L155"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -45295,7 +45163,7 @@
       "source_location": "L197"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -45304,7 +45172,7 @@
       "source_location": "L104"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -45313,7 +45181,7 @@
       "source_location": "L25"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -45322,7 +45190,7 @@
       "source_location": "L72"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -45331,97 +45199,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1250,
+      "community": 1240,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1242,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1243,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "label": "new.index.tsx",
-      "norm_label": "new.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1252,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
-      "label": "active-cases.index.tsx",
-      "norm_label": "active-cases.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
-      "label": "appointments.index.tsx",
-      "norm_label": "appointments.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1254,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1256,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
-      "label": "$traceId.test.tsx",
-      "norm_label": "$traceid.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1257,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1244,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
-      "label": "_authed.test.tsx",
-      "norm_label": "_authed.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 1245,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1246,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -45430,7 +45298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -45439,7 +45307,7 @@
       "source_location": "L231"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -45448,7 +45316,7 @@
       "source_location": "L167"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -45457,7 +45325,7 @@
       "source_location": "L116"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -45466,7 +45334,7 @@
       "source_location": "L83"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -45475,97 +45343,97 @@
       "source_location": "L29"
     },
     {
-      "community": 1260,
+      "community": 1250,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
-      "label": "join-team.index.tsx",
-      "norm_label": "join-team.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1251,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
-      "label": "_layout.index.test.tsx",
-      "norm_label": "_layout.index.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1252,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
-      "label": "_layout.test.tsx",
-      "norm_label": "_layout.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
+      "label": "new.index.tsx",
+      "norm_label": "new.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1253,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "label": "StoresSettingsAccordion.tsx",
-      "norm_label": "storessettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
+      "label": "active-cases.index.tsx",
+      "norm_label": "active-cases.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1254,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "label": "expenseStore.ts",
-      "norm_label": "expensestore.ts",
-      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
+      "label": "appointments.index.tsx",
+      "norm_label": "appointments.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1255,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1256,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1257,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
+      "label": "$traceId.test.tsx",
+      "norm_label": "$traceid.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1258,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 1259,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -45574,7 +45442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -45583,7 +45451,7 @@
       "source_location": "L83"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -45592,7 +45460,7 @@
       "source_location": "L62"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -45601,7 +45469,7 @@
       "source_location": "L95"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -45610,7 +45478,7 @@
       "source_location": "L41"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -45619,97 +45487,97 @@
       "source_location": "L12"
     },
     {
-      "community": 1270,
+      "community": 1260,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
-      "label": "AdminShell.stories.tsx",
-      "norm_label": "adminshell.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
+      "label": "_authed.test.tsx",
+      "norm_label": "_authed.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1261,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
-      "label": "admin-shell-patterns.test.tsx",
-      "norm_label": "admin-shell-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
+      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
+      "label": "join-team.index.tsx",
+      "norm_label": "join-team.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1262,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
-      "label": "Surfaces.stories.tsx",
-      "norm_label": "surfaces.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
+      "label": "_layout.index.test.tsx",
+      "norm_label": "_layout.index.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1263,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
+      "label": "_layout.test.tsx",
+      "norm_label": "_layout.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1264,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
+      "label": "StoresSettingsAccordion.tsx",
+      "norm_label": "storessettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1265,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "id": "packages_athena_webapp_src_stores_expensestore_ts",
+      "label": "expenseStore.ts",
+      "norm_label": "expensestore.ts",
+      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1266,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
-      "label": "reference-fixtures.test.tsx",
-      "norm_label": "reference-fixtures.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1267,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_test_setup_ts",
-      "label": "setup.ts",
-      "norm_label": "setup.ts",
-      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1268,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "label": "usePrint.test.ts",
-      "norm_label": "useprint.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1279,
+      "community": 1269,
       "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -45718,7 +45586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -45727,7 +45595,7 @@
       "source_location": "L4"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -45736,7 +45604,7 @@
       "source_location": "L49"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -45745,7 +45613,7 @@
       "source_location": "L34"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -45754,7 +45622,7 @@
       "source_location": "L74"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -45763,97 +45631,97 @@
       "source_location": "L6"
     },
     {
-      "community": 1280,
+      "community": 1270,
       "file_type": "code",
-      "id": "packages_athena_webapp_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/types.ts",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1271,
       "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
+      "label": "AdminShell.stories.tsx",
+      "norm_label": "adminshell.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1272,
       "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1273,
       "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
+      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
+      "label": "Surfaces.stories.tsx",
+      "norm_label": "surfaces.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1274,
       "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1275,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1276,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/api/types.ts",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1277,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "label": "HeartIconFilled.tsx",
-      "norm_label": "hearticonfilled.tsx",
-      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
+      "label": "reference-fixtures.test.tsx",
+      "norm_label": "reference-fixtures.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1278,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "id": "packages_athena_webapp_src_test_setup_ts",
+      "label": "setup.ts",
+      "norm_label": "setup.ts",
+      "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1"
     },
     {
-      "community": 1289,
+      "community": 1279,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "label": "usePrint.test.ts",
+      "norm_label": "useprint.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -45862,7 +45730,7 @@
       "source_location": "L173"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -45871,7 +45739,7 @@
       "source_location": "L102"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -45880,7 +45748,7 @@
       "source_location": "L201"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -45889,7 +45757,7 @@
       "source_location": "L150"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -45898,7 +45766,7 @@
       "source_location": "L155"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -45907,7 +45775,160 @@
       "source_location": "L1"
     },
     {
+      "community": 1280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1282,
+      "file_type": "code",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1283,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1284,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1285,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1286,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1287,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/api/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1288,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
+      "label": "HeartIconFilled.tsx",
+      "norm_label": "hearticonfilled.tsx",
+      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1289,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 1290,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -45916,7 +45937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -45925,7 +45946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -45934,7 +45955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -45943,7 +45964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -45952,7 +45973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -45961,7 +45982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -45970,7 +45991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -45979,21 +46000,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
       "norm_label": "checkoutstorage.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "label": "deliveryFees.test.ts",
-      "norm_label": "deliveryfees.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1"
     },
     {
@@ -46170,59 +46182,68 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 1300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
+      "label": "deliveryFees.test.ts",
+      "norm_label": "deliveryfees.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -46231,7 +46252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -46240,7 +46261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -46249,7 +46270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -46258,7 +46279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -46267,7 +46288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -46276,7 +46297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -46285,7 +46306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -46294,21 +46315,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
       "norm_label": "productfilterbar.tsx",
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
-      "label": "BestSellersSection.test.tsx",
-      "norm_label": "bestsellerssection.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
       "source_location": "L1"
     },
     {
@@ -46368,6 +46380,15 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
+      "label": "BestSellersSection.test.tsx",
+      "norm_label": "bestsellerssection.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
       "norm_label": "homehero.tsx",
@@ -46375,7 +46396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -46384,7 +46405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -46393,7 +46414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -46402,7 +46423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -46411,7 +46432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -46420,7 +46441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -46429,7 +46450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -46438,21 +46459,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
       "norm_label": "productactions.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "label": "ProductInfo.tsx",
-      "norm_label": "productinfo.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1"
     },
     {
@@ -46512,6 +46524,15 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
+      "label": "ProductInfo.tsx",
+      "norm_label": "productinfo.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
       "norm_label": "productreviews.tsx",
@@ -46519,7 +46540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -46528,7 +46549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -46537,7 +46558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -46546,7 +46567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -46555,7 +46576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -46564,7 +46585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -46573,7 +46594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -46582,21 +46603,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
       "norm_label": "savedicon.tsx",
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
-      "label": "CartIcon.tsx",
-      "norm_label": "carticon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1"
     },
     {
@@ -46656,6 +46668,15 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
+      "label": "CartIcon.tsx",
+      "norm_label": "carticon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
       "norm_label": "shoppingbag.test.tsx",
@@ -46663,7 +46684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -46672,7 +46693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -46681,7 +46702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -46690,7 +46711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -46699,7 +46720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -46708,7 +46729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -46717,7 +46738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -46726,21 +46747,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
@@ -46800,6 +46812,15 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
       "norm_label": "command.tsx",
@@ -46807,7 +46828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -46816,7 +46837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -46825,7 +46846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -46834,7 +46855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -46843,7 +46864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -46852,7 +46873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -46861,7 +46882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -46870,21 +46891,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
       "norm_label": "input-with-end-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
@@ -46935,6 +46947,15 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
       "norm_label": "label.tsx",
@@ -46942,7 +46963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -46951,7 +46972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -46960,7 +46981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -46969,7 +46990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -46978,7 +46999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -46987,7 +47008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -46996,7 +47017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -47005,21 +47026,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
@@ -47070,6 +47082,15 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
@@ -47077,7 +47098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -47086,7 +47107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -47095,7 +47116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -47104,7 +47125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -47113,7 +47134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -47122,7 +47143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -47131,7 +47152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -47140,21 +47161,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1"
     },
     {
@@ -47205,6 +47217,15 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
@@ -47212,7 +47233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -47221,7 +47242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -47230,7 +47251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -47239,7 +47260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -47248,7 +47269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -47257,7 +47278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -47266,7 +47287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -47275,21 +47296,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
       "norm_label": "maintenanceutils.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
       "source_location": "L1"
     },
     {
@@ -47340,6 +47352,15 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -47347,7 +47368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -47356,7 +47377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -47365,7 +47386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -47374,7 +47395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -47383,7 +47404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -47392,7 +47413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -47401,7 +47422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -47410,21 +47431,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_states_ts",
-      "label": "states.ts",
-      "norm_label": "states.ts",
-      "source_file": "packages/storefront-webapp/src/lib/states.ts",
       "source_location": "L1"
     },
     {
@@ -47475,6 +47487,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_states_ts",
+      "label": "states.ts",
+      "norm_label": "states.ts",
+      "source_file": "packages/storefront-webapp/src/lib/states.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
       "norm_label": "storefrontfailureobservability.test.ts",
@@ -47482,7 +47503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -47491,7 +47512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -47500,7 +47521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -47509,7 +47530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -47518,7 +47539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -47527,7 +47548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -47536,7 +47557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -47545,21 +47566,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
       "norm_label": "$subcategoryslug.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -47781,6 +47793,15 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
       "norm_label": "rewards.index.tsx",
@@ -47788,7 +47809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -47797,7 +47818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -47806,7 +47827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -47815,7 +47836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -47824,7 +47845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -47833,7 +47854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -47842,7 +47863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -47851,21 +47872,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
       "source_file": "packages/storefront-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/storefront-webapp/vitest.setup.ts",
       "source_location": "L1"
     },
     {
@@ -47916,6 +47928,15 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/storefront-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
       "norm_label": "index.js",
@@ -47923,7 +47944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -47932,7 +47953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -47941,7 +47962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -47950,7 +47971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -50926,7 +50947,7 @@
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L30"
+      "source_location": "L31"
     },
     {
       "community": 192,
@@ -50935,7 +50956,7 @@
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L47"
+      "source_location": "L48"
     },
     {
       "community": 192,
@@ -50944,7 +50965,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L130"
+      "source_location": "L131"
     },
     {
       "community": 193,
@@ -53671,7 +53692,7 @@
       "label": "recordRegisterSessionDepositWithCtx()",
       "norm_label": "recordregistersessiondepositwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L505"
+      "source_location": "L544"
     },
     {
       "community": 24,
@@ -55962,6 +55983,33 @@
     {
       "community": 295,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
+      "label": "RegisterDrawerGate.tsx",
+      "norm_label": "registerdrawergate.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "registerdrawergate_cashcontrolsbutton",
+      "label": "CashControlsButton()",
+      "norm_label": "cashcontrolsbutton()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "registerdrawergate_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 296,
+      "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
       "norm_label": "getsessioncartitemscount()",
@@ -55969,7 +56017,7 @@
       "source_location": "L36"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -55978,7 +56026,7 @@
       "source_location": "L32"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -55987,7 +56035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -55996,7 +56044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -56005,7 +56053,7 @@
       "source_location": "L20"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -56014,7 +56062,7 @@
       "source_location": "L26"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_tsx",
       "label": "WorkflowTraceLink.tsx",
@@ -56023,7 +56071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "workflowtracelink_getworkflowtracelinktarget",
       "label": "getWorkflowTraceLinkTarget()",
@@ -56032,7 +56080,7 @@
       "source_location": "L25"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "workflowtracelink_workflowtracelink",
       "label": "WorkflowTraceLink()",
@@ -56041,7 +56089,7 @@
       "source_location": "L36"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -56050,7 +56098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -56059,40 +56107,13 @@
       "source_location": "L65"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
       "norm_label": "productactionstogglegroup()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
-      "label": "ProductsTableContext.tsx",
-      "norm_label": "productstablecontext.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "productstablecontext_productstableprovider",
-      "label": "ProductsTableProvider()",
-      "norm_label": "productstableprovider()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "productstablecontext_useproductstablestate",
-      "label": "useProductsTableState()",
-      "norm_label": "useproductstablestate()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L60"
     },
     {
       "community": 3,
@@ -56502,6 +56523,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
+      "label": "ProductsTableContext.tsx",
+      "norm_label": "productstablecontext.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "productstablecontext_productstableprovider",
+      "label": "ProductsTableProvider()",
+      "norm_label": "productstableprovider()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "productstablecontext_useproductstablestate",
+      "label": "useProductsTableState()",
+      "norm_label": "useproductstablestate()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L60"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
       "norm_label": "storeproductsview.tsx",
@@ -56509,7 +56557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -56518,7 +56566,7 @@
       "source_location": "L45"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -56527,7 +56575,7 @@
       "source_location": "L19"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -56536,7 +56584,7 @@
       "source_location": "L128"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -56545,7 +56593,7 @@
       "source_location": "L40"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -56554,7 +56602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -56563,7 +56611,7 @@
       "source_location": "L24"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -56572,7 +56620,7 @@
       "source_location": "L20"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -56581,7 +56629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -56590,7 +56638,7 @@
       "source_location": "L25"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -56599,7 +56647,7 @@
       "source_location": "L17"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -56608,7 +56656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -56617,7 +56665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -56626,7 +56674,7 @@
       "source_location": "L59"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -56635,7 +56683,7 @@
       "source_location": "L50"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -56644,7 +56692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -56653,7 +56701,7 @@
       "source_location": "L225"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -56662,7 +56710,7 @@
       "source_location": "L80"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -56671,7 +56719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -56680,7 +56728,7 @@
       "source_location": "L127"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -56689,7 +56737,7 @@
       "source_location": "L71"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -56698,7 +56746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -56707,7 +56755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -56716,7 +56764,7 @@
       "source_location": "L3"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -56725,7 +56773,7 @@
       "source_location": "L9"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -56734,39 +56782,12 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "app_skeleton_appskeleton",
-      "label": "AppSkeleton()",
-      "norm_label": "appskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
-      "label": "app-skeleton.tsx",
-      "norm_label": "app-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
-      "label": "app-skeleton.tsx",
-      "norm_label": "app-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1"
     },
     {
@@ -56898,6 +56919,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "app_skeleton_appskeleton",
+      "label": "AppSkeleton()",
+      "norm_label": "appskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
+      "label": "app-skeleton.tsx",
+      "norm_label": "app-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
+      "label": "app-skeleton.tsx",
+      "norm_label": "app-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
       "norm_label": "dashboardskeleton()",
@@ -56905,7 +56953,7 @@
       "source_location": "L3"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -56914,7 +56962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -56923,7 +56971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -56932,7 +56980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -56941,7 +56989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -56950,7 +56998,7 @@
       "source_location": "L3"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -56959,7 +57007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -56968,7 +57016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -56977,7 +57025,7 @@
       "source_location": "L3"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -56986,7 +57034,7 @@
       "source_location": "L4"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -56995,7 +57043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -57004,7 +57052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -57013,7 +57061,7 @@
       "source_location": "L120"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -57022,7 +57070,7 @@
       "source_location": "L36"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -57031,7 +57079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -57040,7 +57088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -57049,7 +57097,7 @@
       "source_location": "L23"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -57058,7 +57106,7 @@
       "source_location": "L41"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -57067,7 +57115,7 @@
       "source_location": "L20"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -57076,7 +57124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -57085,7 +57133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -57094,7 +57142,7 @@
       "source_location": "L30"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -57103,7 +57151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -57112,7 +57160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -57121,7 +57169,7 @@
       "source_location": "L9"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -57130,39 +57178,12 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
       "norm_label": "loading-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "modal_onchange",
-      "label": "onChange()",
-      "norm_label": "onchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modal_tsx",
-      "label": "modal.tsx",
-      "norm_label": "modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
-      "label": "modal.tsx",
-      "norm_label": "modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1"
     },
     {
@@ -57294,6 +57315,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "modal_onchange",
+      "label": "onChange()",
+      "norm_label": "onchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modal_tsx",
+      "label": "modal.tsx",
+      "norm_label": "modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
+      "label": "modal.tsx",
+      "norm_label": "modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
       "norm_label": "alertmodal()",
@@ -57301,7 +57349,7 @@
       "source_location": "L20"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -57310,7 +57358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -57319,7 +57367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -57328,7 +57376,7 @@
       "source_location": "L12"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -57337,7 +57385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -57346,7 +57394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -57355,7 +57403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -57364,7 +57412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -57373,7 +57421,7 @@
       "source_location": "L3"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -57382,7 +57430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -57391,7 +57439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -57400,7 +57448,7 @@
       "source_location": "L6"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -57409,7 +57457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -57418,7 +57466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -57427,7 +57475,7 @@
       "source_location": "L3"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -57436,7 +57484,7 @@
       "source_location": "L44"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -57445,7 +57493,7 @@
       "source_location": "L19"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -57454,7 +57502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -57463,7 +57511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -57472,7 +57520,7 @@
       "source_location": "L159"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -57481,7 +57529,7 @@
       "source_location": "L195"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -57490,7 +57538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -57499,7 +57547,7 @@
       "source_location": "L22"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -57508,7 +57556,7 @@
       "source_location": "L45"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -57517,7 +57565,7 @@
       "source_location": "L24"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -57526,40 +57574,13 @@
       "source_location": "L38"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
       "norm_label": "onlineordercontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
-      "label": "PermissionsContext.tsx",
-      "norm_label": "permissionscontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "permissionscontext_permissionsprovider",
-      "label": "PermissionsProvider()",
-      "norm_label": "permissionsprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "permissionscontext_usepermissionscontext",
-      "label": "usePermissionsContext()",
-      "norm_label": "usepermissionscontext()",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L51"
     },
     {
       "community": 33,
@@ -57681,6 +57702,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
+      "label": "PermissionsContext.tsx",
+      "norm_label": "permissionscontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "permissionscontext_permissionsprovider",
+      "label": "PermissionsProvider()",
+      "norm_label": "permissionsprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "permissionscontext_usepermissionscontext",
+      "label": "usePermissionsContext()",
+      "norm_label": "usepermissionscontext()",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
       "norm_label": "productcontext.tsx",
@@ -57688,7 +57736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -57697,7 +57745,7 @@
       "source_location": "L54"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -57706,7 +57754,7 @@
       "source_location": "L282"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -57715,7 +57763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -57724,7 +57772,7 @@
       "source_location": "L12"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -57733,7 +57781,7 @@
       "source_location": "L37"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -57742,7 +57790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -57751,7 +57799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -57760,7 +57808,7 @@
       "source_location": "L4"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -57769,7 +57817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -57778,7 +57826,7 @@
       "source_location": "L9"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -57787,7 +57835,7 @@
       "source_location": "L50"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -57796,7 +57844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -57805,7 +57853,7 @@
       "source_location": "L6"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -57814,7 +57862,7 @@
       "source_location": "L31"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -57823,7 +57871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -57832,7 +57880,7 @@
       "source_location": "L5"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -57841,7 +57889,7 @@
       "source_location": "L31"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -57850,7 +57898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -57859,7 +57907,7 @@
       "source_location": "L19"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -57868,7 +57916,7 @@
       "source_location": "L33"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -57877,7 +57925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -57886,7 +57934,7 @@
       "source_location": "L18"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -57895,7 +57943,7 @@
       "source_location": "L26"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -57904,7 +57952,7 @@
       "source_location": "L7"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -57913,39 +57961,12 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
       "norm_label": "maintenanceutils.ts",
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "displayamounts_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "displayamounts_parsedisplayamountinput",
-      "label": "parseDisplayAmountInput()",
-      "norm_label": "parsedisplayamountinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
-      "label": "displayAmounts.ts",
-      "norm_label": "displayamounts.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
       "source_location": "L1"
     },
     {
@@ -58068,6 +58089,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "displayamounts_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "displayamounts_parsedisplayamountinput",
+      "label": "parseDisplayAmountInput()",
+      "norm_label": "parsedisplayamountinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "label": "displayAmounts.ts",
+      "norm_label": "displayamounts.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
       "norm_label": "useconvexcommandgateway()",
@@ -58075,7 +58123,7 @@
       "source_location": "L18"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -58084,7 +58132,7 @@
       "source_location": "L59"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -58093,7 +58141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -58102,7 +58150,7 @@
       "source_location": "L31"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -58111,7 +58159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -58120,7 +58168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -58129,7 +58177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -58138,7 +58186,7 @@
       "source_location": "L28"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -58147,7 +58195,7 @@
       "source_location": "L46"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -58156,7 +58204,7 @@
       "source_location": "L18"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -58165,7 +58213,7 @@
       "source_location": "L28"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -58174,7 +58222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -58183,7 +58231,7 @@
       "source_location": "L127"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -58192,7 +58240,7 @@
       "source_location": "L106"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -58201,7 +58249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -58210,7 +58258,7 @@
       "source_location": "L66"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -58219,7 +58267,7 @@
       "source_location": "L20"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -58228,7 +58276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -58237,7 +58285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -58246,7 +58294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -58255,7 +58303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -58264,7 +58312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -58273,7 +58321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -58282,7 +58330,7 @@
       "source_location": "L16"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -58291,7 +58339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -58300,40 +58348,13 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
       "norm_label": "manualchunks()",
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "vitest_setup_pointercapturestub",
-      "label": "pointerCaptureStub()",
-      "norm_label": "pointercapturestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "vitest_setup_pointerreleasestub",
-      "label": "pointerReleaseStub()",
-      "norm_label": "pointerreleasestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L24"
     },
     {
       "community": 35,
@@ -58455,6 +58476,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "vitest_setup_pointercapturestub",
+      "label": "pointerCaptureStub()",
+      "norm_label": "pointercapturestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "vitest_setup_pointerreleasestub",
+      "label": "pointerReleaseStub()",
+      "norm_label": "pointerreleasestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
       "norm_label": "logout()",
@@ -58462,7 +58510,7 @@
       "source_location": "L32"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -58471,7 +58519,7 @@
       "source_location": "L3"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -58480,7 +58528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -58489,7 +58537,7 @@
       "source_location": "L7"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -58498,7 +58546,7 @@
       "source_location": "L5"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -58507,7 +58555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -58516,7 +58564,7 @@
       "source_location": "L6"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -58525,7 +58573,7 @@
       "source_location": "L18"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -58534,7 +58582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -58543,7 +58591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -58552,7 +58600,7 @@
       "source_location": "L3"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -58561,7 +58609,7 @@
       "source_location": "L5"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -58570,7 +58618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -58579,7 +58627,7 @@
       "source_location": "L18"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -58588,7 +58636,7 @@
       "source_location": "L23"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -58597,7 +58645,7 @@
       "source_location": "L22"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -58606,7 +58654,7 @@
       "source_location": "L55"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -58615,7 +58663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -58624,7 +58672,7 @@
       "source_location": "L77"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -58633,7 +58681,7 @@
       "source_location": "L11"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -58642,7 +58690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -58651,7 +58699,7 @@
       "source_location": "L11"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -58660,7 +58708,7 @@
       "source_location": "L22"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -58669,7 +58717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -58678,7 +58726,7 @@
       "source_location": "L110"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -58687,39 +58735,12 @@
       "source_location": "L89"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
       "norm_label": "mobilebagsummary.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "checkoutstorage_loadcheckoutstate",
-      "label": "loadCheckoutState()",
-      "norm_label": "loadcheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "checkoutstorage_savecheckoutstate",
-      "label": "saveCheckoutState()",
-      "norm_label": "savecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "label": "checkoutStorage.ts",
-      "norm_label": "checkoutstorage.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1"
     },
     {
@@ -58842,6 +58863,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "checkoutstorage_loadcheckoutstate",
+      "label": "loadCheckoutState()",
+      "norm_label": "loadcheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "checkoutstorage_savecheckoutstate",
+      "label": "saveCheckoutState()",
+      "norm_label": "savecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
+      "label": "checkoutStorage.ts",
+      "norm_label": "checkoutstorage.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
       "norm_label": "enablecategories()",
@@ -58849,7 +58897,7 @@
       "source_location": "L131"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -58858,7 +58906,7 @@
       "source_location": "L12"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -58867,7 +58915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -58876,7 +58924,7 @@
       "source_location": "L20"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -58885,7 +58933,7 @@
       "source_location": "L46"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -58894,7 +58942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -58903,7 +58951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -58912,7 +58960,7 @@
       "source_location": "L20"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -58921,7 +58969,7 @@
       "source_location": "L59"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -58930,7 +58978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -58939,7 +58987,7 @@
       "source_location": "L25"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -58948,7 +58996,7 @@
       "source_location": "L20"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -58957,7 +59005,7 @@
       "source_location": "L30"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -58966,7 +59014,7 @@
       "source_location": "L95"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -58975,7 +59023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -58984,7 +59032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -58993,7 +59041,7 @@
       "source_location": "L61"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -59002,7 +59050,7 @@
       "source_location": "L65"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -59011,7 +59059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -59020,7 +59068,7 @@
       "source_location": "L150"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -59029,7 +59077,7 @@
       "source_location": "L157"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -59038,7 +59086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -59047,7 +59095,7 @@
       "source_location": "L63"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -59056,7 +59104,7 @@
       "source_location": "L48"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -59065,7 +59113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -59074,40 +59122,13 @@
       "source_location": "L63"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "label": "WelcomeBackModalForm.tsx",
-      "norm_label": "welcomebackmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L36"
     },
     {
       "community": 37,
@@ -59229,6 +59250,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
+      "label": "WelcomeBackModalForm.tsx",
+      "norm_label": "welcomebackmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
       "norm_label": "navigationbarprovider()",
@@ -59236,7 +59284,7 @@
       "source_location": "L16"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -59245,7 +59293,7 @@
       "source_location": "L39"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -59254,7 +59302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -59263,7 +59311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -59272,7 +59320,7 @@
       "source_location": "L25"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -59281,7 +59329,7 @@
       "source_location": "L82"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -59290,7 +59338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -59299,7 +59347,7 @@
       "source_location": "L20"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -59308,7 +59356,7 @@
       "source_location": "L55"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -59317,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -59326,7 +59374,7 @@
       "source_location": "L107"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -59335,7 +59383,7 @@
       "source_location": "L25"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -59344,7 +59392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -59353,7 +59401,7 @@
       "source_location": "L556"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -59362,7 +59410,7 @@
       "source_location": "L52"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -59371,7 +59419,7 @@
       "source_location": "L429"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -59380,7 +59428,7 @@
       "source_location": "L102"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -59389,7 +59437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -59398,7 +59446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -59407,7 +59455,7 @@
       "source_location": "L250"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -59416,7 +59464,7 @@
       "source_location": "L46"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -59425,7 +59473,7 @@
       "source_location": "L17"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -59434,7 +59482,7 @@
       "source_location": "L63"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -59443,7 +59491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -59452,7 +59500,7 @@
       "source_location": "L47"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -59461,40 +59509,13 @@
       "source_location": "L141"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
       "norm_label": "login.tsx",
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "label": "verify.index.tsx",
-      "norm_label": "verify.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "verify_index_verify",
-      "label": "Verify()",
-      "norm_label": "verify()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "verify_index_verifycheckoutsessionpayment",
-      "label": "VerifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L107"
     },
     {
       "community": 38,
@@ -59607,6 +59628,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
+      "label": "verify.index.tsx",
+      "norm_label": "verify.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "verify_index_verify",
+      "label": "Verify()",
+      "norm_label": "verify()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "verify_index_verifycheckoutsessionpayment",
+      "label": "VerifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
       "norm_label": "signup.tsx",
@@ -59614,7 +59662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -59623,7 +59671,7 @@
       "source_location": "L161"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -59632,7 +59680,7 @@
       "source_location": "L66"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -59641,7 +59689,7 @@
       "source_location": "L11"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -59650,7 +59698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -59659,7 +59707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -59668,7 +59716,7 @@
       "source_location": "L16"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -59677,7 +59725,7 @@
       "source_location": "L10"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -59686,7 +59734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59695,7 +59743,7 @@
       "source_location": "L17"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -59704,7 +59752,7 @@
       "source_location": "L11"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -59713,7 +59761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -59722,7 +59770,7 @@
       "source_location": "L21"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -59731,7 +59779,7 @@
       "source_location": "L15"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -59740,7 +59788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59749,7 +59797,7 @@
       "source_location": "L48"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -59758,7 +59806,7 @@
       "source_location": "L42"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -59767,7 +59815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59776,7 +59824,7 @@
       "source_location": "L16"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -59785,7 +59833,7 @@
       "source_location": "L10"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -59794,7 +59842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59803,7 +59851,7 @@
       "source_location": "L19"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -59812,7 +59860,7 @@
       "source_location": "L13"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -59821,7 +59869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59830,7 +59878,7 @@
       "source_location": "L16"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -59839,39 +59887,12 @@
       "source_location": "L10"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
       "norm_label": "harness-self-review.test.ts",
       "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "harness_test_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "harness_test_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "scripts_harness_test_test_ts",
-      "label": "harness-test.test.ts",
-      "norm_label": "harness-test.test.ts",
-      "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
     },
     {
@@ -59985,6 +60006,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "harness_test_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "harness_test_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "scripts_harness_test_test_ts",
+      "label": "harness-test.test.ts",
+      "norm_label": "harness-test.test.ts",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
       "norm_label": "log()",
@@ -59992,7 +60040,7 @@
       "source_location": "L26"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -60001,7 +60049,7 @@
       "source_location": "L18"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -60010,7 +60058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -60019,7 +60067,7 @@
       "source_location": "L45"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -60028,7 +60076,7 @@
       "source_location": "L20"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -60037,7 +60085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -60046,7 +60094,7 @@
       "source_location": "L8"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -60055,7 +60103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -60064,7 +60112,7 @@
       "source_location": "L9"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -60073,7 +60121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -60082,7 +60130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60091,7 +60139,7 @@
       "source_location": "L12"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -60100,7 +60148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -60109,7 +60157,7 @@
       "source_location": "L8"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -60118,7 +60166,7 @@
       "source_location": "L10"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -60127,7 +60175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -60136,7 +60184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -60145,7 +60193,7 @@
       "source_location": "L18"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -60154,31 +60202,13 @@
       "source_location": "L10"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
       "norm_label": "mtnmomo.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
-      "label": "routerComposition.test.ts",
-      "norm_label": "routercomposition.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "routercomposition_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
-      "source_location": "L6"
     },
     {
       "community": 4,
@@ -60534,6 +60564,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
+      "label": "routerComposition.test.ts",
+      "norm_label": "routercomposition.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "routercomposition_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
       "norm_label": "mapathenaauthsyncerror()",
@@ -60541,7 +60589,7 @@
       "source_location": "L110"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -60550,7 +60598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -60559,7 +60607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60568,7 +60616,7 @@
       "source_location": "L8"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -60577,7 +60625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -60586,7 +60634,7 @@
       "source_location": "L22"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -60595,7 +60643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60604,7 +60652,7 @@
       "source_location": "L6"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -60613,7 +60661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -60622,7 +60670,7 @@
       "source_location": "L29"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -60631,7 +60679,7 @@
       "source_location": "L22"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -60640,7 +60688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -60649,7 +60697,7 @@
       "source_location": "L4"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -60658,7 +60706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -60667,7 +60715,7 @@
       "source_location": "L3"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -60676,7 +60724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -60685,30 +60733,12 @@
       "source_location": "L3"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
       "norm_label": "openai.ts",
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "foundation_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
-      "label": "foundation.test.ts",
-      "norm_label": "foundation.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L1"
     },
     {
@@ -60813,6 +60843,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "foundation_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
+      "label": "foundation.test.ts",
+      "norm_label": "foundation.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
       "norm_label": "buildapprovalrequest()",
@@ -60820,7 +60868,7 @@
       "source_location": "L3"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -60829,7 +60877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -60838,7 +60886,7 @@
       "source_location": "L19"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -60847,7 +60895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -60856,7 +60904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -60865,7 +60913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -60874,7 +60922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -60883,7 +60931,7 @@
       "source_location": "L17"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -60892,7 +60940,7 @@
       "source_location": "L9"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -60901,7 +60949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -60910,7 +60958,7 @@
       "source_location": "L31"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -60919,7 +60967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -60928,7 +60976,7 @@
       "source_location": "L6"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -60937,7 +60985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -60946,7 +60994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -60955,7 +61003,7 @@
       "source_location": "L88"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -60964,30 +61012,12 @@
       "source_location": "L9"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "modulewiring_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
-      "label": "moduleWiring.test.ts",
-      "norm_label": "modulewiring.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
       "source_location": "L1"
     },
     {
@@ -61092,6 +61122,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "modulewiring_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
+      "label": "moduleWiring.test.ts",
+      "norm_label": "modulewiring.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
       "norm_label": "createstockopsaccessqueryctx()",
@@ -61099,7 +61147,7 @@
       "source_location": "L15"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -61108,7 +61156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -61117,7 +61165,7 @@
       "source_location": "L7"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -61126,7 +61174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -61135,7 +61183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -61144,7 +61192,7 @@
       "source_location": "L8"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -61153,7 +61201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -61162,7 +61210,7 @@
       "source_location": "L5"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -61171,7 +61219,7 @@
       "source_location": "L15"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -61180,7 +61228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -61189,7 +61237,7 @@
       "source_location": "L8"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -61198,7 +61246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -61207,7 +61255,7 @@
       "source_location": "L17"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -61216,7 +61264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61225,7 +61273,7 @@
       "source_location": "L6"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -61234,7 +61282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -61243,30 +61291,12 @@
       "source_location": "L5"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
       "norm_label": "customerengagementevents.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "onlineorderitem_updateonlineorderitem",
-      "label": "updateOnlineOrderItem()",
-      "norm_label": "updateonlineorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
     },
     {
@@ -61371,6 +61401,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "onlineorderitem_updateonlineorderitem",
+      "label": "updateOnlineOrderItem()",
+      "norm_label": "updateonlineorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -61378,7 +61426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -61387,7 +61435,7 @@
       "source_location": "L19"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -61396,7 +61444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -61405,7 +61453,7 @@
       "source_location": "L7"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -61414,7 +61462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -61423,7 +61471,7 @@
       "source_location": "L14"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -61432,7 +61480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -61441,7 +61489,7 @@
       "source_location": "L8"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -61450,7 +61498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -61459,7 +61507,7 @@
       "source_location": "L3"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -61468,7 +61516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -61477,7 +61525,7 @@
       "source_location": "L5"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -61486,7 +61534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -61495,7 +61543,7 @@
       "source_location": "L16"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -61504,7 +61552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -61513,7 +61561,7 @@
       "source_location": "L30"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_ts",
       "label": "posSale.ts",
@@ -61522,30 +61570,12 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "possale_buildpossaletraceseed",
       "label": "buildPosSaleTraceSeed()",
       "norm_label": "buildpossaletraceseed()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSale.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "possession_buildpossessiontraceseed",
-      "label": "buildPosSessionTraceSeed()",
-      "norm_label": "buildpossessiontraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
       "source_location": "L43"
     },
     {
@@ -61650,6 +61680,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "possession_buildpossessiontraceseed",
+      "label": "buildPosSessionTraceSeed()",
+      "norm_label": "buildpossessiontraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
       "norm_label": "presentation.ts",
@@ -61657,7 +61705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -61666,7 +61714,7 @@
       "source_location": "L31"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -61675,7 +61723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -61684,7 +61732,7 @@
       "source_location": "L5"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -61693,7 +61741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -61702,7 +61750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -61711,7 +61759,7 @@
       "source_location": "L7"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -61720,7 +61768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -61729,7 +61777,7 @@
       "source_location": "L12"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -61738,7 +61786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -61747,7 +61795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -61756,7 +61804,7 @@
       "source_location": "L11"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -61765,7 +61813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -61774,7 +61822,7 @@
       "source_location": "L11"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -61783,7 +61831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -61792,7 +61840,7 @@
       "source_location": "L3"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -61801,31 +61849,13 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
       "norm_label": "storeactions()",
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storedropdown_tsx",
-      "label": "StoreDropdown.tsx",
-      "norm_label": "storedropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "storedropdown_storedropdown",
-      "label": "StoreDropdown()",
-      "norm_label": "storedropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
-      "source_location": "L42"
     },
     {
       "community": 45,
@@ -61929,6 +61959,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storedropdown_tsx",
+      "label": "StoreDropdown.tsx",
+      "norm_label": "storedropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "storedropdown_storedropdown",
+      "label": "StoreDropdown()",
+      "norm_label": "storedropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
       "norm_label": "storeview.tsx",
@@ -61936,7 +61984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -61945,7 +61993,7 @@
       "source_location": "L13"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -61954,7 +62002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -61963,7 +62011,7 @@
       "source_location": "L42"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -61972,7 +62020,7 @@
       "source_location": "L31"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -61981,7 +62029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -61990,7 +62038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -61999,7 +62047,7 @@
       "source_location": "L10"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -62008,7 +62056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -62017,7 +62065,7 @@
       "source_location": "L14"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -62026,7 +62074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -62035,7 +62083,7 @@
       "source_location": "L5"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -62044,7 +62092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -62053,7 +62101,7 @@
       "source_location": "L10"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -62062,7 +62110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -62071,7 +62119,7 @@
       "source_location": "L15"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -62080,31 +62128,13 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
       "norm_label": "productpage()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "copyimagesview_setisupdatingsku",
-      "label": "setIsUpdatingSku()",
-      "norm_label": "setisupdatingsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
-      "label": "CopyImagesView.tsx",
-      "norm_label": "copyimagesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 46,
@@ -62199,6 +62229,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "copyimagesview_setisupdatingsku",
+      "label": "setIsUpdatingSku()",
+      "norm_label": "setisupdatingsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
+      "label": "CopyImagesView.tsx",
+      "norm_label": "copyimagesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
       "norm_label": "product-variant-columns.tsx",
@@ -62206,7 +62254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -62215,7 +62263,7 @@
       "source_location": "L47"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -62224,7 +62272,7 @@
       "source_location": "L151"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -62233,7 +62281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -62242,7 +62290,7 @@
       "source_location": "L6"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -62251,7 +62299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -62260,7 +62308,7 @@
       "source_location": "L19"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -62269,7 +62317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -62278,7 +62326,7 @@
       "source_location": "L7"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -62287,7 +62335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -62296,7 +62344,7 @@
       "source_location": "L42"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -62305,7 +62353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -62314,7 +62362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -62323,7 +62371,7 @@
       "source_location": "L66"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -62332,7 +62380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -62341,7 +62389,7 @@
       "source_location": "L18"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -62350,30 +62398,12 @@
       "source_location": "L6"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
       "norm_label": "logitems.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "logview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
-      "label": "LogView.tsx",
-      "norm_label": "logview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1"
     },
     {
@@ -62469,6 +62499,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "logview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
+      "label": "LogView.tsx",
+      "norm_label": "logview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -62476,7 +62524,7 @@
       "source_location": "L27"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -62485,7 +62533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -62494,7 +62542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -62503,7 +62551,7 @@
       "source_location": "L12"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -62512,7 +62560,7 @@
       "source_location": "L3"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -62521,7 +62569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -62530,7 +62578,7 @@
       "source_location": "L5"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -62539,7 +62587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -62548,7 +62596,7 @@
       "source_location": "L49"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -62557,7 +62605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -62566,7 +62614,7 @@
       "source_location": "L23"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -62575,7 +62623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -62584,7 +62632,7 @@
       "source_location": "L50"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -62593,7 +62641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -62602,7 +62650,7 @@
       "source_location": "L13"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -62611,7 +62659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -62620,30 +62668,12 @@
       "source_location": "L11"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
       "norm_label": "checkoutsesssionsview.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "expensecompletion_expensecompletion",
-      "label": "ExpenseCompletion()",
-      "norm_label": "expensecompletion()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "label": "ExpenseCompletion.tsx",
-      "norm_label": "expensecompletion.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1"
     },
     {
@@ -62739,6 +62769,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "expensecompletion_expensecompletion",
+      "label": "ExpenseCompletion()",
+      "norm_label": "expensecompletion()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
+      "label": "ExpenseCompletion.tsx",
+      "norm_label": "expensecompletion.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
       "norm_label": "handleaddbestseller()",
@@ -62746,7 +62794,7 @@
       "source_location": "L29"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -62755,7 +62803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -62764,7 +62812,7 @@
       "source_location": "L37"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -62773,7 +62821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -62782,7 +62830,7 @@
       "source_location": "L25"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -62791,7 +62839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -62800,7 +62848,7 @@
       "source_location": "L83"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -62809,7 +62857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -62818,7 +62866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -62827,7 +62875,7 @@
       "source_location": "L35"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -62836,7 +62884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -62845,7 +62893,7 @@
       "source_location": "L28"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -62854,7 +62902,7 @@
       "source_location": "L12"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -62863,7 +62911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -62872,7 +62920,7 @@
       "source_location": "L13"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -62881,7 +62929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -62890,30 +62938,12 @@
       "source_location": "L43"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
       "norm_label": "emailstatusview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1"
     },
     {
@@ -63009,6 +63039,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
       "norm_label": "gettimefilter()",
@@ -63016,7 +63064,7 @@
       "source_location": "L35"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -63025,7 +63073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -63034,7 +63082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -63043,7 +63091,7 @@
       "source_location": "L81"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -63052,7 +63100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -63061,7 +63109,7 @@
       "source_location": "L6"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -63070,7 +63118,7 @@
       "source_location": "L34"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -63079,7 +63127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -63088,7 +63136,7 @@
       "source_location": "L89"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -63097,7 +63145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -63106,7 +63154,7 @@
       "source_location": "L8"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -63115,7 +63163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -63124,7 +63172,7 @@
       "source_location": "L5"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -63133,7 +63181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -63142,7 +63190,7 @@
       "source_location": "L7"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -63151,7 +63199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -63160,31 +63208,13 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
       "norm_label": "pininput()",
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L35"
     },
     {
       "community": 5,
@@ -63531,6 +63561,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
       "norm_label": "printinstructions.tsx",
@@ -63538,7 +63586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -63547,7 +63595,7 @@
       "source_location": "L3"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -63556,7 +63604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -63565,7 +63613,7 @@
       "source_location": "L14"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -63574,7 +63622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -63583,7 +63631,7 @@
       "source_location": "L86"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -63592,7 +63640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -63601,7 +63649,7 @@
       "source_location": "L15"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -63610,7 +63658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -63619,7 +63667,7 @@
       "source_location": "L14"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -63628,7 +63676,7 @@
       "source_location": "L18"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -63637,7 +63685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -63646,31 +63694,13 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
       "norm_label": "registercustomerpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
-      "label": "RegisterDrawerGate.tsx",
-      "norm_label": "registerdrawergate.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "registerdrawergate_registerdrawergate",
-      "label": "RegisterDrawerGate()",
-      "norm_label": "registerdrawergate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
-      "source_location": "L11"
     },
     {
       "community": 508,
@@ -71712,19 +71742,19 @@
     {
       "community": 828,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
-      "label": "sessionCommandRepository.test.ts",
-      "norm_label": "sessioncommandrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
+      "label": "registerSessionRepository.test.ts",
+      "norm_label": "registersessionrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts",
       "source_location": "L1"
     },
     {
       "community": 829,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
+      "label": "sessionCommandRepository.test.ts",
+      "norm_label": "sessioncommandrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts",
       "source_location": "L1"
     },
     {
@@ -71793,6 +71823,15 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
       "norm_label": "customers.ts",
@@ -71800,7 +71839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -71809,7 +71848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -71818,7 +71857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -71827,7 +71866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -71836,7 +71875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -71845,7 +71884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -71854,7 +71893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71863,21 +71902,12 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
       "norm_label": "bestseller.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
       "source_location": "L1"
     },
     {
@@ -71946,6 +71976,15 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
@@ -71953,7 +71992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -71962,7 +72001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -71971,7 +72010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -71980,7 +72019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -71989,7 +72028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -71998,7 +72037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -72007,7 +72046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -72016,21 +72055,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
-      "label": "redeemedPromoCode.ts",
-      "norm_label": "redeemedpromocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1"
     },
     {
@@ -72099,6 +72129,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
+      "label": "redeemedPromoCode.ts",
+      "norm_label": "redeemedpromocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -72106,7 +72145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -72115,7 +72154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -72124,7 +72163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -72133,7 +72172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -72142,7 +72181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -72151,7 +72190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -72160,7 +72199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -72169,21 +72208,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
-      "label": "inventoryMovement.ts",
-      "norm_label": "inventorymovement.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
       "source_location": "L1"
     },
     {
@@ -72252,6 +72282,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
+      "label": "inventoryMovement.ts",
+      "norm_label": "inventorymovement.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
       "norm_label": "operationalevent.ts",
@@ -72259,7 +72298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -72268,7 +72307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -72277,7 +72316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -72286,7 +72325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -72295,7 +72334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -72304,7 +72343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -72313,7 +72352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -72322,21 +72361,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
-      "label": "expenseSession.ts",
-      "norm_label": "expensesession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1"
     },
     {
@@ -72405,6 +72435,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
+      "label": "expenseSession.ts",
+      "norm_label": "expensesession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
       "norm_label": "expensesessionitem.ts",
@@ -72412,7 +72451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -72421,7 +72460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -72430,7 +72469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -72439,7 +72478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -72448,7 +72487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -72457,7 +72496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -72466,7 +72505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -72475,21 +72514,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
       "norm_label": "postransactionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
       "source_location": "L1"
     },
     {
@@ -72558,6 +72588,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
       "norm_label": "serviceappointment.ts",
@@ -72565,7 +72604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -72574,7 +72613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -72583,7 +72622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -72592,7 +72631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -72601,7 +72640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -72610,7 +72649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -72619,7 +72658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -72628,21 +72667,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
       "norm_label": "receivingbatch.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
-      "label": "stockAdjustmentBatch.ts",
-      "norm_label": "stockadjustmentbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
       "source_location": "L1"
     },
     {
@@ -72711,6 +72741,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
+      "label": "stockAdjustmentBatch.ts",
+      "norm_label": "stockadjustmentbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
       "norm_label": "vendor.ts",
@@ -72718,7 +72757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -72727,7 +72766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -72736,7 +72775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -72745,7 +72784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -72754,7 +72793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -72763,7 +72802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -72772,7 +72811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -72781,21 +72820,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "label": "offer.ts",
-      "norm_label": "offer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1"
     },
     {
@@ -73053,6 +73083,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
+      "label": "offer.ts",
+      "norm_label": "offer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
@@ -73060,7 +73099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -73069,7 +73108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -73078,7 +73117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -73087,7 +73126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -73096,7 +73135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -73105,7 +73144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -73114,7 +73153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -73123,21 +73162,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
       "norm_label": "storefrontverificationcode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
       "source_location": "L1"
     },
     {
@@ -73206,6 +73236,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
       "norm_label": "catalogappointments.test.ts",
@@ -73213,7 +73252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -73222,7 +73261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -73231,7 +73270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -73240,7 +73279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -73249,7 +73288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -73258,7 +73297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -73267,7 +73306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -73276,21 +73315,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
       "norm_label": "paystackactions.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
       "source_location": "L1"
     },
     {
@@ -73359,6 +73389,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
@@ -73366,7 +73405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -73375,7 +73414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -73384,7 +73423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_test_ts",
       "label": "posSale.test.ts",
@@ -73393,7 +73432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -73402,7 +73441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -73411,7 +73450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -73420,7 +73459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -73429,21 +73468,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
@@ -73512,6 +73542,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -73519,7 +73558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -73528,7 +73567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -73537,7 +73576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -73546,7 +73585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -73555,7 +73594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -73564,7 +73603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -73573,7 +73612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -73582,7 +73621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -73591,322 +73630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 94,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 940,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 941,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 942,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 943,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 944,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
-      "label": "ConversionFunnelChart.tsx",
-      "norm_label": "conversionfunnelchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 945,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
-      "label": "RevenueChart.tsx",
-      "norm_label": "revenuechart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 946,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 947,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 950,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 951,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 952,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 953,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 954,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 955,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 956,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 957,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 96,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -73915,7 +73639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 96,
+      "community": 94,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -73924,7 +73648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 96,
+      "community": 94,
       "file_type": "code",
       "id": "productutils_getproductname",
       "label": "getProductName()",
@@ -73933,7 +73657,7 @@
       "source_location": "L18"
     },
     {
-      "community": 96,
+      "community": 94,
       "file_type": "code",
       "id": "productutils_haslowstock",
       "label": "hasLowStock()",
@@ -73942,7 +73666,7 @@
       "source_location": "L52"
     },
     {
-      "community": 96,
+      "community": 94,
       "file_type": "code",
       "id": "productutils_issoldout",
       "label": "isSoldOut()",
@@ -73951,7 +73675,7 @@
       "source_location": "L45"
     },
     {
-      "community": 96,
+      "community": 94,
       "file_type": "code",
       "id": "productutils_sortproduct",
       "label": "sortProduct()",
@@ -73960,7 +73684,7 @@
       "source_location": "L66"
     },
     {
-      "community": 96,
+      "community": 94,
       "file_type": "code",
       "id": "productutils_sortskusbylength",
       "label": "sortSkusByLength()",
@@ -73969,7 +73693,322 @@
       "source_location": "L62"
     },
     {
+      "community": 940,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 943,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 944,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 945,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
+      "label": "ConversionFunnelChart.tsx",
+      "norm_label": "conversionfunnelchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 946,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
+      "label": "RevenueChart.tsx",
+      "norm_label": "revenuechart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 947,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 948,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 949,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
+    },
+    {
+      "community": 950,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 953,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 954,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 955,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 956,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 957,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 958,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 959,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
+    },
+    {
       "community": 960,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -73978,7 +74017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -73987,7 +74026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -73996,7 +74035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74005,7 +74044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -74014,7 +74053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -74023,7 +74062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74032,7 +74071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74041,21 +74080,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
       "source_location": "L1"
     },
     {
@@ -74124,6 +74154,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -74131,7 +74170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74140,7 +74179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74149,7 +74188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -74158,7 +74197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -74167,7 +74206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74176,7 +74215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74185,7 +74224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -74194,21 +74233,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "label": "app-sidebar.tsx",
-      "norm_label": "app-sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
       "source_location": "L1"
     },
     {
@@ -74277,6 +74307,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
+      "label": "app-sidebar.tsx",
+      "norm_label": "app-sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
       "norm_label": "assetscolumns.tsx",
@@ -74284,7 +74323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -74293,7 +74332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74302,7 +74341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74311,7 +74350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74320,7 +74359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -74329,7 +74368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -74338,7 +74377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -74347,21 +74386,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
       "norm_label": "inputotp.test.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
-      "label": "LoginForm.test.tsx",
-      "norm_label": "loginform.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
       "source_location": "L1"
     },
     {
@@ -74430,6 +74460,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
+      "label": "LoginForm.test.tsx",
+      "norm_label": "loginform.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
       "norm_label": "loginform.tsx",
@@ -74437,7 +74476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -74446,7 +74485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -74455,7 +74494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74464,7 +74503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74473,7 +74512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -74482,7 +74521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74491,7 +74530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -74500,21 +74539,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1500
-- Graph nodes: 3803
-- Graph edges: 3357
-- Communities: 1415
+- Code files discovered: 1501
+- Graph nodes: 3805
+- Graph edges: 3358
+- Communities: 1416
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
@@ -10,6 +10,7 @@ vi.mock("./registerSessionTracing", () => ({
 
 import {
   getOpenRegisterSession,
+  getRegisterSessionForRegisterState,
   openRegisterSession,
   recordRegisterSessionTransaction,
 } from "./registerSessions";
@@ -230,6 +231,50 @@ describe("register session workflow trace handlers", () => {
       storeId: "store-1",
       registerNumber: "A1",
     });
+
+    expect(session).toBeNull();
+  });
+
+  it("returns a closing register session for POS register-state gate display", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildRegisterSession({
+          _id: "session-1",
+          status: "closing",
+        }),
+      ],
+    });
+
+    const session = await getHandler(getRegisterSessionForRegisterState)(
+      ctx as never,
+      {
+        storeId: "store-1",
+        registerNumber: "A1",
+      },
+    );
+
+    expect(session).toEqual(
+      expect.objectContaining({ _id: "session-1", status: "closing" }),
+    );
+  });
+
+  it("does not return a closed register session for POS register-state gate display", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildRegisterSession({
+          _id: "session-1",
+          status: "closed",
+        }),
+      ],
+    });
+
+    const session = await getHandler(getRegisterSessionForRegisterState)(
+      ctx as never,
+      {
+        storeId: "store-1",
+        registerNumber: "A1",
+      },
+    );
 
     expect(session).toBeNull();
   });

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -410,6 +410,45 @@ export const getOpenRegisterSession = internalQuery({
   },
 });
 
+export const getRegisterSessionForRegisterState = internalQuery({
+  args: {
+    storeId: v.id("store"),
+    registerNumber: v.optional(v.string()),
+    terminalId: v.optional(v.id("posTerminal")),
+  },
+  handler: async (ctx, args) => {
+    if (args.registerNumber) {
+      const latestByRegister = await ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_registerNumber", (q) =>
+          q.eq("storeId", args.storeId).eq("registerNumber", args.registerNumber!)
+        )
+        .order("desc")
+        .first();
+
+      return latestByRegister &&
+        isRegisterSessionConflictBlockingStatus(latestByRegister.status)
+        ? latestByRegister
+        : null;
+    }
+
+    if (!args.terminalId) {
+      return null;
+    }
+
+    const latestByTerminal = await ctx.db
+      .query("registerSession")
+      .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId!))
+      .order("desc")
+      .first();
+
+    return latestByTerminal &&
+      isRegisterSessionConflictBlockingStatus(latestByTerminal.status)
+      ? latestByTerminal
+      : null;
+  },
+});
+
 export const recordRegisterSessionTransaction = internalMutation({
   args: {
     registerSessionId: v.id("registerSession"),

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { internal } from "../../../_generated/api";
+import type { Id } from "../../../_generated/dataModel";
+
+import { getActiveRegisterSessionForRegisterState } from "./registerSessionRepository";
+
+describe("getActiveRegisterSessionForRegisterState", () => {
+  it("uses the register-state lookup so closing sessions can drive the POS closeout gate", async () => {
+    const ctx = {
+      runQuery: vi.fn().mockResolvedValue({
+        _id: "drawer-1" as Id<"registerSession">,
+        expectedCash: 5_000,
+        openingFloat: 5_000,
+        openedAt: 1710000000000,
+        registerNumber: "1",
+        status: "closing",
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    };
+
+    const session = await getActiveRegisterSessionForRegisterState(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      registerNumber: "1",
+    });
+
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      internal.operations.registerSessions.getRegisterSessionForRegisterState,
+      {
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+      },
+    );
+    expect(session).toEqual(
+      expect.objectContaining({
+        _id: "drawer-1",
+        status: "closing",
+        registerNumber: "1",
+      }),
+    );
+  });
+});

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts
@@ -35,7 +35,7 @@ export async function getActiveRegisterSessionForRegisterState(
   identity: RegisterStateIdentity,
 ): Promise<PosCashDrawerSummary | null> {
   const session = await ctx.runQuery(
-    internal.operations.registerSessions.getOpenRegisterSession,
+    internal.operations.registerSessions.getRegisterSessionForRegisterState,
     {
       storeId: identity.storeId,
       terminalId: identity.terminalId,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 12 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, purchaseOrders.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 12 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 350 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 351 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -52,6 +52,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/application/openDrawer.test.ts`](../../convex/pos/application/openDrawer.test.ts)
 - [`convex/pos/application/posSessionTracing.test.ts`](../../convex/pos/application/posSessionTracing.test.ts)
 - [`convex/pos/application/sessionCommands.test.ts`](../../convex/pos/application/sessionCommands.test.ts)
+- [`convex/pos/infrastructure/repositories/registerSessionRepository.test.ts`](../../convex/pos/infrastructure/repositories/registerSessionRepository.test.ts)
 - [`convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts`](../../convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts)
 - [`convex/pos/infrastructure/repositories/sessionRepository.test.ts`](../../convex/pos/infrastructure/repositories/sessionRepository.test.ts)
 - [`convex/pos/public/transactions.test.ts`](../../convex/pos/public/transactions.test.ts)

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -262,4 +262,65 @@ describe("POSRegisterView", () => {
 
     expect(onSignOut).toHaveBeenCalled();
   });
+
+  it("renders closeout-blocked copy without drawer-opening controls", async () => {
+    const onSignOut = vi.fn();
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: false,
+      },
+      registerInfo: {
+        customerName: undefined,
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {},
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      drawerGate: {
+        mode: "closeoutBlocked",
+        isRecovery: false,
+        registerLabel: "Front Counter",
+        registerNumber: "1",
+        errorMessage: null,
+        onSignOut,
+      },
+      sessionPanel: null,
+      cashierCard: null,
+      authDialog: {
+        open: false,
+      },
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.getByText("Finish drawer closeout before selling")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Front Counter is already in closeout/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /cash controls/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/opening float/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/notes/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /open drawer/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
+    expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
+    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /sign out/i }));
+
+    expect(onSignOut).toHaveBeenCalled();
+  });
 });

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -8,6 +8,34 @@ import { Textarea } from "@/components/ui/textarea";
 import type { RegisterDrawerGateState } from "@/lib/pos/presentation/register/registerUiState";
 import { getOrigin } from "~/src/lib/navigationUtils";
 
+function CashControlsButton({
+  className,
+  variant = "ghost",
+}: {
+  className?: string;
+  variant?: "default" | "ghost";
+}) {
+  return (
+    <Button asChild className={className} type="button" variant={variant}>
+      <Link
+        className="inline-flex items-center justify-center"
+        params={(params) => ({
+          ...params,
+          orgUrlSlug: params.orgUrlSlug!,
+          storeUrlSlug: params.storeUrlSlug!,
+        })}
+        search={{
+          o: getOrigin(),
+        }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers"
+      >
+        Cash controls
+        <ArrowRightIcon className="ml-2 h-4 w-4" />
+      </Link>
+    </Button>
+  );
+}
+
 export function RegisterDrawerGate({
   drawerGate,
 }: {
@@ -15,9 +43,54 @@ export function RegisterDrawerGate({
 }) {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    void drawerGate.onSubmit();
+    void drawerGate.onSubmit?.();
   };
+  const isCloseoutBlocked = drawerGate.mode === "closeoutBlocked";
   const isRecovery = drawerGate.mode === "recovery";
+
+  if (isCloseoutBlocked) {
+    return (
+      <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
+        <div className="space-y-3">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-stone-500">
+            Drawer closeout
+          </p>
+          <div className="space-y-1">
+            <h2 className="text-2xl font-semibold text-stone-900">
+              Finish drawer closeout before selling
+            </h2>
+            <p className="text-sm text-stone-600">
+              {drawerGate.registerLabel} is already in closeout. Finish the
+              register closeout in Cash Controls before returning to POS.
+            </p>
+            <p className="text-sm text-stone-500">
+              Register {drawerGate.registerNumber}
+            </p>
+          </div>
+        </div>
+
+        {drawerGate.errorMessage ? (
+          <p className="mt-6 text-sm text-red-600" role="alert">
+            {drawerGate.errorMessage}
+          </p>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <CashControlsButton className="w-full sm:w-auto" variant="default" />
+
+          <Button
+            className="w-full sm:w-auto"
+            onClick={() => void drawerGate.onSignOut()}
+            type="button"
+            variant="outline"
+          >
+            <LogOutIcon className="mr-2 h-4 w-4" />
+            Sign out
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
@@ -50,10 +123,10 @@ export function RegisterDrawerGate({
             disabled={drawerGate.isSubmitting}
             inputMode="decimal"
             onChange={(event) =>
-              drawerGate.onOpeningFloatChange(event.target.value)
+              drawerGate.onOpeningFloatChange?.(event.target.value)
             }
             placeholder="0.00"
-            value={drawerGate.openingFloat}
+            value={drawerGate.openingFloat ?? ""}
           />
         </label>
 
@@ -63,10 +136,10 @@ export function RegisterDrawerGate({
           </span>
           <Textarea
             disabled={drawerGate.isSubmitting}
-            onChange={(event) => drawerGate.onNotesChange(event.target.value)}
+            onChange={(event) => drawerGate.onNotesChange?.(event.target.value)}
             placeholder="Add a quick note for this drawer opening"
             rows={4}
-            value={drawerGate.notes}
+            value={drawerGate.notes ?? ""}
           />
         </label>
 
@@ -96,23 +169,7 @@ export function RegisterDrawerGate({
             Sign out
           </Button>
 
-          <Button asChild className="w-full sm:w-auto" type="button" variant="ghost">
-            <Link
-              className="inline-flex items-center justify-center"
-              params={(params) => ({
-                ...params,
-                orgUrlSlug: params.orgUrlSlug!,
-                storeUrlSlug: params.storeUrlSlug!,
-              })}
-              search={{
-                o: getOrigin(),
-              }}
-              to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers"
-            >
-              Cash controls
-              <ArrowRightIcon className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
+          <CashControlsButton className="w-full sm:w-auto" />
         </div>
       </form>
     </div>

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -125,17 +125,18 @@ export interface RegisterCashierCardState {
 }
 
 export interface RegisterDrawerGateState {
-  mode: "initialSetup" | "recovery";
+  mode: "initialSetup" | "recovery" | "closeoutBlocked";
+  isRecovery?: boolean;
   registerLabel: string;
   registerNumber: string;
-  currency: string;
-  openingFloat: string;
-  notes: string;
+  currency?: string;
+  openingFloat?: string;
+  notes?: string;
   errorMessage: string | null;
-  isSubmitting: boolean;
-  onOpeningFloatChange: (value: string) => void;
-  onNotesChange: (value: string) => void;
-  onSubmit: () => Promise<void>;
+  isSubmitting?: boolean;
+  onOpeningFloatChange?: (value: string) => void;
+  onNotesChange?: (value: string) => void;
+  onSubmit?: () => Promise<void>;
   onSignOut: () => Promise<void>;
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -386,7 +386,7 @@ describe("useRegisterViewModel", () => {
     expect(mockStartSession).not.toHaveBeenCalled();
   });
 
-  it("holds bootstrap on a closing drawer and exposes the drawer gate", async () => {
+  it("holds bootstrap on a closing drawer and exposes the closeout-blocked gate", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -413,9 +413,12 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate).not.toBeNull();
-    expect(result.current.drawerGate?.mode).toBe("initialSetup");
+    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.registerNumber).toBe("1");
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
+    expect(mockOpenDrawer).not.toHaveBeenCalled();
+    expect(result.current.drawerGate).not.toHaveProperty("onSubmit");
   });
 
   it("gates an active POS session without a register assignment while preserving the sale", async () => {
@@ -448,7 +451,7 @@ describe("useRegisterViewModel", () => {
     expect(mockResumeSession).not.toHaveBeenCalled();
   });
 
-  it("gates an active POS session assigned to a closing drawer", async () => {
+  it("gates an active POS session assigned to a closing drawer with closeout guidance", async () => {
     mockRegisterState = {
       phase: "active",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -474,10 +477,13 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate).not.toBeNull();
-    expect(result.current.drawerGate?.mode).toBe("recovery");
+    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.isRecovery).toBe(true);
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
     expect(mockBindSessionToRegisterSession).not.toHaveBeenCalled();
+    expect(mockOpenDrawer).not.toHaveBeenCalled();
+    expect(result.current.drawerGate).not.toHaveProperty("onSubmit");
   });
 
   it("gates an active POS session assigned to a different open drawer", async () => {
@@ -605,12 +611,12 @@ describe("useRegisterViewModel", () => {
     });
 
     act(() => {
-      result.current.drawerGate?.onOpeningFloatChange("50.00");
-      result.current.drawerGate?.onNotesChange("Opening float ready");
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
+      result.current.drawerGate?.onNotesChange?.("Opening float ready");
     });
 
     await act(async () => {
-      await result.current.drawerGate?.onSubmit();
+      await result.current.drawerGate?.onSubmit?.();
     });
 
     expect(mockOpenDrawer).toHaveBeenCalledWith({
@@ -675,11 +681,11 @@ describe("useRegisterViewModel", () => {
     });
 
     act(() => {
-      result.current.drawerGate?.onOpeningFloatChange("50.00");
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
     });
 
     await act(async () => {
-      await result.current.drawerGate?.onSubmit();
+      await result.current.drawerGate?.onSubmit?.();
     });
 
     mockRegisterState = {
@@ -737,11 +743,11 @@ describe("useRegisterViewModel", () => {
     });
 
     act(() => {
-      result.current.drawerGate?.onOpeningFloatChange("50.00");
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
     });
 
     await act(async () => {
-      await result.current.drawerGate?.onSubmit();
+      await result.current.drawerGate?.onSubmit?.();
     });
 
     expect(result.current.drawerGate).not.toBeNull();

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -150,9 +150,14 @@ export function useRegisterViewModel(): RegisterViewModel {
     isPosUsableRegisterSessionStatus(registerState.activeRegisterSession.status)
       ? registerState.activeRegisterSession
       : null;
+  const closeoutBlockedRegisterSession =
+    registerState?.activeRegisterSession?.status === "closing"
+      ? registerState.activeRegisterSession
+      : null;
   const activeRegisterNumber =
     activeSession?.registerNumber ??
     usableActiveRegisterSession?.registerNumber ??
+    closeoutBlockedRegisterSession?.registerNumber ??
     registerState?.activeSession?.registerNumber ??
     registerState?.resumableSession?.registerNumber;
   const activeRegisterSessionId = usableActiveRegisterSession?._id as
@@ -210,6 +215,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const activeSessionHasBlockedRegisterBinding =
     activeSessionNeedsRegisterBinding || activeSessionHasMismatchedRegisterBinding;
+  const hasCloseoutBlockedDrawerState = Boolean(
+    bootstrapState && closeoutBlockedRegisterSession && !usableActiveRegisterSession,
+  );
   const hasMissingDrawerStartupState = Boolean(
     bootstrapState &&
       (bootstrapState.phase === "readyToStart" ||
@@ -229,11 +237,18 @@ export function useRegisterViewModel(): RegisterViewModel {
       staffProfileId &&
       bootstrapState &&
       (hasMissingDrawerStartupState ||
+        hasCloseoutBlockedDrawerState ||
         hasMissingDrawerRecoveryState ||
         activeSessionHasBlockedRegisterBinding),
   );
-  const drawerGateMode: "initialSetup" | "recovery" =
-    hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding
+  const closeoutBlockedGateIsRecovery = Boolean(
+    hasCloseoutBlockedDrawerState &&
+      (hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding),
+  );
+  const drawerGateMode: "initialSetup" | "recovery" | "closeoutBlocked" =
+    hasCloseoutBlockedDrawerState
+      ? "closeoutBlocked"
+      : hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding
       ? "recovery"
       : "initialSetup";
   const setPaymentState = useCallback((nextPayments: Payment[]) => {
@@ -1512,30 +1527,39 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const drawerGate =
     activeStore?._id && terminal?._id && staffProfileId && requiresDrawerGate
-      ? {
-          mode: drawerGateMode,
-          registerLabel: terminal.displayName,
-          registerNumber,
-          currency: activeStore.currency,
-          openingFloat: drawerOpeningFloat,
-          notes: drawerNotes,
-          errorMessage:
-            drawerErrorMessage ??
-            (activeSessionHasMismatchedRegisterBinding
-              ? "This sale is assigned to a different cash drawer."
-              : null),
-          isSubmitting: isOpeningDrawer,
-          onOpeningFloatChange: (value: string) => {
-            setDrawerOpeningFloat(value);
-            setDrawerErrorMessage(null);
-          },
-          onNotesChange: (value: string) => {
-            setDrawerNotes(value);
-            setDrawerErrorMessage(null);
-          },
-          onSubmit: handleOpenDrawer,
-          onSignOut: handleCashierSignOut,
-        }
+      ? drawerGateMode === "closeoutBlocked"
+        ? {
+            mode: drawerGateMode,
+            isRecovery: closeoutBlockedGateIsRecovery,
+            registerLabel: terminal.displayName,
+            registerNumber,
+            errorMessage: drawerErrorMessage,
+            onSignOut: handleCashierSignOut,
+          }
+        : {
+            mode: drawerGateMode,
+            registerLabel: terminal.displayName,
+            registerNumber,
+            currency: activeStore.currency,
+            openingFloat: drawerOpeningFloat,
+            notes: drawerNotes,
+            errorMessage:
+              drawerErrorMessage ??
+              (activeSessionHasMismatchedRegisterBinding
+                ? "This sale is assigned to a different cash drawer."
+                : null),
+            isSubmitting: isOpeningDrawer,
+            onOpeningFloatChange: (value: string) => {
+              setDrawerOpeningFloat(value);
+              setDrawerErrorMessage(null);
+            },
+            onNotesChange: (value: string) => {
+              setDrawerNotes(value);
+              setDrawerErrorMessage(null);
+            },
+            onSubmit: handleOpenDrawer,
+            onSignOut: handleCashierSignOut,
+          }
       : null;
 
   const authDialog =


### PR DESCRIPTION
## Summary
- Add a POS `closeoutBlocked` drawer-gate mode for register sessions already in `closing` status.
- Expose `closing` sessions to POS register-state display through a dedicated register-state lookup while keeping POS-usable drawer commands limited to `open` and `active`.
- Add view-model, component, operations, and repository-boundary tests; refresh graphify and harness-generated docs; update the drawer-invariants learning doc.

## Why
A cashier with a register session already in closeout should be guided to Cash Controls instead of being shown the open-drawer form. The backend still needs to reject stale open-drawer attempts, but the normal POS path should not present an action that is guaranteed to conflict.

## Validation
- `bun run --filter '@athena/webapp' test -- convex/pos/infrastructure/repositories/registerSessionRepository.test.ts convex/operations/registerSessions.trace.test.ts convex/pos/application/getRegisterState.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild`
- `git diff --check`
- `bun run harness:review --base origin/main`
- `bun run graphify:check`
- Pre-push validation passed: graphify check, harness self-review, architecture check, harness review, Athena tests, Convex audit, changed Convex lint, typecheck, build, POS/workflow trace slice, and behavior scenarios.
- Internal review: APPROVED, critical 0, important 0.

Linear: https://linear.app/v26-labs/issue/V26-380/render-closeout-blocked-pos-drawer-gate-for-closing-register-sessions
Linear: https://linear.app/v26-labs/issue/V26-381/refresh-pos-closeout-blocked-validation-artifacts-and-learning
