### PR TITLE
[V26-382]: Format register-session trace money amounts

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3805 nodes · 3358 edges · 1416 communities detected
+- 3806 nodes · 3361 edges · 1416 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1670,112 +1670,112 @@ Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
 ### Community 54 - "Community 54"
+Cohesion: 0.42
+Nodes (7): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
+
+### Community 55 - "Community 55"
 Cohesion: 0.28
 Nodes (3): formatCashierName(), getTransactionById(), summarizeCashierName()
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.25
 Nodes (2): getTerminalByFingerprint(), mapTerminalRecord()
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.28
 Nodes (3): modifyProduct(), onSubmit(), saveProduct()
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.25
 Nodes (2): handleNewSession(), resetAutoSessionInitialized()
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.33
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.36
 Nodes (4): buildPendingSkuContextById(), listPurchaseOrderLineItems(), listReplenishmentRecommendationsWithCtx(), listStoreProductSkus()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 71 - "Community 71"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 72 - "Community 72"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 73 - "Community 73"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 74 - "Community 74"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 75 - "Community 75"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 74 - "Community 74"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 75 - "Community 75"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 76 - "Community 76"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 77 - "Community 77"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.52
 Nodes (5): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 79 - "Community 79"
-Cohesion: 0.52
-Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
-
 ### Community 80 - "Community 80"
 Cohesion: 0.52
-Nodes (5): buildTraceEvent(), buildTraceRecord(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
 ### Community 81 - "Community 81"
 Cohesion: 0.48
@@ -1818,96 +1818,96 @@ Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
 ### Community 91 - "Community 91"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 92 - "Community 92"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 93 - "Community 93"
+### Community 92 - "Community 92"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 94 - "Community 94"
+### Community 93 - "Community 93"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 95 - "Community 95"
+### Community 94 - "Community 94"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 96 - "Community 96"
+### Community 95 - "Community 95"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 97 - "Community 97"
+### Community 96 - "Community 96"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 98 - "Community 98"
+### Community 97 - "Community 97"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 99 - "Community 99"
+### Community 98 - "Community 98"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 100 - "Community 100"
+### Community 99 - "Community 99"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 101 - "Community 101"
+### Community 100 - "Community 100"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 102 - "Community 102"
+### Community 101 - "Community 101"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+
+### Community 102 - "Community 102"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 103 - "Community 103"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 104 - "Community 104"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 105 - "Community 105"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
+
+### Community 105 - "Community 105"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 106 - "Community 106"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 107 - "Community 107"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 108 - "Community 108"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 109 - "Community 109"
+### Community 108 - "Community 108"
 Cohesion: 0.4
 Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
 
-### Community 110 - "Community 110"
+### Community 109 - "Community 109"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 111 - "Community 111"
+### Community 110 - "Community 110"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 111 - "Community 111"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 112 - "Community 112"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 113 - "Community 113"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 114 - "Community 114"
 Cohesion: 0.33
@@ -1974,28 +1974,28 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 131 - "Community 131"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 132 - "Community 132"
+### Community 131 - "Community 131"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 133 - "Community 133"
+### Community 132 - "Community 132"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
+
+### Community 135 - "Community 135"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 136 - "Community 136"
 Cohesion: 0.4
@@ -2006,44 +2006,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 138 - "Community 138"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 139 - "Community 139"
 Cohesion: 0.7
 Nodes (4): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.5
 Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 147 - "Community 147"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 148 - "Community 148"
 Cohesion: 0.4
@@ -2051,7 +2051,7 @@ Nodes (0):
 
 ### Community 149 - "Community 149"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 150 - "Community 150"
 Cohesion: 0.4
@@ -2083,7 +2083,7 @@ Nodes (0):
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 158 - "Community 158"
 Cohesion: 0.4
@@ -2110,32 +2110,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 164 - "Community 164"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 165 - "Community 165"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 166 - "Community 166"
+### Community 165 - "Community 165"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 167 - "Community 167"
+### Community 166 - "Community 166"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 168 - "Community 168"
+### Community 167 - "Community 167"
 Cohesion: 0.6
 Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
-### Community 169 - "Community 169"
+### Community 168 - "Community 168"
 Cohesion: 0.5
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
 
-### Community 170 - "Community 170"
+### Community 169 - "Community 169"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+
+### Community 170 - "Community 170"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 171 - "Community 171"
 Cohesion: 0.4
@@ -2146,36 +2146,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 173 - "Community 173"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 174 - "Community 174"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 175 - "Community 175"
+### Community 174 - "Community 174"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 176 - "Community 176"
+### Community 175 - "Community 175"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 176 - "Community 176"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 177 - "Community 177"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 178 - "Community 178"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 179 - "Community 179"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
+### Community 180 - "Community 180"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
@@ -2198,8 +2198,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 186 - "Community 186"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 187 - "Community 187"
 Cohesion: 0.83
@@ -2226,20 +2226,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 193 - "Community 193"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 194 - "Community 194"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 195 - "Community 195"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 196 - "Community 196"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.5
@@ -2250,16 +2250,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 199 - "Community 199"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 200 - "Community 200"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 201 - "Community 201"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 202 - "Community 202"
 Cohesion: 0.5
@@ -2286,24 +2286,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 208 - "Community 208"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 209 - "Community 209"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 209 - "Community 209"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 211 - "Community 211"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 212 - "Community 212"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 212 - "Community 212"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.5
@@ -2330,64 +2330,64 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 219 - "Community 219"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 220 - "Community 220"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 221 - "Community 221"
+### Community 220 - "Community 220"
 Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 221 - "Community 221"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 223 - "Community 223"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 224 - "Community 224"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 225 - "Community 225"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 226 - "Community 226"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 228 - "Community 228"
-Cohesion: 0.67
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 230 - "Community 230"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.67
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 232 - "Community 232"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 233 - "Community 233"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.5
@@ -2406,55 +2406,55 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 238 - "Community 238"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 239 - "Community 239"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 240 - "Community 240"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 245 - "Community 245"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 247 - "Community 247"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 248 - "Community 248"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 249 - "Community 249"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 250 - "Community 250"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 251 - "Community 251"
@@ -2466,16 +2466,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 1.0
-Nodes (2): expenseItemError(), mapExpenseValidationError()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 1.0
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Nodes (2): expenseItemError(), mapExpenseValidationError()
 
 ### Community 255 - "Community 255"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
@@ -2494,48 +2494,48 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 260 - "Community 260"
-Cohesion: 1.0
-Nodes (2): mapOpenDrawerUserError(), openDrawer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (2): buildRegisterState(), getRegisterState()
+Nodes (2): mapOpenDrawerUserError(), openDrawer()
 
 ### Community 262 - "Community 262"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterState(), getRegisterState()
 
 ### Community 263 - "Community 263"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 265 - "Community 265"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 266 - "Community 266"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 267 - "Community 267"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 267 - "Community 267"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 268 - "Community 268"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 269 - "Community 269"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 270 - "Community 270"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 270 - "Community 270"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.67
@@ -2546,32 +2546,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 273 - "Community 273"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 276 - "Community 276"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 277 - "Community 277"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 278 - "Community 278"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 280 - "Community 280"
 Cohesion: 0.67
@@ -2586,16 +2586,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 283 - "Community 283"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 285 - "Community 285"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
@@ -2603,11 +2603,11 @@ Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 288 - "Community 288"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.67
@@ -2615,19 +2615,19 @@ Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 291 - "Community 291"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 292 - "Community 292"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 293 - "Community 293"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 293 - "Community 293"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 294 - "Community 294"
 Cohesion: 0.67
@@ -2646,12 +2646,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 298 - "Community 298"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
-
-### Community 299 - "Community 299"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 299 - "Community 299"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
@@ -2687,79 +2687,79 @@ Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 316 - "Community 316"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 317 - "Community 317"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 325 - "Community 325"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 326 - "Community 326"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 327 - "Community 327"
 Cohesion: 0.67
@@ -2787,11 +2787,11 @@ Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 334 - "Community 334"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 335 - "Community 335"
 Cohesion: 0.67
@@ -2806,16 +2806,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 338 - "Community 338"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 339 - "Community 339"
 Cohesion: 1.0
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 339 - "Community 339"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 340 - "Community 340"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 341 - "Community 341"
 Cohesion: 0.67
@@ -2823,63 +2823,63 @@ Nodes (0):
 
 ### Community 342 - "Community 342"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 343 - "Community 343"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 344 - "Community 344"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 345 - "Community 345"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 346 - "Community 346"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 347 - "Community 347"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 349 - "Community 349"
-Cohesion: 0.67
-Nodes (1): manualChunks()
-
 ### Community 350 - "Community 350"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 352 - "Community 352"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 353 - "Community 353"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 354 - "Community 354"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 355 - "Community 355"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 356 - "Community 356"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 357 - "Community 357"
 Cohesion: 0.67
@@ -2890,12 +2890,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 360 - "Community 360"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 360 - "Community 360"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
@@ -2906,12 +2906,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 364 - "Community 364"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 365 - "Community 365"
 Cohesion: 0.67
@@ -2990,16 +2990,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 384 - "Community 384"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 385 - "Community 385"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 386 - "Community 386"
+### Community 385 - "Community 385"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 386 - "Community 386"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 387 - "Community 387"
 Cohesion: 1.0
@@ -3014,20 +3014,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 390 - "Community 390"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 392 - "Community 392"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 393 - "Community 393"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 394 - "Community 394"
 Cohesion: 1.0
@@ -7118,49 +7118,47 @@ Cohesion: 1.0
 Nodes (0):
 
 ## Knowledge Gaps
-- **Thin community `Community 393`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 394`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 395`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 396`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 397`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 398`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 399`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 400`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 401`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 402`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 403`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 404`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 405`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 406`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 407`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 408`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 409`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 410`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 411`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 412`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 413`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
+- **Thin community `Community 414`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 415`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9899,7 +9899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L153",
+      "source_location": "L164",
       "target": "registersessiontracing_buildtraceevent",
       "weight": 1
     },
@@ -9911,7 +9911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L118",
+      "source_location": "L129",
       "target": "registersessiontracing_buildtracerecord",
       "weight": 1
     },
@@ -9935,7 +9935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L274",
+      "source_location": "L285",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -9959,7 +9959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L103",
+      "source_location": "L114",
       "target": "registersessiontracing_resolvestorecurrency",
       "weight": 1
     },
@@ -32351,7 +32351,7 @@
       "relation": "calls",
       "source": "registersessiontracing_displaytraceamount",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196",
+      "source_location": "L207",
       "target": "registersessiontracing_buildtraceevent",
       "weight": 1
     },
@@ -32363,7 +32363,7 @@
       "relation": "calls",
       "source": "registersessiontracing_resolveoccurredat",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L158",
+      "source_location": "L169",
       "target": "registersessiontracing_buildtraceevent",
       "weight": 1
     },
@@ -32375,7 +32375,7 @@
       "relation": "calls",
       "source": "registersessiontracing_resolveoccurredat",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L123",
+      "source_location": "L134",
       "target": "registersessiontracing_buildtracerecord",
       "weight": 1
     },
@@ -32387,7 +32387,7 @@
       "relation": "calls",
       "source": "registersessiontracing_buildtraceevent",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L293",
+      "source_location": "L304",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -32399,7 +32399,7 @@
       "relation": "calls",
       "source": "registersessiontracing_buildtracerecord",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L289",
+      "source_location": "L300",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -32411,7 +32411,7 @@
       "relation": "calls",
       "source": "registersessiontracing_resolvestorecurrency",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L278",
+      "source_location": "L289",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -32423,7 +32423,7 @@
       "relation": "calls",
       "source": "registersessiontracing_safetracewrite",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L301",
+      "source_location": "L312",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -64609,7 +64609,7 @@
       "label": "buildTraceEvent()",
       "norm_label": "buildtraceevent()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L153"
+      "source_location": "L164"
     },
     {
       "community": 54,
@@ -64618,7 +64618,7 @@
       "label": "buildTraceRecord()",
       "norm_label": "buildtracerecord()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L118"
+      "source_location": "L129"
     },
     {
       "community": 54,
@@ -64636,7 +64636,7 @@
       "label": "recordRegisterSessionTraceBestEffort()",
       "norm_label": "recordregistersessiontracebesteffort()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L274"
+      "source_location": "L285"
     },
     {
       "community": 54,
@@ -64654,7 +64654,7 @@
       "label": "resolveStoreCurrency()",
       "norm_label": "resolvestorecurrency()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L103"
+      "source_location": "L114"
     },
     {
       "community": 54,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9845,14 +9845,38 @@
     },
     {
       "_src": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "_tgt": "registersessiontracing_test_buildctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L33",
+      "target": "registersessiontracing_test_buildctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "_tgt": "registersessiontracing_test_buildsession",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L17",
+      "source_location": "L19",
       "target": "registersessiontracing_test_buildsession",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "_tgt": "registersessiontracing_test_formatstoredtraceamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L42",
+      "target": "registersessiontracing_test_formatstoredtraceamount",
       "weight": 1
     },
     {
@@ -9863,7 +9887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L81",
+      "source_location": "L83",
       "target": "registersessiontracing_buildactorrefs",
       "weight": 1
     },
@@ -9875,7 +9899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L129",
+      "source_location": "L153",
       "target": "registersessiontracing_buildtraceevent",
       "weight": 1
     },
@@ -9887,8 +9911,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L94",
+      "source_location": "L118",
       "target": "registersessiontracing_buildtracerecord",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "_tgt": "registersessiontracing_displaytraceamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L96",
+      "target": "registersessiontracing_displaytraceamount",
       "weight": 1
     },
     {
@@ -9899,7 +9935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L249",
+      "source_location": "L274",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -9911,8 +9947,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L56",
+      "source_location": "L58",
       "target": "registersessiontracing_resolveoccurredat",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "_tgt": "registersessiontracing_resolvestorecurrency",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L103",
+      "target": "registersessiontracing_resolvestorecurrency",
       "weight": 1
     },
     {
@@ -9923,7 +9971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L72",
+      "source_location": "L74",
       "target": "registersessiontracing_safetracewrite",
       "weight": 1
     },
@@ -21029,25 +21077,13 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "_tgt": "workflowtraceview_formattimestamp",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L44",
-      "target": "workflowtraceview_formattimestamp",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "_tgt": "workflowtraceview_formattracelabel",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L40",
+      "source_location": "L41",
       "target": "workflowtraceview_formattracelabel",
       "weight": 1
     },
@@ -21059,7 +21095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L51",
+      "source_location": "L45",
       "target": "workflowtraceview_getstatustone",
       "weight": 1
     },
@@ -21071,32 +21107,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L71",
+      "source_location": "L65",
       "target": "workflowtraceview_workflowtraceheader",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "_tgt": "workflowtraceview_workflowtracetimeline",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L110",
-      "target": "workflowtraceview_workflowtracetimeline",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "_tgt": "workflowtraceview_workflowtraceview",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L173",
-      "target": "workflowtraceview_workflowtraceview",
       "weight": 1
     },
     {
@@ -32333,13 +32345,25 @@
     },
     {
       "_src": "registersessiontracing_buildtraceevent",
+      "_tgt": "registersessiontracing_displaytraceamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessiontracing_displaytraceamount",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196",
+      "target": "registersessiontracing_buildtraceevent",
+      "weight": 1
+    },
+    {
+      "_src": "registersessiontracing_buildtraceevent",
       "_tgt": "registersessiontracing_resolveoccurredat",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
       "source": "registersessiontracing_resolveoccurredat",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L133",
+      "source_location": "L158",
       "target": "registersessiontracing_buildtraceevent",
       "weight": 1
     },
@@ -32351,7 +32375,7 @@
       "relation": "calls",
       "source": "registersessiontracing_resolveoccurredat",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L99",
+      "source_location": "L123",
       "target": "registersessiontracing_buildtracerecord",
       "weight": 1
     },
@@ -32363,7 +32387,7 @@
       "relation": "calls",
       "source": "registersessiontracing_buildtraceevent",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L267",
+      "source_location": "L293",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -32375,7 +32399,19 @@
       "relation": "calls",
       "source": "registersessiontracing_buildtracerecord",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L263",
+      "source_location": "L289",
+      "target": "registersessiontracing_recordregistersessiontracebesteffort",
+      "weight": 1
+    },
+    {
+      "_src": "registersessiontracing_recordregistersessiontracebesteffort",
+      "_tgt": "registersessiontracing_resolvestorecurrency",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessiontracing_resolvestorecurrency",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L278",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -32387,7 +32423,7 @@
       "relation": "calls",
       "source": "registersessiontracing_safetracewrite",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L274",
+      "source_location": "L301",
       "target": "registersessiontracing_recordregistersessiontracebesteffort",
       "weight": 1
     },
@@ -41331,56 +41367,56 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1000,
@@ -41475,56 +41511,56 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L1"
+      "id": "expensesessions_buildnextexpensesessionnumber",
+      "label": "buildNextExpenseSessionNumber()",
+      "norm_label": "buildnextexpensesessionnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L72"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "id": "expensesessions_expensesessionerror",
+      "label": "expenseSessionError()",
+      "norm_label": "expensesessionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L42"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L27"
+      "id": "expensesessions_listexpensesessionsbystatusbefore",
+      "label": "listExpenseSessionsByStatusBefore()",
+      "norm_label": "listexpensesessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L105"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L65"
+      "id": "expensesessions_loadexpensesessionitems",
+      "label": "loadExpenseSessionItems()",
+      "norm_label": "loadexpensesessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L80"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L31"
+      "id": "expensesessions_mapexpensesessionvalidationerror",
+      "label": "mapExpenseSessionValidationError()",
+      "norm_label": "mapexpensesessionvalidationerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L56"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L76"
+      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
+      "label": "expenseSessions.ts",
+      "norm_label": "expensesessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L1"
     },
     {
       "community": 1010,
@@ -41619,55 +41655,55 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessions_buildnextexpensesessionnumber",
-      "label": "buildNextExpenseSessionNumber()",
-      "norm_label": "buildnextexpensesessionnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L72"
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L18"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessions_expensesessionerror",
-      "label": "expenseSessionError()",
-      "norm_label": "expensesessionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L42"
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L176"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "label": "listExpenseSessionsByStatusBefore()",
-      "norm_label": "listexpensesessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L105"
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L133"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessions_loadexpensesessionitems",
-      "label": "loadExpenseSessionItems()",
-      "norm_label": "loadexpensesessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L80"
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L86"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessions_mapexpensesessionvalidationerror",
-      "label": "mapExpenseSessionValidationError()",
-      "norm_label": "mapexpensesessionvalidationerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L56"
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L117"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "label": "expenseSessions.ts",
-      "norm_label": "expensesessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
     },
     {
@@ -41763,56 +41799,56 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L176"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
     },
     {
       "community": 1030,
@@ -41907,56 +41943,56 @@
     {
       "community": 104,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L1"
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L104"
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L48"
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L57"
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L1"
     },
     {
       "community": 1040,
@@ -42051,56 +42087,56 @@
     {
       "community": 105,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
     },
     {
       "community": 1050,
@@ -42195,56 +42231,56 @@
     {
       "community": 106,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
     },
     {
       "community": 1060,
@@ -42339,56 +42375,56 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
     },
     {
       "community": 1070,
@@ -42483,56 +42519,56 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L57"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1080,
@@ -42627,56 +42663,56 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1090,
@@ -42951,56 +42987,56 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1100,
@@ -43095,56 +43131,56 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
     },
     {
       "community": 1110,
@@ -43239,56 +43275,56 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L15"
     },
     {
       "community": 1120,
@@ -43383,56 +43419,56 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L15"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1130,
@@ -46182,55 +46218,55 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L100"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1"
     },
     {
@@ -46326,55 +46362,55 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1"
     },
     {
@@ -46470,55 +46506,55 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L72"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L124"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L106"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L63"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L151"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
       "source_location": "L1"
     },
     {
@@ -46614,55 +46650,55 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L72"
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L129"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L124"
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L145"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L106"
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L117"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L63"
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L149"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L151"
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L133"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L1"
     },
     {
@@ -46758,56 +46794,47 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L81"
     },
     {
       "community": 1340,
@@ -46902,47 +46929,47 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "label": "paymentAllocationAttribution.ts",
-      "norm_label": "paymentallocationattribution.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "paymentallocationattribution_buildinstorepaymentallocations",
-      "label": "buildInStorePaymentAllocations()",
-      "norm_label": "buildinstorepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L46"
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L62"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "paymentallocationattribution_normalizeinstorepayments",
-      "label": "normalizeInStorePayments()",
-      "norm_label": "normalizeinstorepayments()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L22"
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L40"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
-      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L118"
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L106"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "paymentallocationattribution_selectregistersessionforattribution",
-      "label": "selectRegisterSessionForAttribution()",
-      "norm_label": "selectregistersessionforattribution()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L81"
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L21"
     },
     {
       "community": 1350,
@@ -47037,47 +47064,47 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
+      "label": "validateExpenseItemBelongsToSession()",
+      "norm_label": "validateexpenseitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionactive",
+      "label": "validateExpenseSessionActive()",
+      "norm_label": "validateexpensesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionexists",
+      "label": "validateExpenseSessionExists()",
+      "norm_label": "validateexpensesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
+      "label": "validateExpenseSessionModifiable()",
+      "norm_label": "validateexpensesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
+      "label": "expenseSessionValidation.ts",
+      "norm_label": "expensesessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L21"
     },
     {
       "community": 1360,
@@ -47172,47 +47199,47 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "label": "validateExpenseItemBelongsToSession()",
-      "norm_label": "validateexpenseitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionactive",
-      "label": "validateExpenseSessionActive()",
-      "norm_label": "validateexpensesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionexists",
-      "label": "validateExpenseSessionExists()",
-      "norm_label": "validateexpensesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "label": "validateExpenseSessionModifiable()",
-      "norm_label": "validateexpensesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "label": "expenseSessionValidation.ts",
-      "norm_label": "expensesessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L18"
     },
     {
       "community": 1370,
@@ -47307,47 +47334,47 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
+      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
+      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
+      "label": "decideApprovalRequestAsCommandWithCtx()",
+      "norm_label": "decideapprovalrequestascommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestwithctx",
+      "label": "decideApprovalRequestWithCtx()",
+      "norm_label": "decideapprovalrequestwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "approvalrequests_mapdecideapprovalrequesterror",
+      "label": "mapDecideApprovalRequestError()",
+      "norm_label": "mapdecideapprovalrequesterror()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
+      "label": "approvalRequests.ts",
+      "norm_label": "approvalrequests.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
     },
     {
       "community": 1380,
@@ -47442,46 +47469,46 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
-      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
-      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L77"
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
-      "label": "decideApprovalRequestAsCommandWithCtx()",
-      "norm_label": "decideapprovalrequestascommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L158"
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestwithctx",
-      "label": "decideApprovalRequestWithCtx()",
-      "norm_label": "decideapprovalrequestwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L27"
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "approvalrequests_mapdecideapprovalrequesterror",
-      "label": "mapDecideApprovalRequestError()",
-      "norm_label": "mapdecideapprovalrequesterror()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L106"
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
-      "label": "approvalRequests.ts",
-      "norm_label": "approvalrequests.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
       "source_location": "L1"
     },
     {
@@ -47748,46 +47775,46 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -47883,47 +47910,47 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 1410,
@@ -47982,51 +48009,6 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
       "norm_label": "serviceintake.test.ts",
@@ -48034,7 +48016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -48043,7 +48025,7 @@
       "source_location": "L16"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -48052,7 +48034,7 @@
       "source_location": "L29"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -48061,7 +48043,7 @@
       "source_location": "L12"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -48070,7 +48052,7 @@
       "source_location": "L8"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -48079,7 +48061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -48088,7 +48070,7 @@
       "source_location": "L11"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -48097,7 +48079,7 @@
       "source_location": "L21"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -48106,7 +48088,7 @@
       "source_location": "L87"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -48115,7 +48097,7 @@
       "source_location": "L65"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -48124,7 +48106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -48133,7 +48115,7 @@
       "source_location": "L115"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -48142,7 +48124,7 @@
       "source_location": "L90"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -48151,7 +48133,7 @@
       "source_location": "L74"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -48160,7 +48142,7 @@
       "source_location": "L70"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -48169,7 +48151,7 @@
       "source_location": "L89"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -48178,7 +48160,7 @@
       "source_location": "L765"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -48187,7 +48169,7 @@
       "source_location": "L37"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -48196,7 +48178,7 @@
       "source_location": "L60"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -48205,7 +48187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -48214,7 +48196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -48223,7 +48205,7 @@
       "source_location": "L124"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -48232,7 +48214,7 @@
       "source_location": "L67"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -48241,7 +48223,7 @@
       "source_location": "L106"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -48250,7 +48232,7 @@
       "source_location": "L73"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -48259,7 +48241,7 @@
       "source_location": "L61"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -48268,7 +48250,7 @@
       "source_location": "L75"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -48277,7 +48259,7 @@
       "source_location": "L116"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -48286,7 +48268,7 @@
       "source_location": "L20"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -48295,7 +48277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -48304,7 +48286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -48313,7 +48295,7 @@
       "source_location": "L286"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -48322,7 +48304,7 @@
       "source_location": "L203"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -48331,13 +48313,58 @@
       "source_location": "L243"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
       "norm_label": "setinitialselectedoption()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 15,
@@ -48828,51 +48855,6 @@
     {
       "community": 157,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
       "norm_label": "paymentview.tsx",
@@ -48880,7 +48862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -48889,7 +48871,7 @@
       "source_location": "L189"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -48898,7 +48880,7 @@
       "source_location": "L252"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -48907,7 +48889,7 @@
       "source_location": "L234"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "paymentview_handleclearall",
       "label": "handleClearAll()",
@@ -48916,7 +48898,7 @@
       "source_location": "L227"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "label": "PaymentsAddedList.tsx",
@@ -48925,7 +48907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
       "label": "getPaymentMethodLabel()",
@@ -48934,7 +48916,7 @@
       "source_location": "L27"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "paymentsaddedlist_handlecanceledit",
       "label": "handleCancelEdit()",
@@ -48943,7 +48925,7 @@
       "source_location": "L104"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "paymentsaddedlist_handlesaveedit",
       "label": "handleSaveEdit()",
@@ -48952,13 +48934,58 @@
       "source_location": "L72"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "paymentsaddedlist_handlestartedit",
       "label": "handleStartEdit()",
       "norm_label": "handlestartedit()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L67"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
+      "label": "ReceivingView.tsx",
+      "norm_label": "receivingview.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "receivingview_builddefaultreceivedquantities",
+      "label": "buildDefaultReceivedQuantities()",
+      "norm_label": "builddefaultreceivedquantities()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "receivingview_buildreceivedquantitiesaftersubmission",
+      "label": "buildReceivedQuantitiesAfterSubmission()",
+      "norm_label": "buildreceivedquantitiesaftersubmission()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "receivingview_buildsubmissionkey",
+      "label": "buildSubmissionKey()",
+      "norm_label": "buildsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "receivingview_receivingview",
+      "label": "ReceivingView()",
+      "norm_label": "receivingview()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L72"
     },
     {
       "community": 16,
@@ -49125,51 +49152,6 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
-      "label": "ReceivingView.tsx",
-      "norm_label": "receivingview.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "receivingview_builddefaultreceivedquantities",
-      "label": "buildDefaultReceivedQuantities()",
-      "norm_label": "builddefaultreceivedquantities()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "receivingview_buildreceivedquantitiesaftersubmission",
-      "label": "buildReceivedQuantitiesAfterSubmission()",
-      "norm_label": "buildreceivedquantitiesaftersubmission()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "receivingview_buildsubmissionkey",
-      "label": "buildSubmissionKey()",
-      "norm_label": "buildsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "receivingview_receivingview",
-      "label": "ReceivingView()",
-      "norm_label": "receivingview()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
       "norm_label": "promocodeview.tsx",
@@ -49177,7 +49159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -49186,7 +49168,7 @@
       "source_location": "L157"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -49195,7 +49177,7 @@
       "source_location": "L230"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -49204,7 +49186,7 @@
       "source_location": "L322"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -49213,7 +49195,7 @@
       "source_location": "L377"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -49222,7 +49204,7 @@
       "source_location": "L99"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -49231,7 +49213,7 @@
       "source_location": "L53"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -49240,7 +49222,7 @@
       "source_location": "L75"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -49249,7 +49231,7 @@
       "source_location": "L63"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -49258,7 +49240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -49267,7 +49249,7 @@
       "source_location": "L7"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -49276,7 +49258,7 @@
       "source_location": "L69"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -49285,7 +49267,7 @@
       "source_location": "L44"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -49294,7 +49276,7 @@
       "source_location": "L103"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -49303,7 +49285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -49312,7 +49294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -49321,7 +49303,7 @@
       "source_location": "L16"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -49330,7 +49312,7 @@
       "source_location": "L23"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -49339,7 +49321,7 @@
       "source_location": "L9"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -49348,7 +49330,7 @@
       "source_location": "L30"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -49357,7 +49339,7 @@
       "source_location": "L18"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -49366,7 +49348,7 @@
       "source_location": "L23"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -49375,7 +49357,7 @@
       "source_location": "L65"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -49384,7 +49366,7 @@
       "source_location": "L45"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -49393,7 +49375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -49402,7 +49384,7 @@
       "source_location": "L78"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -49411,7 +49393,7 @@
       "source_location": "L74"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -49420,7 +49402,7 @@
       "source_location": "L103"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -49429,7 +49411,7 @@
       "source_location": "L109"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -49438,7 +49420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -49447,7 +49429,7 @@
       "source_location": "L75"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -49456,7 +49438,7 @@
       "source_location": "L26"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -49465,7 +49447,7 @@
       "source_location": "L38"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -49474,7 +49456,7 @@
       "source_location": "L4"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -49483,7 +49465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -49492,7 +49474,7 @@
       "source_location": "L3"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -49501,7 +49483,7 @@
       "source_location": "L29"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -49510,7 +49492,7 @@
       "source_location": "L33"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -49519,7 +49501,7 @@
       "source_location": "L40"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -49528,7 +49510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "cataloggateway_mapproductbyidresult",
       "label": "mapProductByIdResult()",
@@ -49537,7 +49519,7 @@
       "source_location": "L38"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "cataloggateway_useconvexbarcodelookup",
       "label": "useConvexBarcodeLookup()",
@@ -49546,7 +49528,7 @@
       "source_location": "L85"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductidlookup",
       "label": "useConvexProductIdLookup()",
@@ -49555,7 +49537,7 @@
       "source_location": "L96"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductsearch",
       "label": "useConvexProductSearch()",
@@ -49564,13 +49546,58 @@
       "source_location": "L67"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
       "label": "catalogGateway.ts",
       "norm_label": "cataloggateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
+      "label": "registerGateway.ts",
+      "norm_label": "registergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "registergateway_mapregisterstatedto",
+      "label": "mapRegisterStateDto()",
+      "norm_label": "mapregisterstatedto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "registergateway_mapterminaldto",
+      "label": "mapTerminalDto()",
+      "norm_label": "mapterminaldto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "registergateway_useconvexregisterstate",
+      "label": "useConvexRegisterState()",
+      "norm_label": "useconvexregisterstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "registergateway_useconvexterminalbyfingerprint",
+      "label": "useConvexTerminalByFingerprint()",
+      "norm_label": "useconvexterminalbyfingerprint()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
+      "source_location": "L55"
     },
     {
       "community": 17,
@@ -49737,51 +49764,6 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
-      "label": "registerGateway.ts",
-      "norm_label": "registergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "registergateway_mapregisterstatedto",
-      "label": "mapRegisterStateDto()",
-      "norm_label": "mapregisterstatedto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "registergateway_mapterminaldto",
-      "label": "mapTerminalDto()",
-      "norm_label": "mapterminaldto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "registergateway_useconvexregisterstate",
-      "label": "useConvexRegisterState()",
-      "norm_label": "useconvexregisterstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "registergateway_useconvexterminalbyfingerprint",
-      "label": "useConvexTerminalByFingerprint()",
-      "norm_label": "useconvexterminalbyfingerprint()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
       "norm_label": "transactionutils.ts",
@@ -49789,7 +49771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -49798,7 +49780,7 @@
       "source_location": "L42"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -49807,7 +49789,7 @@
       "source_location": "L29"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -49816,7 +49798,7 @@
       "source_location": "L49"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -49825,7 +49807,7 @@
       "source_location": "L14"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -49834,7 +49816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -49843,7 +49825,7 @@
       "source_location": "L184"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -49852,7 +49834,7 @@
       "source_location": "L200"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -49861,7 +49843,7 @@
       "source_location": "L244"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -49870,7 +49852,7 @@
       "source_location": "L206"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -49879,7 +49861,7 @@
       "source_location": "L93"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -49888,7 +49870,7 @@
       "source_location": "L75"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -49897,7 +49879,7 @@
       "source_location": "L4"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -49906,7 +49888,7 @@
       "source_location": "L47"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -49915,7 +49897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -49924,7 +49906,7 @@
       "source_location": "L11"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -49933,7 +49915,7 @@
       "source_location": "L25"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -49942,7 +49924,7 @@
       "source_location": "L9"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -49951,7 +49933,7 @@
       "source_location": "L39"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -49960,7 +49942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -49969,7 +49951,7 @@
       "source_location": "L4"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -49978,7 +49960,7 @@
       "source_location": "L24"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -49987,7 +49969,7 @@
       "source_location": "L6"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -49996,7 +49978,7 @@
       "source_location": "L42"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -50005,7 +49987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -50014,7 +49996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -50023,7 +50005,7 @@
       "source_location": "L28"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -50032,7 +50014,7 @@
       "source_location": "L5"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -50041,7 +50023,7 @@
       "source_location": "L7"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -50050,7 +50032,7 @@
       "source_location": "L46"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -50059,7 +50041,7 @@
       "source_location": "L147"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -50068,7 +50050,7 @@
       "source_location": "L185"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -50077,7 +50059,7 @@
       "source_location": "L115"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -50086,7 +50068,7 @@
       "source_location": "L31"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -50095,7 +50077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -50104,7 +50086,7 @@
       "source_location": "L14"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -50113,7 +50095,7 @@
       "source_location": "L22"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -50122,7 +50104,7 @@
       "source_location": "L30"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -50131,7 +50113,7 @@
       "source_location": "L3"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -50140,7 +50122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -50149,7 +50131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -50158,7 +50140,7 @@
       "source_location": "L136"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -50167,7 +50149,7 @@
       "source_location": "L154"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -50176,13 +50158,58 @@
       "source_location": "L25"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
       "norm_label": "normalizestorefronterror()",
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "harness_repo_validation_collectharnessrepovalidationselection",
+      "label": "collectHarnessRepoValidationSelection()",
+      "norm_label": "collectharnessrepovalidationselection()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
+      "label": "matchesHarnessRepoValidationPath()",
+      "norm_label": "matchesharnessrepovalidationpath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "harness_repo_validation_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "harness_repo_validation_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "scripts_harness_repo_validation_ts",
+      "label": "harness-repo-validation.ts",
+      "norm_label": "harness-repo-validation.ts",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L1"
     },
     {
       "community": 18,
@@ -50340,51 +50367,6 @@
     {
       "community": 180,
       "file_type": "code",
-      "id": "harness_repo_validation_collectharnessrepovalidationselection",
-      "label": "collectHarnessRepoValidationSelection()",
-      "norm_label": "collectharnessrepovalidationselection()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
-      "label": "matchesHarnessRepoValidationPath()",
-      "norm_label": "matchesharnessrepovalidationpath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "harness_repo_validation_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "harness_repo_validation_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "scripts_harness_repo_validation_ts",
-      "label": "harness-repo-validation.ts",
-      "norm_label": "harness-repo-validation.ts",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
       "norm_label": "registersessiontracelifecycle.test.ts",
@@ -50392,7 +50374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -50401,7 +50383,7 @@
       "source_location": "L63"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -50410,7 +50392,7 @@
       "source_location": "L79"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -50419,7 +50401,7 @@
       "source_location": "L206"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -50428,7 +50410,7 @@
       "source_location": "L109"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -50437,7 +50419,7 @@
       "source_location": "L84"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -50446,7 +50428,7 @@
       "source_location": "L95"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -50455,7 +50437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -50464,7 +50446,7 @@
       "source_location": "L70"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -50473,7 +50455,7 @@
       "source_location": "L29"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -50482,7 +50464,7 @@
       "source_location": "L80"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -50491,7 +50473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -50500,7 +50482,7 @@
       "source_location": "L21"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -50509,7 +50491,7 @@
       "source_location": "L35"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -50518,7 +50500,7 @@
       "source_location": "L45"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -50527,7 +50509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -50536,7 +50518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -50545,7 +50527,7 @@
       "source_location": "L21"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -50554,7 +50536,7 @@
       "source_location": "L35"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -50563,7 +50545,7 @@
       "source_location": "L45"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -50572,7 +50554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -50581,7 +50563,7 @@
       "source_location": "L210"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -50590,13 +50572,49 @@
       "source_location": "L89"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
       "source_location": "L227"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 186,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 187,
@@ -50934,6 +50952,42 @@
     {
       "community": 192,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "label": "registerSessionTracing.test.ts",
+      "norm_label": "registersessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "registersessiontracing_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "registersessiontracing_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "registersessiontracing_test_formatstoredtraceamount",
+      "label": "formatStoredTraceAmount()",
+      "norm_label": "formatstoredtraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
       "norm_label": "registersessions.trace.test.ts",
@@ -50941,7 +50995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -50950,7 +51004,7 @@
       "source_location": "L31"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -50959,7 +51013,7 @@
       "source_location": "L48"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -50968,7 +51022,7 @@
       "source_location": "L131"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -50977,7 +51031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -50986,7 +51040,7 @@
       "source_location": "L37"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -50995,7 +51049,7 @@
       "source_location": "L24"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -51004,7 +51058,7 @@
       "source_location": "L19"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
       "label": "terminals.ts",
@@ -51013,7 +51067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "terminals_deleteterminal",
       "label": "deleteTerminal()",
@@ -51022,7 +51076,7 @@
       "source_location": "L89"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "terminals_registerterminal",
       "label": "registerTerminal()",
@@ -51031,7 +51085,7 @@
       "source_location": "L13"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "terminals_updateterminal",
       "label": "updateTerminal()",
@@ -51040,7 +51094,7 @@
       "source_location": "L54"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -51049,7 +51103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -51058,7 +51112,7 @@
       "source_location": "L122"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -51067,7 +51121,7 @@
       "source_location": "L34"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -51076,7 +51130,7 @@
       "source_location": "L72"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -51085,7 +51139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -51094,7 +51148,7 @@
       "source_location": "L162"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -51103,7 +51157,7 @@
       "source_location": "L56"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
@@ -51112,7 +51166,7 @@
       "source_location": "L180"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -51121,7 +51175,7 @@
       "source_location": "L31"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -51130,7 +51184,7 @@
       "source_location": "L176"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -51139,7 +51193,7 @@
       "source_location": "L27"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -51148,7 +51202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -51157,7 +51211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -51166,7 +51220,7 @@
       "source_location": "L23"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -51175,49 +51229,13 @@
       "source_location": "L9"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
       "norm_label": "toasynciterable()",
       "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
       "source_location": "L13"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
-      "label": "commerceQueryIndexes.test.ts",
-      "norm_label": "commercequeryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 2,
@@ -51672,6 +51690,42 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "commercequeryindexes_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
+      "label": "commerceQueryIndexes.test.ts",
+      "norm_label": "commercequeryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
       "norm_label": "findexistingcustomerprofileid()",
@@ -51679,7 +51733,7 @@
       "source_location": "L21"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -51688,7 +51742,7 @@
       "source_location": "L63"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -51697,7 +51751,7 @@
       "source_location": "L71"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -51706,7 +51760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -51715,7 +51769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -51724,7 +51778,7 @@
       "source_location": "L13"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -51733,7 +51787,7 @@
       "source_location": "L31"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -51742,7 +51796,7 @@
       "source_location": "L9"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -51751,7 +51805,7 @@
       "source_location": "L51"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -51760,7 +51814,7 @@
       "source_location": "L37"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -51769,7 +51823,7 @@
       "source_location": "L44"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -51778,7 +51832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -51787,7 +51841,7 @@
       "source_location": "L227"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -51796,7 +51850,7 @@
       "source_location": "L46"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -51805,7 +51859,7 @@
       "source_location": "L27"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -51814,7 +51868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -51823,7 +51877,7 @@
       "source_location": "L55"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -51832,7 +51886,7 @@
       "source_location": "L32"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -51841,7 +51895,7 @@
       "source_location": "L211"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -51850,7 +51904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -51859,7 +51913,7 @@
       "source_location": "L52"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -51868,7 +51922,7 @@
       "source_location": "L27"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -51877,7 +51931,7 @@
       "source_location": "L288"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -51886,7 +51940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -51895,7 +51949,7 @@
       "source_location": "L48"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -51904,7 +51958,7 @@
       "source_location": "L88"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -51913,7 +51967,7 @@
       "source_location": "L14"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -51922,7 +51976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -51931,7 +51985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -51940,7 +51994,7 @@
       "source_location": "L15"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -51949,7 +52003,7 @@
       "source_location": "L28"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -51958,7 +52012,7 @@
       "source_location": "L19"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -51967,7 +52021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -51976,7 +52030,7 @@
       "source_location": "L52"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -51985,49 +52039,13 @@
       "source_location": "L3"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
       "norm_label": "groupproductviewsbyday()",
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "label": "MaintenanceMessageEditor.tsx",
-      "norm_label": "maintenancemessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L1"
     },
     {
       "community": 21,
@@ -52185,6 +52203,42 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "maintenancemessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
+      "label": "MaintenanceMessageEditor.tsx",
+      "norm_label": "maintenancemessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
       "norm_label": "shoplook.tsx",
@@ -52192,7 +52246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -52201,7 +52255,7 @@
       "source_location": "L67"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -52210,7 +52264,7 @@
       "source_location": "L90"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -52219,7 +52273,7 @@
       "source_location": "L73"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -52228,7 +52282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -52237,7 +52291,7 @@
       "source_location": "L105"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -52246,7 +52300,7 @@
       "source_location": "L97"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -52255,7 +52309,7 @@
       "source_location": "L83"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -52264,7 +52318,7 @@
       "source_location": "L91"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -52273,7 +52327,7 @@
       "source_location": "L68"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -52282,7 +52336,7 @@
       "source_location": "L22"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -52291,7 +52345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -52300,7 +52354,7 @@
       "source_location": "L131"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "ordersummary_handleprintreceipt",
       "label": "handlePrintReceipt()",
@@ -52309,7 +52363,7 @@
       "source_location": "L154"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -52318,7 +52372,7 @@
       "source_location": "L148"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -52327,7 +52381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -52336,7 +52390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -52345,7 +52399,7 @@
       "source_location": "L247"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -52354,7 +52408,7 @@
       "source_location": "L284"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -52363,7 +52417,7 @@
       "source_location": "L166"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -52372,7 +52426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -52381,7 +52435,7 @@
       "source_location": "L78"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -52390,7 +52444,7 @@
       "source_location": "L118"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -52399,7 +52453,7 @@
       "source_location": "L89"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -52408,7 +52462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -52417,7 +52471,7 @@
       "source_location": "L63"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -52426,7 +52480,7 @@
       "source_location": "L54"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -52435,7 +52489,7 @@
       "source_location": "L11"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -52444,7 +52498,7 @@
       "source_location": "L16"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -52453,7 +52507,7 @@
       "source_location": "L35"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -52462,7 +52516,7 @@
       "source_location": "L6"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -52471,7 +52525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -52480,7 +52534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -52489,7 +52543,7 @@
       "source_location": "L5"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -52498,49 +52552,13 @@
       "source_location": "L30"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
       "norm_label": "promodiscountinputvalue()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
       "source_location": "L21"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
-      "label": "ServiceCasesView.tsx",
-      "norm_label": "servicecasesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "servicecasesview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L178"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "servicecasesview_handlecreatecase",
-      "label": "handleCreateCase()",
-      "norm_label": "handlecreatecase()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L205"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "servicecasesview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L806"
     },
     {
       "community": 22,
@@ -52698,6 +52716,78 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "label": "ServiceCasesView.tsx",
+      "norm_label": "servicecasesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "servicecasesview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L178"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "servicecasesview_handlecreatecase",
+      "label": "handleCreateCase()",
+      "norm_label": "handlecreatecase()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L205"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "servicecasesview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L806"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
+      "label": "WorkflowTraceView.tsx",
+      "norm_label": "workflowtraceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "workflowtraceview_formattracelabel",
+      "label": "formatTraceLabel()",
+      "norm_label": "formattracelabel()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "workflowtraceview_getstatustone",
+      "label": "getStatusTone()",
+      "norm_label": "getstatustone()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "workflowtraceview_workflowtraceheader",
+      "label": "WorkflowTraceHeader()",
+      "norm_label": "workflowtraceheader()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
       "norm_label": "formatlastactivity()",
@@ -52705,7 +52795,7 @@
       "source_location": "L75"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -52714,7 +52804,7 @@
       "source_location": "L82"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -52723,7 +52813,7 @@
       "source_location": "L93"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -52732,7 +52822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -52741,7 +52831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -52750,7 +52840,7 @@
       "source_location": "L15"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -52759,7 +52849,7 @@
       "source_location": "L28"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -52768,7 +52858,7 @@
       "source_location": "L54"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -52777,7 +52867,7 @@
       "source_location": "L66"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -52786,7 +52876,7 @@
       "source_location": "L121"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -52795,7 +52885,7 @@
       "source_location": "L74"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -52804,7 +52894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -52813,7 +52903,7 @@
       "source_location": "L51"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -52822,7 +52912,7 @@
       "source_location": "L92"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -52831,7 +52921,7 @@
       "source_location": "L16"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -52840,7 +52930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -52849,7 +52939,7 @@
       "source_location": "L20"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -52858,7 +52948,7 @@
       "source_location": "L10"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -52867,7 +52957,7 @@
       "source_location": "L46"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -52876,7 +52966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -52885,7 +52975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -52894,7 +52984,7 @@
       "source_location": "L83"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -52903,7 +52993,7 @@
       "source_location": "L100"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -52912,7 +53002,7 @@
       "source_location": "L79"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -52921,7 +53011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -52930,7 +53020,7 @@
       "source_location": "L38"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -52939,7 +53029,7 @@
       "source_location": "L65"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -52948,7 +53038,7 @@
       "source_location": "L91"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -52957,7 +53047,7 @@
       "source_location": "L4"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -52966,7 +53056,7 @@
       "source_location": "L20"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -52975,84 +53065,12 @@
       "source_location": "L42"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
       "norm_label": "fingerprint.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "layout_completependingauthsync",
-      "label": "completePendingAuthSync()",
-      "norm_label": "completependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "layout_handlependingauthsync",
-      "label": "handlePendingAuthSync()",
-      "norm_label": "handlependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "layout_sleep",
-      "label": "sleep()",
-      "norm_label": "sleep()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "offers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "offers_getuserredeemedoffers",
-      "label": "getUserRedeemedOffers()",
-      "norm_label": "getuserredeemedoffers()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "offers_submitoffer",
-      "label": "submitOffer()",
-      "norm_label": "submitoffer()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
     },
     {
@@ -53211,6 +53229,78 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "layout_completependingauthsync",
+      "label": "completePendingAuthSync()",
+      "norm_label": "completependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "layout_handlependingauthsync",
+      "label": "handlePendingAuthSync()",
+      "norm_label": "handlependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "layout_sleep",
+      "label": "sleep()",
+      "norm_label": "sleep()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "offers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "offers_getuserredeemedoffers",
+      "label": "getUserRedeemedOffers()",
+      "norm_label": "getuserredeemedoffers()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "offers_submitoffer",
+      "label": "submitOffer()",
+      "norm_label": "submitoffer()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -53218,7 +53308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -53227,7 +53317,7 @@
       "source_location": "L8"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -53236,7 +53326,7 @@
       "source_location": "L5"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -53245,7 +53335,7 @@
       "source_location": "L20"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -53254,7 +53344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -53263,7 +53353,7 @@
       "source_location": "L11"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -53272,7 +53362,7 @@
       "source_location": "L9"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -53281,7 +53371,7 @@
       "source_location": "L25"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -53290,7 +53380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -53299,7 +53389,7 @@
       "source_location": "L50"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -53308,7 +53398,7 @@
       "source_location": "L92"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -53317,7 +53407,7 @@
       "source_location": "L74"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -53326,7 +53416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -53335,7 +53425,7 @@
       "source_location": "L62"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -53344,7 +53434,7 @@
       "source_location": "L109"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -53353,7 +53443,7 @@
       "source_location": "L177"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -53362,7 +53452,7 @@
       "source_location": "L18"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -53371,7 +53461,7 @@
       "source_location": "L52"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -53380,7 +53470,7 @@
       "source_location": "L68"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -53389,7 +53479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -53398,7 +53488,7 @@
       "source_location": "L68"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -53407,7 +53497,7 @@
       "source_location": "L26"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -53416,7 +53506,7 @@
       "source_location": "L7"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -53425,7 +53515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -53434,7 +53524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -53443,7 +53533,7 @@
       "source_location": "L43"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -53452,7 +53542,7 @@
       "source_location": "L13"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -53461,7 +53551,7 @@
       "source_location": "L88"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -53470,7 +53560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -53479,7 +53569,7 @@
       "source_location": "L111"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -53488,85 +53578,13 @@
       "source_location": "L66"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
-      "label": "_shopLayout.tsx",
-      "norm_label": "_shoplayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "shoplayout_clearfilters",
-      "label": "clearFilters()",
-      "norm_label": "clearfilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "shoplayout_onclickonmobilefilters",
-      "label": "onClickOnMobileFilters()",
-      "norm_label": "onclickonmobilefilters()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "shoplayout_onmobilefilterscloseclick",
-      "label": "onMobileFiltersCloseClick()",
-      "norm_label": "onmobilefilterscloseclick()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
-      "source_location": "L110"
     },
     {
       "community": 24,
@@ -53715,6 +53733,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
+      "label": "_shopLayout.tsx",
+      "norm_label": "_shoplayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "shoplayout_clearfilters",
+      "label": "clearFilters()",
+      "norm_label": "clearfilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "shoplayout_onclickonmobilefilters",
+      "label": "onClickOnMobileFilters()",
+      "norm_label": "onclickonmobilefilters()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "shoplayout_onmobilefilterscloseclick",
+      "label": "onMobileFiltersCloseClick()",
+      "norm_label": "onmobilefilterscloseclick()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
       "norm_label": "cancelorder()",
@@ -53722,7 +53776,7 @@
       "source_location": "L121"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -53731,7 +53785,7 @@
       "source_location": "L26"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -53740,7 +53794,7 @@
       "source_location": "L71"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -53749,7 +53803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -53758,7 +53812,7 @@
       "source_location": "L46"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -53767,7 +53821,7 @@
       "source_location": "L24"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -53776,7 +53830,7 @@
       "source_location": "L20"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -53785,7 +53839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -53794,7 +53848,7 @@
       "source_location": "L33"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -53803,7 +53857,7 @@
       "source_location": "L6"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -53812,7 +53866,7 @@
       "source_location": "L25"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -53821,7 +53875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -53830,7 +53884,7 @@
       "source_location": "L17"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -53839,7 +53893,7 @@
       "source_location": "L11"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -53848,7 +53902,7 @@
       "source_location": "L24"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -53857,7 +53911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -53866,7 +53920,7 @@
       "source_location": "L20"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -53875,7 +53929,7 @@
       "source_location": "L65"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -53884,7 +53938,7 @@
       "source_location": "L14"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -53893,7 +53947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -53902,7 +53956,7 @@
       "source_location": "L126"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -53911,7 +53965,7 @@
       "source_location": "L130"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -53920,7 +53974,7 @@
       "source_location": "L871"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -53929,7 +53983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -53938,7 +53992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -53947,7 +54001,7 @@
       "source_location": "L8"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -53956,7 +54010,7 @@
       "source_location": "L79"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -53965,7 +54019,7 @@
       "source_location": "L61"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -53974,7 +54028,7 @@
       "source_location": "L49"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -53983,7 +54037,7 @@
       "source_location": "L17"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -53992,7 +54046,7 @@
       "source_location": "L11"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -54001,7 +54055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -54010,7 +54064,7 @@
       "source_location": "L26"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -54019,7 +54073,7 @@
       "source_location": "L72"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -54028,48 +54082,12 @@
       "source_location": "L36"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
       "norm_label": "harness-test.ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "pre_push_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "pre_push_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "pre_push_review_test_warn",
-      "label": "warn()",
-      "norm_label": "warn()",
-      "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "scripts_pre_push_review_test_ts",
-      "label": "pre-push-review.test.ts",
-      "norm_label": "pre-push-review.test.ts",
-      "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -54219,6 +54237,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "pre_push_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "pre_push_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "pre_push_review_test_warn",
+      "label": "warn()",
+      "norm_label": "warn()",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_test_ts",
+      "label": "pre-push-review.test.ts",
+      "norm_label": "pre-push-review.test.ts",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -54226,7 +54280,7 @@
       "source_location": "L98"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -54235,7 +54289,7 @@
       "source_location": "L33"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -54244,7 +54298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -54253,7 +54307,7 @@
       "source_location": "L85"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -54262,7 +54316,7 @@
       "source_location": "L31"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -54271,7 +54325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -54280,7 +54334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -54289,7 +54343,7 @@
       "source_location": "L5"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -54298,7 +54352,7 @@
       "source_location": "L12"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "expensesessionitems_expenseitemerror",
       "label": "expenseItemError()",
@@ -54307,7 +54361,7 @@
       "source_location": "L22"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "expensesessionitems_mapexpensevalidationerror",
       "label": "mapExpenseValidationError()",
@@ -54316,7 +54370,7 @@
       "source_location": "L33"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -54325,7 +54379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -54334,7 +54388,7 @@
       "source_location": "L36"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -54343,7 +54397,7 @@
       "source_location": "L22"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -54352,7 +54406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -54361,7 +54415,7 @@
       "source_location": "L43"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -54370,7 +54424,7 @@
       "source_location": "L11"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -54379,7 +54433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -54388,7 +54442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -54397,7 +54451,7 @@
       "source_location": "L22"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -54406,7 +54460,7 @@
       "source_location": "L99"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -54415,7 +54469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -54424,7 +54478,7 @@
       "source_location": "L16"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -54433,7 +54487,7 @@
       "source_location": "L92"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -54442,7 +54496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -54451,40 +54505,13 @@
       "source_location": "L21"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
       "norm_label": "uniqueoperationalroles()",
       "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
       "source_location": "L31"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "index_listtransactions",
-      "label": "listTransactions()",
-      "norm_label": "listtransactions()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "index_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L1"
     },
     {
       "community": 26,
@@ -54633,6 +54660,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "index_listtransactions",
+      "label": "listTransactions()",
+      "norm_label": "listtransactions()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_paystack_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -54640,7 +54694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -54649,7 +54703,7 @@
       "source_location": "L20"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -54658,7 +54712,7 @@
       "source_location": "L38"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -54667,7 +54721,7 @@
       "source_location": "L17"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -54676,7 +54730,7 @@
       "source_location": "L37"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -54685,7 +54739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -54694,7 +54748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -54703,7 +54757,7 @@
       "source_location": "L18"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -54712,7 +54766,7 @@
       "source_location": "L9"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -54721,7 +54775,7 @@
       "source_location": "L8"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -54730,7 +54784,7 @@
       "source_location": "L9"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -54739,7 +54793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -54748,7 +54802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -54757,7 +54811,7 @@
       "source_location": "L7"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -54766,7 +54820,7 @@
       "source_location": "L29"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -54775,7 +54829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -54784,7 +54838,7 @@
       "source_location": "L13"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -54793,7 +54847,7 @@
       "source_location": "L45"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -54802,7 +54856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -54811,7 +54865,7 @@
       "source_location": "L33"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -54820,7 +54874,7 @@
       "source_location": "L13"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -54829,7 +54883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -54838,7 +54892,7 @@
       "source_location": "L13"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -54847,7 +54901,7 @@
       "source_location": "L17"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -54856,7 +54910,7 @@
       "source_location": "L17"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -54865,40 +54919,13 @@
       "source_location": "L61"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
       "norm_label": "appointments.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
-      "label": "serviceCases.test.ts",
-      "norm_label": "servicecases.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "servicecases_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "servicecases_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L16"
     },
     {
       "community": 27,
@@ -55038,6 +55065,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
+      "label": "serviceCases.test.ts",
+      "norm_label": "servicecases.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "servicecases_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "servicecases_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
       "norm_label": "receiving.test.ts",
@@ -55045,7 +55099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -55054,7 +55108,7 @@
       "source_location": "L20"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -55063,7 +55117,7 @@
       "source_location": "L16"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -55072,7 +55126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -55081,7 +55135,7 @@
       "source_location": "L12"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -55090,7 +55144,7 @@
       "source_location": "L7"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -55099,7 +55153,7 @@
       "source_location": "L25"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -55108,7 +55162,7 @@
       "source_location": "L21"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -55117,7 +55171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -55126,7 +55180,7 @@
       "source_location": "L7"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -55135,7 +55189,7 @@
       "source_location": "L14"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -55144,7 +55198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -55153,7 +55207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -55162,7 +55216,7 @@
       "source_location": "L45"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -55171,7 +55225,7 @@
       "source_location": "L37"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -55180,7 +55234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -55189,7 +55243,7 @@
       "source_location": "L10"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -55198,7 +55252,7 @@
       "source_location": "L44"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -55207,7 +55261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -55216,7 +55270,7 @@
       "source_location": "L86"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -55225,7 +55279,7 @@
       "source_location": "L102"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -55234,7 +55288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -55243,7 +55297,7 @@
       "source_location": "L35"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -55252,7 +55306,7 @@
       "source_location": "L25"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -55261,7 +55315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -55270,40 +55324,13 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
       "norm_label": "view()",
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "label": "ProductAvailability.tsx",
-      "norm_label": "productavailability.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "productavailability_productavailability",
-      "label": "ProductAvailability()",
-      "norm_label": "productavailability()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "productavailability_productavailabilityview",
-      "label": "ProductAvailabilityView()",
-      "norm_label": "productavailabilityview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L5"
     },
     {
       "community": 28,
@@ -55443,6 +55470,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
+      "label": "ProductAvailability.tsx",
+      "norm_label": "productavailability.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "productavailability_productavailability",
+      "label": "ProductAvailability()",
+      "norm_label": "productavailability()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "productavailability_productavailabilityview",
+      "label": "ProductAvailabilityView()",
+      "norm_label": "productavailabilityview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
       "norm_label": "sheetprovider.tsx",
@@ -55450,7 +55504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -55459,7 +55513,7 @@
       "source_location": "L19"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -55468,7 +55522,7 @@
       "source_location": "L11"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -55477,7 +55531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -55486,7 +55540,7 @@
       "source_location": "L21"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -55495,7 +55549,7 @@
       "source_location": "L8"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -55504,7 +55558,7 @@
       "source_location": "L21"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -55513,7 +55567,7 @@
       "source_location": "L13"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -55522,7 +55576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -55531,7 +55585,7 @@
       "source_location": "L100"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -55540,7 +55594,7 @@
       "source_location": "L10"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -55549,7 +55603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -55558,7 +55612,7 @@
       "source_location": "L100"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -55567,7 +55621,7 @@
       "source_location": "L10"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -55576,7 +55630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -55585,7 +55639,7 @@
       "source_location": "L15"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -55594,7 +55648,7 @@
       "source_location": "L39"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -55603,7 +55657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -55612,7 +55666,7 @@
       "source_location": "L43"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -55621,7 +55675,7 @@
       "source_location": "L51"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -55630,7 +55684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -55639,7 +55693,7 @@
       "source_location": "L3"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -55648,7 +55702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -55657,7 +55711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -55666,7 +55720,7 @@
       "source_location": "L53"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -55675,39 +55729,12 @@
       "source_location": "L65"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
       "norm_label": "bestsellers.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "featuredsection_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "featuredsection_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "label": "FeaturedSection.tsx",
-      "norm_label": "featuredsection.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
     },
     {
@@ -55848,6 +55875,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "featuredsection_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "featuredsection_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
+      "label": "FeaturedSection.tsx",
+      "norm_label": "featuredsection.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
       "norm_label": "videoplayer.tsx",
@@ -55855,7 +55909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -55864,7 +55918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -55873,7 +55927,7 @@
       "source_location": "L9"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
@@ -55882,7 +55936,7 @@
       "source_location": "L301"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -55891,7 +55945,7 @@
       "source_location": "L291"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -55900,7 +55954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -55909,7 +55963,7 @@
       "source_location": "L70"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -55918,7 +55972,7 @@
       "source_location": "L227"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -55927,7 +55981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -55936,7 +55990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -55945,7 +55999,7 @@
       "source_location": "L67"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -55954,7 +56008,7 @@
       "source_location": "L9"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -55963,7 +56017,7 @@
       "source_location": "L100"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -55972,7 +56026,7 @@
       "source_location": "L95"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -55981,7 +56035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -55990,7 +56044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "registerdrawergate_cashcontrolsbutton",
       "label": "CashControlsButton()",
@@ -55999,7 +56053,7 @@
       "source_location": "L11"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -56008,7 +56062,7 @@
       "source_location": "L44"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -56017,7 +56071,7 @@
       "source_location": "L36"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -56026,7 +56080,7 @@
       "source_location": "L32"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -56035,7 +56089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -56044,7 +56098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -56053,7 +56107,7 @@
       "source_location": "L20"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -56062,7 +56116,7 @@
       "source_location": "L26"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_tsx",
       "label": "WorkflowTraceLink.tsx",
@@ -56071,7 +56125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "workflowtracelink_getworkflowtracelinktarget",
       "label": "getWorkflowTraceLinkTarget()",
@@ -56080,40 +56134,13 @@
       "source_location": "L25"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "workflowtracelink_workflowtracelink",
       "label": "WorkflowTraceLink()",
       "norm_label": "workflowtracelink()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/WorkflowTraceLink.tsx",
       "source_location": "L36"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
-      "label": "ProductsListView.tsx",
-      "norm_label": "productslistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "productslistview_handleclearcache",
-      "label": "handleClearCache()",
-      "norm_label": "handleclearcache()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "productslistview_productactionstogglegroup",
-      "label": "ProductActionsToggleGroup()",
-      "norm_label": "productactionstogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L20"
     },
     {
       "community": 3,
@@ -56523,6 +56550,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
+      "label": "ProductsListView.tsx",
+      "norm_label": "productslistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "productslistview_handleclearcache",
+      "label": "handleClearCache()",
+      "norm_label": "handleclearcache()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "productslistview_productactionstogglegroup",
+      "label": "ProductActionsToggleGroup()",
+      "norm_label": "productactionstogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
       "norm_label": "productstablecontext.tsx",
@@ -56530,7 +56584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -56539,7 +56593,7 @@
       "source_location": "L16"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -56548,7 +56602,7 @@
       "source_location": "L60"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -56557,7 +56611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -56566,7 +56620,7 @@
       "source_location": "L45"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -56575,7 +56629,7 @@
       "source_location": "L19"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -56584,7 +56638,7 @@
       "source_location": "L128"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -56593,7 +56647,7 @@
       "source_location": "L40"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -56602,7 +56656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -56611,7 +56665,7 @@
       "source_location": "L24"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -56620,7 +56674,7 @@
       "source_location": "L20"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -56629,7 +56683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -56638,7 +56692,7 @@
       "source_location": "L25"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -56647,7 +56701,7 @@
       "source_location": "L17"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -56656,7 +56710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -56665,7 +56719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -56674,7 +56728,7 @@
       "source_location": "L59"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -56683,7 +56737,7 @@
       "source_location": "L50"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -56692,7 +56746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -56701,7 +56755,7 @@
       "source_location": "L225"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -56710,7 +56764,7 @@
       "source_location": "L80"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -56719,7 +56773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -56728,7 +56782,7 @@
       "source_location": "L127"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -56737,7 +56791,7 @@
       "source_location": "L71"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -56746,7 +56800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -56755,40 +56809,13 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
       "norm_label": "singlelineerror()",
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "index_errorpage",
-      "label": "ErrorPage()",
-      "norm_label": "errorpage()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_error_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 31,
@@ -56919,6 +56946,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "index_errorpage",
+      "label": "ErrorPage()",
+      "norm_label": "errorpage()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_error_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
       "norm_label": "appskeleton()",
@@ -56926,7 +56980,7 @@
       "source_location": "L3"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -56935,7 +56989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -56944,7 +56998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -56953,7 +57007,7 @@
       "source_location": "L3"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -56962,7 +57016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -56971,7 +57025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -56980,7 +57034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -56989,7 +57043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -56998,7 +57052,7 @@
       "source_location": "L3"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -57007,7 +57061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -57016,7 +57070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -57025,7 +57079,7 @@
       "source_location": "L3"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -57034,7 +57088,7 @@
       "source_location": "L4"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -57043,7 +57097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -57052,7 +57106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -57061,7 +57115,7 @@
       "source_location": "L120"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -57070,7 +57124,7 @@
       "source_location": "L36"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -57079,7 +57133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -57088,7 +57142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -57097,7 +57151,7 @@
       "source_location": "L23"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -57106,7 +57160,7 @@
       "source_location": "L41"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -57115,7 +57169,7 @@
       "source_location": "L20"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -57124,7 +57178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -57133,7 +57187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -57142,7 +57196,7 @@
       "source_location": "L30"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -57151,39 +57205,12 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
       "norm_label": "badge.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "loading_button_loadingbutton",
-      "label": "LoadingButton()",
-      "norm_label": "loadingbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
-      "label": "loading-button.tsx",
-      "norm_label": "loading-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
-      "label": "loading-button.tsx",
-      "norm_label": "loading-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1"
     },
     {
@@ -57315,6 +57342,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "loading_button_loadingbutton",
+      "label": "LoadingButton()",
+      "norm_label": "loadingbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
+      "label": "loading-button.tsx",
+      "norm_label": "loading-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
+      "label": "loading-button.tsx",
+      "norm_label": "loading-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
       "norm_label": "onchange()",
@@ -57322,7 +57376,7 @@
       "source_location": "L38"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -57331,7 +57385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -57340,7 +57394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -57349,7 +57403,7 @@
       "source_location": "L20"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -57358,7 +57412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -57367,7 +57421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -57376,7 +57430,7 @@
       "source_location": "L12"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -57385,7 +57439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -57394,7 +57448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -57403,7 +57457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -57412,7 +57466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -57421,7 +57475,7 @@
       "source_location": "L3"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -57430,7 +57484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -57439,7 +57493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -57448,7 +57502,7 @@
       "source_location": "L6"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -57457,7 +57511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -57466,7 +57520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -57475,7 +57529,7 @@
       "source_location": "L3"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -57484,7 +57538,7 @@
       "source_location": "L44"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -57493,7 +57547,7 @@
       "source_location": "L19"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -57502,7 +57556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -57511,7 +57565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -57520,7 +57574,7 @@
       "source_location": "L159"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -57529,7 +57583,7 @@
       "source_location": "L195"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -57538,7 +57592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -57547,40 +57601,13 @@
       "source_location": "L22"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
       "norm_label": "useractivity()",
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "onlineordercontext_onlineorderprovider",
-      "label": "OnlineOrderProvider()",
-      "norm_label": "onlineorderprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "onlineordercontext_useonlineorder",
-      "label": "useOnlineOrder()",
-      "norm_label": "useonlineorder()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "label": "OnlineOrderContext.tsx",
-      "norm_label": "onlineordercontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L1"
     },
     {
       "community": 33,
@@ -57702,6 +57729,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "onlineordercontext_onlineorderprovider",
+      "label": "OnlineOrderProvider()",
+      "norm_label": "onlineorderprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "onlineordercontext_useonlineorder",
+      "label": "useOnlineOrder()",
+      "norm_label": "useonlineorder()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
+      "label": "OnlineOrderContext.tsx",
+      "norm_label": "onlineordercontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
       "norm_label": "permissionscontext.tsx",
@@ -57709,7 +57763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -57718,7 +57772,7 @@
       "source_location": "L23"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -57727,7 +57781,7 @@
       "source_location": "L51"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -57736,7 +57790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -57745,7 +57799,7 @@
       "source_location": "L54"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -57754,7 +57808,7 @@
       "source_location": "L282"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -57763,7 +57817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -57772,7 +57826,7 @@
       "source_location": "L12"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -57781,7 +57835,7 @@
       "source_location": "L37"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -57790,7 +57844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -57799,7 +57853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -57808,7 +57862,7 @@
       "source_location": "L4"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -57817,7 +57871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -57826,7 +57880,7 @@
       "source_location": "L9"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -57835,7 +57889,7 @@
       "source_location": "L50"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -57844,7 +57898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -57853,7 +57907,7 @@
       "source_location": "L6"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -57862,7 +57916,7 @@
       "source_location": "L31"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -57871,7 +57925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -57880,7 +57934,7 @@
       "source_location": "L5"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -57889,7 +57943,7 @@
       "source_location": "L31"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -57898,7 +57952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -57907,7 +57961,7 @@
       "source_location": "L19"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -57916,7 +57970,7 @@
       "source_location": "L33"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -57925,7 +57979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -57934,40 +57988,13 @@
       "source_location": "L18"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
       "norm_label": "runcommand()",
       "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
       "source_location": "L26"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "maintenanceutils_isinmaintenancemode",
-      "label": "isInMaintenanceMode()",
-      "norm_label": "isinmaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
     },
     {
       "community": 34,
@@ -58089,6 +58116,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "maintenanceutils_isinmaintenancemode",
+      "label": "isInMaintenanceMode()",
+      "norm_label": "isinmaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
       "norm_label": "formatstoredamount()",
@@ -58096,7 +58150,7 @@
       "source_location": "L3"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -58105,7 +58159,7 @@
       "source_location": "L10"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -58114,7 +58168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -58123,7 +58177,7 @@
       "source_location": "L18"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -58132,7 +58186,7 @@
       "source_location": "L59"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -58141,7 +58195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -58150,7 +58204,7 @@
       "source_location": "L31"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -58159,7 +58213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -58168,7 +58222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -58177,7 +58231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -58186,7 +58240,7 @@
       "source_location": "L28"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -58195,7 +58249,7 @@
       "source_location": "L46"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -58204,7 +58258,7 @@
       "source_location": "L18"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -58213,7 +58267,7 @@
       "source_location": "L28"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -58222,7 +58276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -58231,7 +58285,7 @@
       "source_location": "L127"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -58240,7 +58294,7 @@
       "source_location": "L106"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -58249,7 +58303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -58258,7 +58312,7 @@
       "source_location": "L66"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -58267,7 +58321,7 @@
       "source_location": "L20"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -58276,7 +58330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -58285,7 +58339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -58294,7 +58348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -58303,7 +58357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -58312,7 +58366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -58321,40 +58375,13 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
       "norm_label": "createversionchecker()",
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vite_config_ts",
-      "label": "vite.config.ts",
-      "norm_label": "vite.config.ts",
-      "source_file": "packages/athena-webapp/vite.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vite_config_ts",
-      "label": "vite.config.ts",
-      "norm_label": "vite.config.ts",
-      "source_file": "packages/storefront-webapp/vite.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "vite_config_manualchunks",
-      "label": "manualChunks()",
-      "norm_label": "manualchunks()",
-      "source_file": "packages/storefront-webapp/vite.config.ts",
-      "source_location": "L19"
     },
     {
       "community": 35,
@@ -58476,6 +58503,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_vite_config_ts",
+      "label": "vite.config.ts",
+      "norm_label": "vite.config.ts",
+      "source_file": "packages/athena-webapp/vite.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vite_config_ts",
+      "label": "vite.config.ts",
+      "norm_label": "vite.config.ts",
+      "source_file": "packages/storefront-webapp/vite.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "vite_config_manualchunks",
+      "label": "manualChunks()",
+      "norm_label": "manualchunks()",
+      "source_file": "packages/storefront-webapp/vite.config.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
       "norm_label": "vitest.setup.ts",
@@ -58483,7 +58537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -58492,7 +58546,7 @@
       "source_location": "L23"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -58501,7 +58555,7 @@
       "source_location": "L24"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -58510,7 +58564,7 @@
       "source_location": "L32"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -58519,7 +58573,7 @@
       "source_location": "L3"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -58528,7 +58582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -58537,7 +58591,7 @@
       "source_location": "L7"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -58546,7 +58600,7 @@
       "source_location": "L5"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -58555,7 +58609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -58564,7 +58618,7 @@
       "source_location": "L6"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -58573,7 +58627,7 @@
       "source_location": "L18"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -58582,7 +58636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -58591,7 +58645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -58600,7 +58654,7 @@
       "source_location": "L3"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -58609,7 +58663,7 @@
       "source_location": "L5"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -58618,7 +58672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -58627,7 +58681,7 @@
       "source_location": "L18"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -58636,7 +58690,7 @@
       "source_location": "L23"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -58645,7 +58699,7 @@
       "source_location": "L22"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -58654,7 +58708,7 @@
       "source_location": "L55"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -58663,7 +58717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -58672,7 +58726,7 @@
       "source_location": "L77"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -58681,7 +58735,7 @@
       "source_location": "L11"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -58690,7 +58744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -58699,7 +58753,7 @@
       "source_location": "L11"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -58708,39 +58762,12 @@
       "source_location": "L22"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
       "norm_label": "deliverysection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "mobilebagsummary_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "mobilebagsummary_handleredeempromocode",
-      "label": "handleRedeemPromoCode()",
-      "norm_label": "handleredeempromocode()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "label": "MobileBagSummary.tsx",
-      "norm_label": "mobilebagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -58863,6 +58890,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "mobilebagsummary_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "mobilebagsummary_handleredeempromocode",
+      "label": "handleRedeemPromoCode()",
+      "norm_label": "handleredeempromocode()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
+      "label": "MobileBagSummary.tsx",
+      "norm_label": "mobilebagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
       "norm_label": "loadcheckoutstate()",
@@ -58870,7 +58924,7 @@
       "source_location": "L4"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -58879,7 +58933,7 @@
       "source_location": "L24"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -58888,7 +58942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -58897,7 +58951,7 @@
       "source_location": "L131"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -58906,7 +58960,7 @@
       "source_location": "L12"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -58915,7 +58969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -58924,7 +58978,7 @@
       "source_location": "L20"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -58933,7 +58987,7 @@
       "source_location": "L46"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -58942,7 +58996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -58951,7 +59005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -58960,7 +59014,7 @@
       "source_location": "L20"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -58969,7 +59023,7 @@
       "source_location": "L59"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -58978,7 +59032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -58987,7 +59041,7 @@
       "source_location": "L25"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -58996,7 +59050,7 @@
       "source_location": "L20"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -59005,7 +59059,7 @@
       "source_location": "L30"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -59014,7 +59068,7 @@
       "source_location": "L95"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -59023,7 +59077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -59032,7 +59086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -59041,7 +59095,7 @@
       "source_location": "L61"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -59050,7 +59104,7 @@
       "source_location": "L65"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -59059,7 +59113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -59068,7 +59122,7 @@
       "source_location": "L150"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -59077,7 +59131,7 @@
       "source_location": "L157"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -59086,7 +59140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -59095,40 +59149,13 @@
       "source_location": "L63"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
     },
     {
       "community": 37,
@@ -59250,6 +59277,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
       "norm_label": "welcomebackmodalform.tsx",
@@ -59257,7 +59311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -59266,7 +59320,7 @@
       "source_location": "L51"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -59275,7 +59329,7 @@
       "source_location": "L36"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -59284,7 +59338,7 @@
       "source_location": "L16"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -59293,7 +59347,7 @@
       "source_location": "L39"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -59302,7 +59356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -59311,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -59320,7 +59374,7 @@
       "source_location": "L25"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -59329,7 +59383,7 @@
       "source_location": "L82"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -59338,7 +59392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -59347,7 +59401,7 @@
       "source_location": "L20"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -59356,7 +59410,7 @@
       "source_location": "L55"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -59365,7 +59419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -59374,7 +59428,7 @@
       "source_location": "L107"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -59383,7 +59437,7 @@
       "source_location": "L25"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -59392,7 +59446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -59401,7 +59455,7 @@
       "source_location": "L556"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -59410,7 +59464,7 @@
       "source_location": "L52"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -59419,7 +59473,7 @@
       "source_location": "L429"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -59428,7 +59482,7 @@
       "source_location": "L102"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -59437,7 +59491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -59446,7 +59500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -59455,7 +59509,7 @@
       "source_location": "L250"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -59464,7 +59518,7 @@
       "source_location": "L46"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -59473,7 +59527,7 @@
       "source_location": "L17"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -59482,39 +59536,12 @@
       "source_location": "L63"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
       "norm_label": "account.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
     },
     {
@@ -59628,6 +59655,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
       "norm_label": "verify.index.tsx",
@@ -59635,7 +59689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -59644,7 +59698,7 @@
       "source_location": "L21"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -59653,7 +59707,7 @@
       "source_location": "L107"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -59662,7 +59716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -59671,7 +59725,7 @@
       "source_location": "L161"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -59680,7 +59734,7 @@
       "source_location": "L66"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -59689,7 +59743,7 @@
       "source_location": "L11"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -59698,7 +59752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -59707,7 +59761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -59716,7 +59770,7 @@
       "source_location": "L16"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -59725,7 +59779,7 @@
       "source_location": "L10"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -59734,7 +59788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59743,7 +59797,7 @@
       "source_location": "L17"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -59752,7 +59806,7 @@
       "source_location": "L11"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -59761,7 +59815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -59770,7 +59824,7 @@
       "source_location": "L21"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -59779,7 +59833,7 @@
       "source_location": "L15"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -59788,7 +59842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59797,7 +59851,7 @@
       "source_location": "L48"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -59806,7 +59860,7 @@
       "source_location": "L42"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -59815,7 +59869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59824,7 +59878,7 @@
       "source_location": "L16"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -59833,7 +59887,7 @@
       "source_location": "L10"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -59842,7 +59896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -59851,7 +59905,7 @@
       "source_location": "L19"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -59860,39 +59914,12 @@
       "source_location": "L13"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
       "norm_label": "harness-inferential-review.test.ts",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "harness_self_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "harness_self_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "scripts_harness_self_review_test_ts",
-      "label": "harness-self-review.test.ts",
-      "norm_label": "harness-self-review.test.ts",
-      "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -60006,6 +60033,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "harness_self_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "harness_self_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "scripts_harness_self_review_test_ts",
+      "label": "harness-self-review.test.ts",
+      "norm_label": "harness-self-review.test.ts",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -60013,7 +60067,7 @@
       "source_location": "L20"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -60022,7 +60076,7 @@
       "source_location": "L14"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -60031,7 +60085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -60040,7 +60094,7 @@
       "source_location": "L26"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -60049,7 +60103,7 @@
       "source_location": "L18"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -60058,7 +60112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -60067,7 +60121,7 @@
       "source_location": "L45"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -60076,7 +60130,7 @@
       "source_location": "L20"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -60085,7 +60139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -60094,7 +60148,7 @@
       "source_location": "L8"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -60103,7 +60157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -60112,7 +60166,7 @@
       "source_location": "L9"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -60121,7 +60175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -60130,7 +60184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60139,7 +60193,7 @@
       "source_location": "L12"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -60148,7 +60202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -60157,7 +60211,7 @@
       "source_location": "L8"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -60166,7 +60220,7 @@
       "source_location": "L10"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -60175,7 +60229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -60184,31 +60238,13 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
       "norm_label": "verificationcode()",
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "mtnmomo_handlecollectionnotification",
-      "label": "handleCollectionNotification()",
-      "norm_label": "handlecollectionnotification()",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
-      "label": "mtnMomo.ts",
-      "norm_label": "mtnmomo.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -60564,6 +60600,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "mtnmomo_handlecollectionnotification",
+      "label": "handleCollectionNotification()",
+      "norm_label": "handlecollectionnotification()",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
+      "label": "mtnMomo.ts",
+      "norm_label": "mtnmomo.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
       "norm_label": "routercomposition.test.ts",
@@ -60571,7 +60625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60580,7 +60634,7 @@
       "source_location": "L6"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -60589,7 +60643,7 @@
       "source_location": "L110"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -60598,7 +60652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -60607,7 +60661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60616,7 +60670,7 @@
       "source_location": "L8"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -60625,7 +60679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -60634,7 +60688,7 @@
       "source_location": "L22"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -60643,7 +60697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -60652,7 +60706,7 @@
       "source_location": "L6"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -60661,7 +60715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -60670,7 +60724,7 @@
       "source_location": "L29"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -60679,7 +60733,7 @@
       "source_location": "L22"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -60688,7 +60742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -60697,7 +60751,7 @@
       "source_location": "L4"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -60706,7 +60760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -60715,30 +60769,12 @@
       "source_location": "L3"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
       "norm_label": "anthropic.ts",
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "openai_callopenai",
-      "label": "callOpenAi()",
-      "norm_label": "callopenai()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
-      "label": "openai.ts",
-      "norm_label": "openai.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L1"
     },
     {
@@ -60843,6 +60879,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "openai_callopenai",
+      "label": "callOpenAi()",
+      "norm_label": "callopenai()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
+      "label": "openai.ts",
+      "norm_label": "openai.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
@@ -60850,7 +60904,7 @@
       "source_location": "L6"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -60859,7 +60913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -60868,7 +60922,7 @@
       "source_location": "L3"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -60877,7 +60931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -60886,7 +60940,7 @@
       "source_location": "L19"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -60895,7 +60949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -60904,31 +60958,13 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
       "norm_label": "eventbuilders.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 414,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
-      "label": "registerSessionTracing.test.ts",
-      "norm_label": "registersessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 414,
-      "file_type": "code",
-      "id": "registersessiontracing_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L17"
     },
     {
       "community": 415,
@@ -64551,83 +64587,83 @@
     {
       "community": 54,
       "file_type": "code",
-      "id": "gettransactions_formatcashiername",
-      "label": "formatCashierName()",
-      "norm_label": "formatcashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L234"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 54,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 54,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L74"
     },
     {
       "community": 540,
@@ -64812,83 +64848,83 @@
     {
       "community": 55,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrepository_ts",
-      "label": "terminalRepository.ts",
-      "norm_label": "terminalrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "id": "gettransactions_formatcashiername",
+      "label": "formatCashierName()",
+      "norm_label": "formatcashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L234"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 55,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_deleteterminalrecord",
-      "label": "deleteTerminalRecord()",
-      "norm_label": "deleteterminalrecord()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_getterminalbyfingerprint",
-      "label": "getTerminalByFingerprint()",
-      "norm_label": "getterminalbyfingerprint()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_getterminalbyid",
-      "label": "getTerminalById()",
-      "norm_label": "getterminalbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_getterminalforregisterstate",
-      "label": "getTerminalForRegisterState()",
-      "norm_label": "getterminalforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_listterminalsforstore",
-      "label": "listTerminalsForStore()",
-      "norm_label": "listterminalsforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_mapterminalrecord",
-      "label": "mapTerminalRecord()",
-      "norm_label": "mapterminalrecord()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_patchterminalrecord",
-      "label": "patchTerminalRecord()",
-      "norm_label": "patchterminalrecord()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 55,
-      "file_type": "code",
-      "id": "terminalrepository_registerterminalrecord",
-      "label": "registerTerminalRecord()",
-      "norm_label": "registerterminalrecord()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
-      "source_location": "L89"
     },
     {
       "community": 550,
@@ -65073,83 +65109,83 @@
     {
       "community": 56,
       "file_type": "code",
-      "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "label": "buildCustomerObservabilityTimeline()",
-      "norm_label": "buildcustomerobservabilitytimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventjourney",
-      "label": "getOperationalEventJourney()",
-      "norm_label": "getoperationaleventjourney()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventstatus",
-      "label": "getOperationalEventStatus()",
-      "norm_label": "getoperationaleventstatus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventstep",
-      "label": "getOperationalEventStep()",
-      "norm_label": "getoperationaleventstep()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "label": "isFailureStatus()",
-      "norm_label": "isfailurestatus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_isoperationaleventdoc",
-      "label": "isOperationalEventDoc()",
-      "norm_label": "isoperationaleventdoc()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_normalizeevent",
-      "label": "normalizeEvent()",
-      "norm_label": "normalizeevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 56,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
-      "label": "customerObservabilityTimelineData.ts",
-      "norm_label": "customerobservabilitytimelinedata.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrepository_ts",
+      "label": "terminalRepository.ts",
+      "norm_label": "terminalrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_deleteterminalrecord",
+      "label": "deleteTerminalRecord()",
+      "norm_label": "deleteterminalrecord()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_getterminalbyfingerprint",
+      "label": "getTerminalByFingerprint()",
+      "norm_label": "getterminalbyfingerprint()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_getterminalbyid",
+      "label": "getTerminalById()",
+      "norm_label": "getterminalbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_getterminalforregisterstate",
+      "label": "getTerminalForRegisterState()",
+      "norm_label": "getterminalforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_listterminalsforstore",
+      "label": "listTerminalsForStore()",
+      "norm_label": "listterminalsforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_mapterminalrecord",
+      "label": "mapTerminalRecord()",
+      "norm_label": "mapterminalrecord()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_patchterminalrecord",
+      "label": "patchTerminalRecord()",
+      "norm_label": "patchterminalrecord()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 56,
+      "file_type": "code",
+      "id": "terminalrepository_registerterminalrecord",
+      "label": "registerTerminalRecord()",
+      "norm_label": "registerterminalrecord()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts",
+      "source_location": "L89"
     },
     {
       "community": 560,
@@ -65334,83 +65370,83 @@
     {
       "community": 57,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
+      "label": "buildCustomerObservabilityTimeline()",
+      "norm_label": "buildcustomerobservabilitytimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getoperationaleventjourney",
+      "label": "getOperationalEventJourney()",
+      "norm_label": "getoperationaleventjourney()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getoperationaleventstatus",
+      "label": "getOperationalEventStatus()",
+      "norm_label": "getoperationaleventstatus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_getoperationaleventstep",
+      "label": "getOperationalEventStep()",
+      "norm_label": "getoperationaleventstep()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_isfailurestatus",
+      "label": "isFailureStatus()",
+      "norm_label": "isfailurestatus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_isoperationaleventdoc",
+      "label": "isOperationalEventDoc()",
+      "norm_label": "isoperationaleventdoc()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "customerobservabilitytimelinedata_normalizeevent",
+      "label": "normalizeEvent()",
+      "norm_label": "normalizeevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 57,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
+      "label": "customerObservabilityTimelineData.ts",
+      "norm_label": "customerobservabilitytimelinedata.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L241"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L372"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L361"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_updateproductvisibility",
-      "label": "updateProductVisibility()",
-      "norm_label": "updateproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L423"
-    },
-    {
-      "community": 57,
-      "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L294"
     },
     {
       "community": 570,
@@ -65595,83 +65631,83 @@
     {
       "community": 58,
       "file_type": "code",
-      "id": "expenseview_handlebarcodesubmit",
-      "label": "handleBarcodeSubmit()",
-      "norm_label": "handlebarcodesubmit()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L297"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "expenseview_handlecashierauthenticated",
-      "label": "handleCashierAuthenticated()",
-      "norm_label": "handlecashierauthenticated()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "expenseview_handleclearcart",
-      "label": "handleClearCart()",
-      "norm_label": "handleclearcart()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L324"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "expenseview_handlecompleteexpense",
-      "label": "handleCompleteExpense()",
-      "norm_label": "handlecompleteexpense()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L337"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "expenseview_handlenavigateback",
-      "label": "handleNavigateBack()",
-      "norm_label": "handlenavigateback()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L387"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "expenseview_handlenewsession",
-      "label": "handleNewSession()",
-      "norm_label": "handlenewsession()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "expenseview_handlesessionloaded",
-      "label": "handleSessionLoaded()",
-      "norm_label": "handlesessionloaded()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "expenseview_resetautosessioninitialized",
-      "label": "resetAutoSessionInitialized()",
-      "norm_label": "resetautosessioninitialized()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
-      "label": "ExpenseView.tsx",
-      "norm_label": "expenseview.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L241"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L372"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L168"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L361"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_updateproductvisibility",
+      "label": "updateProductVisibility()",
+      "norm_label": "updateproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L423"
+    },
+    {
+      "community": 58,
+      "file_type": "code",
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L294"
     },
     {
       "community": 580,
@@ -65856,83 +65892,83 @@
     {
       "community": 59,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
-      "label": "refundUtils.ts",
-      "norm_label": "refundutils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "id": "expenseview_handlebarcodesubmit",
+      "label": "handleBarcodeSubmit()",
+      "norm_label": "handlebarcodesubmit()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L297"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "expenseview_handlecashierauthenticated",
+      "label": "handleCashierAuthenticated()",
+      "norm_label": "handlecashierauthenticated()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "expenseview_handleclearcart",
+      "label": "handleClearCart()",
+      "norm_label": "handleclearcart()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L324"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "expenseview_handlecompleteexpense",
+      "label": "handleCompleteExpense()",
+      "norm_label": "handlecompleteexpense()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L337"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "expenseview_handlenavigateback",
+      "label": "handleNavigateBack()",
+      "norm_label": "handlenavigateback()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L387"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "expenseview_handlenewsession",
+      "label": "handleNewSession()",
+      "norm_label": "handlenewsession()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "expenseview_handlesessionloaded",
+      "label": "handleSessionLoaded()",
+      "norm_label": "handlesessionloaded()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "expenseview_resetautosessioninitialized",
+      "label": "resetAutoSessionInitialized()",
+      "norm_label": "resetautosessioninitialized()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
+      "label": "ExpenseView.tsx",
+      "norm_label": "expenseview.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_calculaterefundamount",
-      "label": "calculateRefundAmount()",
-      "norm_label": "calculaterefundamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_getamountrefunded",
-      "label": "getAmountRefunded()",
-      "norm_label": "getamountrefunded()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_getavailableitems",
-      "label": "getAvailableItems()",
-      "norm_label": "getavailableitems()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_getitemstorefund",
-      "label": "getItemsToRefund()",
-      "norm_label": "getitemstorefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_getnetamount",
-      "label": "getNetAmount()",
-      "norm_label": "getnetamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_refundreducer",
-      "label": "refundReducer()",
-      "norm_label": "refundreducer()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_shouldshowreturntostock",
-      "label": "shouldShowReturnToStock()",
-      "norm_label": "shouldshowreturntostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 59,
-      "file_type": "code",
-      "id": "refundutils_validaterefund",
-      "label": "validateRefund()",
-      "norm_label": "validaterefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L199"
     },
     {
       "community": 590,
@@ -66351,83 +66387,83 @@
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
-      "label": "ServiceCatalogView.tsx",
-      "norm_label": "servicecatalogview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
+      "label": "refundUtils.ts",
+      "norm_label": "refundutils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L187"
+      "id": "refundutils_calculaterefundamount",
+      "label": "calculateRefundAmount()",
+      "norm_label": "calculaterefundamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L124"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_handleedit",
-      "label": "handleEdit()",
-      "norm_label": "handleedit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L197"
+      "id": "refundutils_getamountrefunded",
+      "label": "getAmountRefunded()",
+      "norm_label": "getamountrefunded()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L98"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_handlereset",
-      "label": "handleReset()",
-      "norm_label": "handlereset()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L203"
+      "id": "refundutils_getavailableitems",
+      "label": "getAvailableItems()",
+      "norm_label": "getavailableitems()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L115"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L209"
+      "id": "refundutils_getitemstorefund",
+      "label": "getItemsToRefund()",
+      "norm_label": "getitemstorefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L174"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_itemtoformstate",
-      "label": "itemToFormState()",
-      "norm_label": "itemtoformstate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L101"
+      "id": "refundutils_getnetamount",
+      "label": "getNetAmount()",
+      "norm_label": "getnetamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L106"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_parseservicecatalogform",
-      "label": "parseServiceCatalogForm()",
-      "norm_label": "parseservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L121"
+      "id": "refundutils_refundreducer",
+      "label": "refundReducer()",
+      "norm_label": "refundreducer()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L31"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_validateservicecatalogform",
-      "label": "validateServiceCatalogForm()",
-      "norm_label": "validateservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L74"
+      "id": "refundutils_shouldshowreturntostock",
+      "label": "shouldShowReturnToStock()",
+      "norm_label": "shouldshowreturntostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L255"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "servicecatalogview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L499"
+      "id": "refundutils_validaterefund",
+      "label": "validateRefund()",
+      "norm_label": "validaterefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L199"
     },
     {
       "community": 600,
@@ -66612,83 +66648,83 @@
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "label": "handleDeliveryRestrictionToggle()",
-      "norm_label": "handledeliveryrestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L155"
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
+      "label": "ServiceCatalogView.tsx",
+      "norm_label": "servicecatalogview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "label": "handlePickupRestrictionToggle()",
-      "norm_label": "handlepickuprestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L116"
+      "id": "servicecatalogview_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L187"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "label": "handleSaveDeliveryRestriction()",
-      "norm_label": "handlesavedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "id": "servicecatalogview_handleedit",
+      "label": "handleEdit()",
+      "norm_label": "handleedit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "servicecatalogview_handlereset",
+      "label": "handleReset()",
+      "norm_label": "handlereset()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
       "source_location": "L203"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_handlesavepickuprestriction",
-      "label": "handleSavePickupRestriction()",
-      "norm_label": "handlesavepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L194"
+      "id": "servicecatalogview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L209"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_savedeliveryrestriction",
-      "label": "saveDeliveryRestriction()",
-      "norm_label": "savedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "id": "servicecatalogview_itemtoformstate",
+      "label": "itemToFormState()",
+      "norm_label": "itemtoformstate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
       "source_location": "L101"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_saveenabledeliverychanges",
-      "label": "saveEnableDeliveryChanges()",
-      "norm_label": "saveenabledeliverychanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L63"
+      "id": "servicecatalogview_parseservicecatalogform",
+      "label": "parseServiceCatalogForm()",
+      "norm_label": "parseservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L121"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_saveenablestorepickupchanges",
-      "label": "saveEnableStorePickupChanges()",
-      "norm_label": "saveenablestorepickupchanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L40"
+      "id": "servicecatalogview_validateservicecatalogform",
+      "label": "validateServiceCatalogForm()",
+      "norm_label": "validateservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L74"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "fulfillmentview_savepickuprestriction",
-      "label": "savePickupRestriction()",
-      "norm_label": "savepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
-      "label": "FulfillmentView.tsx",
-      "norm_label": "fulfillmentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L1"
+      "id": "servicecatalogview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L499"
     },
     {
       "community": 610,
@@ -66873,82 +66909,82 @@
     {
       "community": 62,
       "file_type": "code",
-      "id": "logger_logger",
-      "label": "Logger",
-      "norm_label": "logger",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L12"
+      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
+      "label": "handleDeliveryRestrictionToggle()",
+      "norm_label": "handledeliveryrestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L155"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "logger_logger_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L15"
+      "id": "fulfillmentview_handlepickuprestrictiontoggle",
+      "label": "handlePickupRestrictionToggle()",
+      "norm_label": "handlepickuprestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "logger_logger_debug",
-      "label": ".debug()",
-      "norm_label": ".debug()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L45"
+      "id": "fulfillmentview_handlesavedeliveryrestriction",
+      "label": "handleSaveDeliveryRestriction()",
+      "norm_label": "handlesavedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L203"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "logger_logger_error",
-      "label": ".error()",
-      "norm_label": ".error()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "id": "fulfillmentview_handlesavepickuprestriction",
+      "label": "handleSavePickupRestriction()",
+      "norm_label": "handlesavepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "fulfillmentview_savedeliveryrestriction",
+      "label": "saveDeliveryRestriction()",
+      "norm_label": "savedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "fulfillmentview_saveenabledeliverychanges",
+      "label": "saveEnableDeliveryChanges()",
+      "norm_label": "saveenabledeliverychanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L63"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "logger_logger_formatmessage",
-      "label": ".formatMessage()",
-      "norm_label": ".formatmessage()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L30"
+      "id": "fulfillmentview_saveenablestorepickupchanges",
+      "label": "saveEnableStorePickupChanges()",
+      "norm_label": "saveenablestorepickupchanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L40"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "logger_logger_info",
-      "label": ".info()",
-      "norm_label": ".info()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L51"
+      "id": "fulfillmentview_savepickuprestriction",
+      "label": "savePickupRestriction()",
+      "norm_label": "savepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L86"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "logger_logger_shouldlog",
-      "label": ".shouldLog()",
-      "norm_label": ".shouldlog()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "logger_logger_warn",
-      "label": ".warn()",
-      "norm_label": ".warn()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_logger_ts",
-      "label": "logger.ts",
-      "norm_label": "logger.ts",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
+      "label": "FulfillmentView.tsx",
+      "norm_label": "fulfillmentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L1"
     },
     {
@@ -67134,73 +67170,82 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "athenauserauth_findathenauserbyemailwithctx",
-      "label": "findAthenaUserByEmailWithCtx()",
-      "norm_label": "findathenauserbyemailwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "id": "logger_logger",
+      "label": "Logger",
+      "norm_label": "logger",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L12"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "athenauserauth_getauthenticatedathenauserwithctx",
-      "label": "getAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "getauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L54"
+      "id": "logger_logger_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L15"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "athenauserauth_getauthenticateduserrecord",
-      "label": "getAuthenticatedUserRecord()",
-      "norm_label": "getauthenticateduserrecord()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L34"
+      "id": "logger_logger_debug",
+      "label": ".debug()",
+      "norm_label": ".debug()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L45"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "athenauserauth_normalizeemail",
-      "label": "normalizeEmail()",
-      "norm_label": "normalizeemail()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L8"
+      "id": "logger_logger_error",
+      "label": ".error()",
+      "norm_label": ".error()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L63"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
-      "label": "requireAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "requireauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L64"
+      "id": "logger_logger_formatmessage",
+      "label": ".formatMessage()",
+      "norm_label": ".formatmessage()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L30"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "athenauserauth_requireorganizationmemberrolewithctx",
-      "label": "requireOrganizationMemberRoleWithCtx()",
-      "norm_label": "requireorganizationmemberrolewithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L74"
+      "id": "logger_logger_info",
+      "label": ".info()",
+      "norm_label": ".info()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L51"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
-      "label": "syncAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "syncauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L100"
+      "id": "logger_logger_shouldlog",
+      "label": ".shouldLog()",
+      "norm_label": ".shouldlog()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L20"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
-      "label": "athenaUserAuth.ts",
-      "norm_label": "athenauserauth.ts",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "id": "logger_logger_warn",
+      "label": ".warn()",
+      "norm_label": ".warn()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_logger_ts",
+      "label": "logger.ts",
+      "norm_label": "logger.ts",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L1"
     },
     {
@@ -67386,73 +67431,73 @@
     {
       "community": 64,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "athenauserauth_findathenauserbyemailwithctx",
+      "label": "findAthenaUserByEmailWithCtx()",
+      "norm_label": "findathenauserbyemailwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L12"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
+      "id": "athenauserauth_getauthenticatedathenauserwithctx",
+      "label": "getAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "getauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L54"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
+      "id": "athenauserauth_getauthenticateduserrecord",
+      "label": "getAuthenticatedUserRecord()",
+      "norm_label": "getauthenticateduserrecord()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L34"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
+      "id": "athenauserauth_normalizeemail",
+      "label": "normalizeEmail()",
+      "norm_label": "normalizeemail()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L8"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
+      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
+      "label": "requireAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "requireauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L64"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "athenauserauth_requireorganizationmemberrolewithctx",
+      "label": "requireOrganizationMemberRoleWithCtx()",
+      "norm_label": "requireorganizationmemberrolewithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L74"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
+      "label": "syncAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "syncauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L100"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
+      "label": "athenaUserAuth.ts",
+      "norm_label": "athenauserauth.ts",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
       "source_location": "L1"
     },
     {
@@ -67638,73 +67683,73 @@
     {
       "community": 65,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -67890,74 +67935,74 @@
     {
       "community": 66,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
     },
     {
       "community": 660,
@@ -68142,74 +68187,74 @@
     {
       "community": 67,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1474"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1468"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1464"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1484"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1244"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1321"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1226"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
     },
     {
       "community": 670,
@@ -68394,74 +68439,74 @@
     {
       "community": 68,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L42"
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1474"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "replenishment_buildpendingskucontextbyid",
-      "label": "buildPendingSkuContextById()",
-      "norm_label": "buildpendingskucontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L111"
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1468"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "replenishment_getstatusrank",
-      "label": "getStatusRank()",
-      "norm_label": "getstatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L31"
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1464"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L94"
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1484"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L179"
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1244"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L62"
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1321"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L74"
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1226"
     },
     {
       "community": 680,
@@ -68646,74 +68691,74 @@
     {
       "community": 69,
       "file_type": "code",
-      "id": "data_table_row_actions_datatablerowactions",
-      "label": "DataTableRowActions()",
-      "norm_label": "datatablerowactions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
       "source_location": "L1"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L42"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_buildpendingskucontextbyid",
+      "label": "buildPendingSkuContextById()",
+      "norm_label": "buildpendingskucontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L111"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_getstatusrank",
+      "label": "getStatusRank()",
+      "norm_label": "getstatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L31"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L94"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L179"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L74"
     },
     {
       "community": 690,
@@ -69123,73 +69168,73 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "customerinfopanel_clearcustomer",
-      "label": "clearCustomer()",
-      "norm_label": "clearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L167"
+      "id": "data_table_row_actions_datatablerowactions",
+      "label": "DataTableRowActions()",
+      "norm_label": "datatablerowactions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L25"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "customerinfopanel_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L158"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "customerinfopanel_handlecreatecustomer",
-      "label": "handleCreateCustomer()",
-      "norm_label": "handlecreatecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L86"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "customerinfopanel_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L125"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "customerinfopanel_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L66"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "customerinfopanel_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L115"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "customerinfopanel_showcommanderror",
-      "label": "showCommandError()",
-      "norm_label": "showcommanderror()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L62"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
-      "label": "CustomerInfoPanel.tsx",
-      "norm_label": "customerinfopanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L1"
     },
     {
@@ -69375,74 +69420,74 @@
     {
       "community": 71,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
-      "label": "welcome-offer-modal.tsx",
-      "norm_label": "welcome-offer-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "id": "customerinfopanel_clearcustomer",
+      "label": "clearCustomer()",
+      "norm_label": "clearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L158"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecreatecustomer",
+      "label": "handleCreateCustomer()",
+      "norm_label": "handlecreatecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "customerinfopanel_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L125"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "customerinfopanel_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "customerinfopanel_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "customerinfopanel_showcommanderror",
+      "label": "showCommandError()",
+      "norm_label": "showcommanderror()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
+      "label": "CustomerInfoPanel.tsx",
+      "norm_label": "customerinfopanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlecolorchange",
-      "label": "handleColorChange()",
-      "norm_label": "handlecolorchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlenumberchange",
-      "label": "handleNumberChange()",
-      "norm_label": "handlenumberchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleselectchange",
-      "label": "handleSelectChange()",
-      "norm_label": "handleselectchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleswitchchange",
-      "label": "handleSwitchChange()",
-      "norm_label": "handleswitchchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "welcome_offer_modal_updateimages",
-      "label": "updateImages()",
-      "norm_label": "updateimages()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L100"
     },
     {
       "community": 710,
@@ -69627,74 +69672,74 @@
     {
       "community": 72,
       "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L317"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L193"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L221"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
+      "label": "welcome-offer-modal.tsx",
+      "norm_label": "welcome-offer-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlecolorchange",
+      "label": "handleColorChange()",
+      "norm_label": "handlecolorchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlenumberchange",
+      "label": "handleNumberChange()",
+      "norm_label": "handlenumberchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleselectchange",
+      "label": "handleSelectChange()",
+      "norm_label": "handleselectchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleswitchchange",
+      "label": "handleSwitchChange()",
+      "norm_label": "handleswitchchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "welcome_offer_modal_updateimages",
+      "label": "updateImages()",
+      "norm_label": "updateimages()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L100"
     },
     {
       "community": 720,
@@ -69879,73 +69924,73 @@
     {
       "community": 73,
       "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L197"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L258"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L189"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L317"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L240"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L193"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L221"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
     },
     {
@@ -70131,74 +70176,74 @@
     {
       "community": 74,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L1"
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "product_buildquerystring",
-      "label": "buildQueryString()",
-      "norm_label": "buildquerystring()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L5"
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "product_getallproducts",
-      "label": "getAllProducts()",
-      "norm_label": "getallproducts()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L20"
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "product_getbaseurl",
+      "id": "bag_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L18"
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "product_getbestsellers",
-      "label": "getBestSellers()",
-      "norm_label": "getbestsellers()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L59"
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "product_getfeatured",
-      "label": "getFeatured()",
-      "norm_label": "getfeatured()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L73"
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "product_getinventorybyskuids",
-      "label": "getInventoryBySkuIds()",
-      "norm_label": "getinventorybyskuids()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L93"
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "product_getproduct",
-      "label": "getProduct()",
-      "norm_label": "getproduct()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L40"
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
     },
     {
       "community": 740,
@@ -70320,74 +70365,74 @@
     {
       "community": 75,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "id": "packages_storefront_webapp_src_api_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L1"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L553"
+      "id": "product_buildquerystring",
+      "label": "buildQueryString()",
+      "norm_label": "buildquerystring()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L5"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L594"
+      "id": "product_getallproducts",
+      "label": "getAllProducts()",
+      "norm_label": "getallproducts()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L20"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L580"
+      "id": "product_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L18"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L504"
+      "id": "product_getbestsellers",
+      "label": "getBestSellers()",
+      "norm_label": "getbestsellers()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L59"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L565"
+      "id": "product_getfeatured",
+      "label": "getFeatured()",
+      "norm_label": "getfeatured()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L73"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
+      "id": "product_getinventorybyskuids",
+      "label": "getInventoryBySkuIds()",
+      "norm_label": "getinventorybyskuids()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L93"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
+      "id": "product_getproduct",
+      "label": "getProduct()",
+      "norm_label": "getproduct()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L40"
     },
     {
       "community": 750,
@@ -70482,74 +70527,74 @@
     {
       "community": 76,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L172"
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L553"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L200"
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L594"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L147"
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L580"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L115"
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L504"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L111"
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L565"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
     },
     {
       "community": 76,
       "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L236"
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
     },
     {
       "community": 760,
@@ -70644,65 +70689,74 @@
     {
       "community": 77,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L236"
     },
     {
       "community": 770,
@@ -70797,64 +70851,64 @@
     {
       "community": 78,
       "file_type": "code",
-      "id": "client_buildheaders",
-      "label": "buildHeaders()",
-      "norm_label": "buildheaders()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20"
     },
     {
       "community": 78,
       "file_type": "code",
-      "id": "client_createcollectionsaccesstoken",
-      "label": "createCollectionsAccessToken()",
-      "norm_label": "createcollectionsaccesstoken()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "client_encodebasicauth",
-      "label": "encodeBasicAuth()",
-      "norm_label": "encodebasicauth()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "client_getrequesttopaystatus",
-      "label": "getRequestToPayStatus()",
-      "norm_label": "getrequesttopaystatus()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "client_requesttopay",
-      "label": "requestToPay()",
-      "norm_label": "requesttopay()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "client_toerror",
-      "label": "toError()",
-      "norm_label": "toerror()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "label": "client.ts",
-      "norm_label": "client.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1"
     },
     {
@@ -70950,64 +71004,64 @@
     {
       "community": 79,
       "file_type": "code",
-      "id": "linking_buildcustomerprofiledraft",
-      "label": "buildCustomerProfileDraft()",
-      "norm_label": "buildcustomerprofiledraft()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L110"
+      "id": "client_buildheaders",
+      "label": "buildHeaders()",
+      "norm_label": "buildheaders()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L20"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "linking_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L85"
+      "id": "client_createcollectionsaccesstoken",
+      "label": "createCollectionsAccessToken()",
+      "norm_label": "createcollectionsaccesstoken()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L30"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "linking_findmatchingcustomerprofile",
-      "label": "findMatchingCustomerProfile()",
-      "norm_label": "findmatchingcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L172"
+      "id": "client_encodebasicauth",
+      "label": "encodeBasicAuth()",
+      "norm_label": "encodebasicauth()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L9"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "linking_normalizelookupvalue",
-      "label": "normalizeLookupValue()",
-      "norm_label": "normalizelookupvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L58"
+      "id": "client_getrequesttopaystatus",
+      "label": "getRequestToPayStatus()",
+      "norm_label": "getrequesttopaystatus()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L115"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "linking_normalizephonenumber",
-      "label": "normalizePhoneNumber()",
-      "norm_label": "normalizephonenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L62"
+      "id": "client_requesttopay",
+      "label": "requestToPay()",
+      "norm_label": "requesttopay()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L65"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "linking_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L66"
+      "id": "client_toerror",
+      "label": "toError()",
+      "norm_label": "toerror()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L13"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
-      "label": "linking.ts",
-      "norm_label": "linking.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "id": "packages_athena_webapp_convex_mtn_client_ts",
+      "label": "client.ts",
+      "norm_label": "client.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L1"
     },
     {
@@ -71301,65 +71355,65 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "linking_buildcustomerprofiledraft",
+      "label": "buildCustomerProfileDraft()",
+      "norm_label": "buildcustomerprofiledraft()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "linking_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "linking_findmatchingcustomerprofile",
+      "label": "findMatchingCustomerProfile()",
+      "norm_label": "findmatchingcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "linking_normalizelookupvalue",
+      "label": "normalizeLookupValue()",
+      "norm_label": "normalizelookupvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "linking_normalizephonenumber",
+      "label": "normalizePhoneNumber()",
+      "norm_label": "normalizephonenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "linking_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
+      "label": "linking.ts",
+      "norm_label": "linking.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L72"
     },
     {
       "community": 800,
@@ -73173,65 +73227,65 @@
     {
       "community": 91,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "label": "WorkflowTraceView.tsx",
-      "norm_label": "workflowtraceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
     },
     {
       "community": 91,
       "file_type": "code",
-      "id": "workflowtraceview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L44"
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
     },
     {
       "community": 91,
       "file_type": "code",
-      "id": "workflowtraceview_formattracelabel",
-      "label": "formatTraceLabel()",
-      "norm_label": "formattracelabel()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L40"
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
     },
     {
       "community": 91,
       "file_type": "code",
-      "id": "workflowtraceview_getstatustone",
-      "label": "getStatusTone()",
-      "norm_label": "getstatustone()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L51"
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
     },
     {
       "community": 91,
       "file_type": "code",
-      "id": "workflowtraceview_workflowtraceheader",
-      "label": "WorkflowTraceHeader()",
-      "norm_label": "workflowtraceheader()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L71"
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
     },
     {
       "community": 91,
       "file_type": "code",
-      "id": "workflowtraceview_workflowtracetimeline",
-      "label": "WorkflowTraceTimeline()",
-      "norm_label": "workflowtracetimeline()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L110"
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
     },
     {
       "community": 91,
       "file_type": "code",
-      "id": "workflowtraceview_workflowtraceview",
-      "label": "WorkflowTraceView()",
-      "norm_label": "workflowtraceview()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L173"
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 910,
@@ -73326,65 +73380,65 @@
     {
       "community": 92,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
     },
     {
       "community": 920,
@@ -73479,65 +73533,65 @@
     {
       "community": 93,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 930,
@@ -73632,65 +73686,65 @@
     {
       "community": 94,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 940,
@@ -73785,65 +73839,65 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 950,
@@ -73938,65 +73992,65 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171"
     },
     {
       "community": 960,
@@ -74091,65 +74145,65 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L394"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L171"
     },
     {
       "community": 970,
@@ -74244,64 +74298,64 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L23"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -74397,64 +74451,55 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L23"
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1501
-- Graph nodes: 3805
-- Graph edges: 3358
+- Graph nodes: 3806
+- Graph edges: 3361
 - Communities: 1416
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 242) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 243) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 39) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
@@ -5,6 +5,8 @@ import {
   createWorkflowTraceWithCtx,
   registerWorkflowTraceLookupWithCtx,
 } from "../workflowTraces/core";
+import { toDisplayAmount } from "../lib/currency";
+import { currencyFormatter } from "../utils";
 
 import { recordRegisterSessionTraceBestEffort } from "./registerSessionTracing";
 
@@ -28,6 +30,19 @@ function buildSession() {
   };
 }
 
+function buildCtx(currency = "GHS") {
+  const getStore = vi.fn().mockResolvedValue({ currency });
+
+  return {
+    ctx: { db: { get: getStore } } as never,
+    getStore,
+  };
+}
+
+function formatStoredTraceAmount(currency: string, amount: number) {
+  return currencyFormatter(currency).format(toDisplayAmount(amount));
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
 });
@@ -37,6 +52,116 @@ afterEach(() => {
 });
 
 describe("recordRegisterSessionTraceBestEffort", () => {
+  const moneyMovementCases = [
+    {
+      amount: 12_345,
+      message: `Recorded sale cash movement of ${formatStoredTraceAmount("GHS", 12_345)}.`,
+      stage: "sale_recorded" as const,
+      step: "register_session_sale_recorded",
+    },
+    {
+      amount: 6_789,
+      message: `Recorded void cash adjustment of ${formatStoredTraceAmount("GHS", 6_789)}.`,
+      stage: "void_recorded" as const,
+      step: "register_session_void_recorded",
+    },
+    {
+      amount: 250_000,
+      message: `Recorded cash deposit of ${formatStoredTraceAmount("GHS", 250_000)}.`,
+      stage: "deposit_recorded" as const,
+      step: "register_session_deposit_recorded",
+    },
+  ];
+
+  it.each(moneyMovementCases)(
+    "formats stored minor-unit amounts in the $stage trace message while preserving details.amount",
+    async ({ amount, message, stage, step }) => {
+      vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue(
+        "trace-1" as never,
+      );
+      vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
+        "lookup-1" as never,
+      );
+      vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
+        "event-1" as never,
+      );
+      const { ctx } = buildCtx();
+
+      await recordRegisterSessionTraceBestEffort(ctx, {
+        stage,
+        session: buildSession(),
+        amount,
+        occurredAt: 222,
+      });
+
+      expect(appendWorkflowTraceEventWithCtx).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          details: expect.objectContaining({ amount }),
+          message,
+          occurredAt: 222,
+          step,
+        }),
+      );
+    },
+  );
+
+  it("uses a display-zero fallback in cash movement trace messages when amount is missing", async () => {
+    vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
+    vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
+      "lookup-1" as never,
+    );
+    vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
+      "event-1" as never,
+    );
+    const { ctx } = buildCtx();
+
+    await recordRegisterSessionTraceBestEffort(ctx, {
+      stage: "sale_recorded",
+      session: buildSession(),
+      occurredAt: 222,
+    });
+
+    expect(appendWorkflowTraceEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.not.objectContaining({ amount: expect.anything() }),
+        message: `Recorded sale cash movement of ${currencyFormatter("GHS").format(0)}.`,
+        occurredAt: 222,
+        step: "register_session_sale_recorded",
+      }),
+    );
+  });
+
+  it("uses the register session store currency when formatting trace money", async () => {
+    vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
+    vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
+      "lookup-1" as never,
+    );
+    vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
+      "event-1" as never,
+    );
+    const { ctx, getStore } = buildCtx("USD");
+
+    await recordRegisterSessionTraceBestEffort(ctx, {
+      stage: "sale_recorded",
+      session: buildSession(),
+      amount: 12_345,
+      occurredAt: 222,
+    });
+
+    expect(getStore).toHaveBeenCalledWith("store-1");
+    expect(appendWorkflowTraceEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({ amount: 12_345 }),
+        message: `Recorded sale cash movement of ${formatStoredTraceAmount("USD", 12_345)}.`,
+        occurredAt: 222,
+        step: "register_session_sale_recorded",
+      }),
+    );
+  });
+
   it("records an opened register-session trace using openedAt for bootstrap ordering", async () => {
     vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
     vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
@@ -45,8 +170,9 @@ describe("recordRegisterSessionTraceBestEffort", () => {
     vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
       "event-1" as never,
     );
+    const { ctx } = buildCtx();
 
-    const result = await recordRegisterSessionTraceBestEffort({} as never, {
+    const result = await recordRegisterSessionTraceBestEffort(ctx, {
       stage: "opened",
       session: buildSession(),
     });
@@ -80,8 +206,9 @@ describe("recordRegisterSessionTraceBestEffort", () => {
     vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
       "event-1" as never,
     );
+    const { ctx } = buildCtx();
 
-    await recordRegisterSessionTraceBestEffort({} as never, {
+    await recordRegisterSessionTraceBestEffort(ctx, {
       stage: "approval_pending",
       session: {
         ...buildSession(),
@@ -120,8 +247,9 @@ describe("recordRegisterSessionTraceBestEffort", () => {
     vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
       "event-1" as never,
     );
+    const { ctx } = buildCtx();
 
-    await recordRegisterSessionTraceBestEffort({} as never, {
+    await recordRegisterSessionTraceBestEffort(ctx, {
       stage: "deposit_recorded",
       session: buildSession(),
       amount: 2_500,
@@ -146,8 +274,9 @@ describe("recordRegisterSessionTraceBestEffort", () => {
     vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
       "event-1" as never,
     );
+    const { ctx } = buildCtx();
 
-    const result = await recordRegisterSessionTraceBestEffort({} as never, {
+    const result = await recordRegisterSessionTraceBestEffort(ctx, {
       stage: "deposit_recorded",
       session: buildSession(),
       amount: 2_500,

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
@@ -150,12 +150,40 @@ describe("recordRegisterSessionTraceBestEffort", () => {
       occurredAt: 222,
     });
 
-    expect(getStore).toHaveBeenCalledWith("store-1");
+    expect(getStore).toHaveBeenCalledWith("store", "store-1");
     expect(appendWorkflowTraceEventWithCtx).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         details: expect.objectContaining({ amount: 12_345 }),
         message: `Recorded sale cash movement of ${formatStoredTraceAmount("USD", 12_345)}.`,
+        occurredAt: 222,
+        step: "register_session_sale_recorded",
+      }),
+    );
+  });
+
+  it("falls back to GHS when the store currency is invalid", async () => {
+    vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
+    vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
+      "lookup-1" as never,
+    );
+    vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
+      "event-1" as never,
+    );
+    const { ctx } = buildCtx("not-a-currency");
+
+    await recordRegisterSessionTraceBestEffort(ctx, {
+      stage: "sale_recorded",
+      session: buildSession(),
+      amount: 12_345,
+      occurredAt: 222,
+    });
+
+    expect(appendWorkflowTraceEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({ amount: 12_345 }),
+        message: `Recorded sale cash movement of ${formatStoredTraceAmount("GHS", 12_345)}.`,
         occurredAt: 222,
         step: "register_session_sale_recorded",
       }),

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.ts
@@ -97,14 +97,25 @@ function displayTraceAmount(
   amount: number | undefined,
   currency: string,
 ) {
-  return currencyFormatter(currency).format(toDisplayAmount(amount ?? 0));
+  const displayAmount = toDisplayAmount(amount ?? 0);
+
+  try {
+    return currencyFormatter(currency).format(displayAmount);
+  } catch (error) {
+    console.error("[workflow-trace] register.session.trace.currency-format", {
+      currency,
+      error,
+    });
+
+    return currencyFormatter("GHS").format(displayAmount);
+  }
 }
 
 async function resolveStoreCurrency(
   ctx: MutationCtx,
   session: RegisterSessionTraceableSession,
 ) {
-  const store = await ctx.db.get(session.storeId).catch((error) => {
+  const store = await ctx.db.get("store", session.storeId).catch((error) => {
     console.error(
       "[workflow-trace] register.session.trace.store-currency",
       error,
@@ -112,7 +123,7 @@ async function resolveStoreCurrency(
     return null;
   });
 
-  return store?.currency ?? "GHS";
+  return store?.currency?.trim() || "GHS";
 }
 
 function buildTraceRecord(args: {

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.ts
@@ -1,6 +1,8 @@
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 
+import { toDisplayAmount } from "../lib/currency";
+import { currencyFormatter } from "../utils";
 import {
   appendWorkflowTraceEventWithCtx,
   createWorkflowTraceWithCtx,
@@ -91,6 +93,28 @@ function buildActorRefs(args: RegisterSessionTraceArgs) {
   return Object.keys(actorRefs).length > 0 ? actorRefs : undefined;
 }
 
+function displayTraceAmount(
+  amount: number | undefined,
+  currency: string,
+) {
+  return currencyFormatter(currency).format(toDisplayAmount(amount ?? 0));
+}
+
+async function resolveStoreCurrency(
+  ctx: MutationCtx,
+  session: RegisterSessionTraceableSession,
+) {
+  const store = await ctx.db.get(session.storeId).catch((error) => {
+    console.error(
+      "[workflow-trace] register.session.trace.store-currency",
+      error,
+    );
+    return null;
+  });
+
+  return store?.currency ?? "GHS";
+}
+
 function buildTraceRecord(args: {
   traceSeed: RegisterSessionTraceSeed;
   input: RegisterSessionTraceArgs;
@@ -127,6 +151,7 @@ function buildTraceRecord(args: {
 }
 
 function buildTraceEvent(args: {
+  currency: string;
   traceSeed: RegisterSessionTraceSeed;
   input: RegisterSessionTraceArgs;
 }) {
@@ -168,7 +193,7 @@ function buildTraceEvent(args: {
         kind: "system_action" as const,
         step: "register_session_sale_recorded",
         status: "info" as const,
-        message: `Recorded sale cash movement of ${args.input.amount ?? 0}.`,
+        message: `Recorded sale cash movement of ${displayTraceAmount(args.input.amount, args.currency)}.`,
         occurredAt,
         details,
         subjectRefs,
@@ -178,7 +203,7 @@ function buildTraceEvent(args: {
         kind: "system_action" as const,
         step: "register_session_void_recorded",
         status: "info" as const,
-        message: `Recorded void cash adjustment of ${args.input.amount ?? 0}.`,
+        message: `Recorded void cash adjustment of ${displayTraceAmount(args.input.amount, args.currency)}.`,
         occurredAt,
         details,
         subjectRefs,
@@ -188,7 +213,7 @@ function buildTraceEvent(args: {
         kind: "system_action" as const,
         step: "register_session_deposit_recorded",
         status: "info" as const,
-        message: `Recorded cash deposit of ${args.input.amount ?? 0}.`,
+        message: `Recorded cash deposit of ${displayTraceAmount(args.input.amount, args.currency)}.`,
         occurredAt,
         details,
         subjectRefs,
@@ -250,6 +275,7 @@ export async function recordRegisterSessionTraceBestEffort(
   ctx: MutationCtx,
   args: RegisterSessionTraceArgs,
 ) {
+  const currency = await resolveStoreCurrency(ctx, args.session);
   const traceSeed = buildRegisterSessionTraceSeed({
     storeId: args.session.storeId,
     organizationId: args.session.organizationId,
@@ -265,6 +291,7 @@ export async function recordRegisterSessionTraceBestEffort(
     input: args,
   });
   const traceEvent = buildTraceEvent({
+    currency,
     traceSeed,
     input: args,
   });

--- a/packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx
+++ b/packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx
@@ -121,13 +121,13 @@ describe("WorkflowTraceTimeline", () => {
     expect(listItems).toHaveLength(2);
     expect(listItems[0]).toHaveTextContent("Workflow started");
     expect(listItems[0]).not.toHaveTextContent("Workflow Started");
-    expect(listItems[0]).not.toHaveTextContent("Started");
-    expect(listItems[0]).not.toHaveTextContent("Milestone");
     expect(listItems[0]).toHaveTextContent("10 minutes ago");
+    expect(listItems[0]).toHaveTextContent("Started");
+    expect(listItems[0]).toHaveTextContent("Milestone");
     expect(listItems[1]).toHaveTextContent("Repair order persisted");
     expect(listItems[1]).not.toHaveTextContent("Repair Order Persisted");
-    expect(listItems[1]).not.toHaveTextContent("Succeeded");
-    expect(listItems[1]).not.toHaveTextContent("System Action");
     expect(listItems[1]).toHaveTextContent("5 minutes ago");
+    expect(listItems[1]).toHaveTextContent("Succeeded");
+    expect(listItems[1]).toHaveTextContent("System Action");
   });
 });

--- a/packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx
+++ b/packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "~/convex/_generated/dataModel";
 
-import { WorkflowTraceView } from "./WorkflowTraceView";
+import { WorkflowTraceTimeline, WorkflowTraceView } from "./WorkflowTraceView";
 
 const mockedHooks = vi.hoisted(() => ({
   useQuery: vi.fn(),
@@ -22,6 +22,10 @@ vi.mock("../common/PageHeader", () => ({
 describe("WorkflowTraceView", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("renders the trace title, health and status badges, and ordered timeline messages", () => {
@@ -75,5 +79,55 @@ describe("WorkflowTraceView", () => {
     expect(listItems).toHaveLength(2);
     expect(listItems[0]).toHaveTextContent("Workflow started");
     expect(listItems[1]).toHaveTextContent("Repair order persisted");
+  });
+});
+
+describe("WorkflowTraceTimeline", () => {
+  it("renders events as a simple ActivityView-like bullet timeline", () => {
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-04-21T09:25:00.000Z").getTime(),
+    );
+
+    render(
+      <WorkflowTraceTimeline
+        events={[
+          {
+            kind: "milestone",
+            message: "Workflow started",
+            occurredAt: new Date("2026-04-21T09:15:00.000Z").getTime(),
+            sequence: 2,
+            source: "workflow.shared",
+            status: "started",
+            step: "workflow_started",
+            traceId: "repair_order:job-42",
+            workflowType: "repair_order",
+          },
+          {
+            kind: "system_action",
+            message: "Repair order persisted",
+            occurredAt: new Date("2026-04-21T09:20:00.000Z").getTime(),
+            sequence: 4,
+            source: "workflow.shared",
+            status: "succeeded",
+            step: "repair_order_persisted",
+            traceId: "repair_order:job-42",
+            workflowType: "repair_order",
+          },
+        ]}
+      />,
+    );
+
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(2);
+    expect(listItems[0]).toHaveTextContent("Workflow started");
+    expect(listItems[0]).not.toHaveTextContent("Workflow Started");
+    expect(listItems[0]).not.toHaveTextContent("Started");
+    expect(listItems[0]).not.toHaveTextContent("Milestone");
+    expect(listItems[0]).toHaveTextContent("10 minutes ago");
+    expect(listItems[1]).toHaveTextContent("Repair order persisted");
+    expect(listItems[1]).not.toHaveTextContent("Repair Order Persisted");
+    expect(listItems[1]).not.toHaveTextContent("Succeeded");
+    expect(listItems[1]).not.toHaveTextContent("System Action");
+    expect(listItems[1]).toHaveTextContent("5 minutes ago");
   });
 });

--- a/packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx
+++ b/packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "convex/react";
+import { Circle } from "lucide-react";
 import type { Id } from "~/convex/_generated/dataModel";
 
 import View from "../View";
@@ -7,7 +8,7 @@ import { FadeIn } from "../common/FadeIn";
 import { Badge } from "../ui/badge";
 import { NotFoundView } from "../states/not-found/NotFoundView";
 import { api } from "~/convex/_generated/api";
-import { capitalizeWords } from "~/src/lib/utils";
+import { capitalizeWords, getRelativeTime } from "~/src/lib/utils";
 
 export type WorkflowTraceHeaderModel = {
   health: string;
@@ -39,13 +40,6 @@ export type WorkflowTraceViewModel = {
 
 function formatTraceLabel(value: string) {
   return capitalizeWords(value.replaceAll("_", " ").replaceAll("-", " "));
-}
-
-function formatTimestamp(timestamp: number) {
-  return new Date(timestamp).toLocaleString("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
 }
 
 function getStatusTone(status: string) {
@@ -121,48 +115,28 @@ export function WorkflowTraceTimeline({
   });
 
   return (
-    <section className="space-y-4 p-4 sm:p-6">
-      <div className="space-y-1">
+    <section className="space-y-6 p-4 sm:p-6">
+      <div>
         <p className="text-sm font-medium">Timeline</p>
-        <p className="text-sm text-muted-foreground">
-          Ordered workflow events for this trace.
-        </p>
       </div>
 
-      <ol className="space-y-3">
+      <ol className="space-y-8">
         {orderedEvents.map((event) => (
           <li
             key={`${event.traceId}-${event.sequence}-${event.step}`}
-            className="rounded-xl border border-border/70 bg-background/80 p-4 shadow-sm"
+            className="flex items-center"
           >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="space-y-2">
-                <p className="text-sm font-medium">
-                  {formatTraceLabel(event.step)}
+            <div className="space-y-2">
+              <div className="flex items-center">
+                <Circle className="h-2 w-2 mt-1 mr-2 text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">
+                  {event.message || formatTraceLabel(event.step)}
                 </p>
-                <div className="flex flex-wrap gap-2">
-                  <Badge
-                    variant="outline"
-                    className={getStatusTone(event.status)}
-                  >
-                    {formatTraceLabel(event.status)}
-                  </Badge>
-                  <Badge variant="outline">
-                    {formatTraceLabel(event.kind)}
-                  </Badge>
-                </div>
               </div>
-
-              <p className="text-xs text-muted-foreground">
-                {formatTimestamp(event.occurredAt)}
+              <p className="text-xs ml-4 text-muted-foreground">
+                {getRelativeTime(event.occurredAt)}
               </p>
             </div>
-
-            {event.message ? (
-              <p className="mt-3 text-sm text-muted-foreground">
-                {event.message}
-              </p>
-            ) : null}
           </li>
         ))}
       </ol>

--- a/packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx
+++ b/packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx
@@ -134,7 +134,7 @@ export function WorkflowTraceTimeline({
                 </p>
               </div>
               <p className="text-xs ml-4 text-muted-foreground">
-                {getRelativeTime(event.occurredAt)}
+                {`${getRelativeTime(event.occurredAt)} · ${formatTraceLabel(event.status)} · ${formatTraceLabel(event.kind)}`}
               </p>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- Format register-session trace money messages from stored minor units using the register session store currency
- Preserve raw minor-unit values in trace details for machine-readable metadata
- Rework the workflow trace timeline to match the simpler ActivityView bullet/message/relative-time presentation
- Refresh graphify artifacts after code changes

## Why
Register-session trace timelines were showing raw minor-unit amounts like `148000` to operators. The trace UI also used heavier per-event cards instead of the lighter ActivityView timeline pattern requested for this surface.

## Validation
- `bun run --filter '@athena/webapp' test -- convex/operations/registerSessionTracing.test.ts src/components/traces/WorkflowTraceView.test.tsx`\n- `bun run --filter '@athena/webapp' test -- convex/workflowTraces/presentation.test.ts convex/workflowTraces/queryUsage.test.ts convex/workflowTraces/schemaIndexes.test.ts convex/workflowTraces/adapters/registerSession.test.ts convex/operations/registerSessionTracing.test.ts src/components/traces/WorkflowTraceView.test.tsx`\n- `bun run --filter '@athena/webapp' audit:convex`\n- `bun run --filter '@athena/webapp' lint:convex:changed`\n- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`\n- `bun run --filter '@athena/webapp' build`\n- `bun run graphify:rebuild && bun run graphify:check`\n- `git diff --check`\n\nLinear: https://linear.app/v26-labs/issue/V26-382/format-register-session-trace-money-amounts-for-operators