### PR TITLE
feat(pos): align register flow with product tone guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,8 @@ Rules:
 
 Reusable implementation learnings live under docs/solutions/.
 Before changing a known bug pattern, search docs/solutions/ for related guidance.
+
+## product copy
+
+For in-product copy work, follow [docs/product-copy-tone.md](docs/product-copy-tone.md).
+Keep operator-facing language calm, clear, restrained, and operational, and normalize raw backend wording before it reaches the UI.

--- a/docs/product-copy-tone.md
+++ b/docs/product-copy-tone.md
@@ -1,0 +1,113 @@
+# Product Copy Tone
+
+## Scope
+
+This guide defines Athena's in-product copy tone. Use it for UI labels, toasts, dialogs, empty states, blocking states, confirmations, and operator guidance.
+
+This first version is written broadly for the product, but the first implementation pass is the POS session flow. Do not treat it as marketing voice guidance.
+
+## Voice
+
+Athena product copy should be:
+
+- Calm
+- Clear
+- Restrained
+- Operational
+
+The product should sound composed under pressure. Copy should help someone keep moving, not react emotionally on their behalf.
+
+## Core Rules
+
+- Lead with the system state when something is blocked.
+- Use plain language before internal terminology.
+- Name the next action when the system knows it.
+- Keep one voice across success, warning, and error states.
+- Keep toasts short. Use fuller guidance only in blocking or recovery surfaces.
+- Normalize awkward backend wording before it reaches operators.
+- Do not dramatize failures.
+- Do not add cheerleading or brand flourish to routine operations.
+
+## Message Shape
+
+### Toasts
+
+Use one or two short sentences.
+
+Pattern:
+
+- State.
+- Action, when needed.
+
+Examples:
+
+- `Drawer closed. Open the drawer before updating this sale.`
+- `Barcode not found. Scan again or search by name.`
+- `Sale resumed.`
+
+### Inline and Blocking States
+
+Use slightly fuller copy when the screen is already blocked and the operator needs orientation.
+
+Pattern:
+
+- State headline
+- Short explanation
+- Direct action
+
+Examples:
+
+- `Drawer closed`
+- `Front Counter needs an open drawer before this sale can continue.`
+- `Open the drawer to continue.`
+
+### Confirmations
+
+Keep confirmation copy compact and factual.
+
+Pattern:
+
+- Completed state.
+
+Examples:
+
+- `Sale started.`
+- `Sale placed on hold.`
+- `Drawer open. You can start selling.`
+
+## Preferred Patterns
+
+- `Register sign-in required. Sign in before adding items.`
+- `Sale assigned to a different drawer. Open that drawer before continuing.`
+- `Opening float required. Enter an amount greater than 0.`
+- `Sign-in details not recognized. Enter the username and PIN again.`
+
+## Avoid
+
+- `Please enter your username`
+- `Payment successful!!!`
+- `Something went wrong with the cashier session`
+- `A register session is already open for this terminal.`
+- `The transaction has been processed and approved.`
+
+## Rewrite Examples
+
+| Avoid                                                          | Prefer                                                                                      |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Invalid staff credentials.`                                   | `Sign-in details not recognized. Enter the username and PIN again.`                         |
+| `This staff member has an active session on another terminal.` | `Register sign-in already active at another register. Sign out there before starting here.` |
+| `Open the cash drawer before modifying this sale.`             | `Drawer closed. Open the drawer before updating this sale.`                                 |
+| `No active session to hold`                                    | `No sale in progress. Start a sale before placing it on hold.`                              |
+| `Transaction completed: TXN-0001`                              | `Sale completed. Transaction TXN-0001 recorded.`                                            |
+
+## Implementation Notes
+
+- Expected command failures may originate from server-side business rules, but the browser must normalize operator-facing copy before display.
+- Unexpected failures should still collapse to the shared generic fallback.
+- If a message already fits this guide, it can pass through unchanged.
+
+## POS Pilot Boundary
+
+The POS session flow is the first implementation slice for this guide. That includes cashier sign-in, drawer gating, session controls, product-add failures, checkout completion, and other operator-facing session messaging inside the register workflow.
+
+Future work should extend this guide intentionally to other product areas rather than creating one-off local tone rules.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1504 files · ~0 words
+- 1506 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3830 nodes · 3388 edges · 1419 communities detected
+- 3837 nodes · 3393 edges · 1421 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1429,6 +1429,8 @@
 - [[_COMMUNITY_Community 1416|Community 1416]]
 - [[_COMMUNITY_Community 1417|Community 1417]]
 - [[_COMMUNITY_Community 1418|Community 1418]]
+- [[_COMMUNITY_Community 1419|Community 1419]]
+- [[_COMMUNITY_Community 1420|Community 1420]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1753,112 +1755,112 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 74 - "Community 74"
+Cohesion: 0.32
+Nodes (3): hasCustomerDetails(), trimOptional(), useRegisterViewModel()
+
+### Community 75 - "Community 75"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.52
 Nodes (5): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.43
 Nodes (4): assertRegisterNumberIsAvailable(), mapRegisterTerminalError(), normalizeRegisterNumber(), registerTerminal()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.33
 Nodes (2): formatCurrency(), SummaryStrip()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.52
 Nodes (6): buildCycleCountDrafts(), buildManualDrafts(), buildStockAdjustmentSubmissionKey(), handleModeChange(), handleSubmit(), trimOptional()
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 96 - "Community 96"
-Cohesion: 0.38
-Nodes (3): hasCustomerDetails(), trimOptional(), useRegisterViewModel()
 
 ### Community 97 - "Community 97"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 98 - "Community 98"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 99 - "Community 99"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 100 - "Community 100"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 101 - "Community 101"
 Cohesion: 0.52
@@ -2669,12 +2671,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
-
-### Community 304 - "Community 304"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 304 - "Community 304"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
 
 ### Community 305 - "Community 305"
 Cohesion: 0.67
@@ -2710,79 +2712,79 @@ Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 314 - "Community 314"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 316 - "Community 316"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 321 - "Community 321"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 322 - "Community 322"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 330 - "Community 330"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 331 - "Community 331"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
@@ -2810,11 +2812,11 @@ Nodes (0):
 
 ### Community 338 - "Community 338"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 339 - "Community 339"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 340 - "Community 340"
 Cohesion: 0.67
@@ -2829,16 +2831,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 343 - "Community 343"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 344 - "Community 344"
 Cohesion: 1.0
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 344 - "Community 344"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 345 - "Community 345"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.67
@@ -2846,63 +2848,63 @@ Nodes (0):
 
 ### Community 347 - "Community 347"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 349 - "Community 349"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 351 - "Community 351"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 352 - "Community 352"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 354 - "Community 354"
-Cohesion: 0.67
-Nodes (1): manualChunks()
-
 ### Community 355 - "Community 355"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 357 - "Community 357"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 358 - "Community 358"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 359 - "Community 359"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 360 - "Community 360"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 361 - "Community 361"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.67
@@ -2913,12 +2915,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 364 - "Community 364"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 365 - "Community 365"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 365 - "Community 365"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 366 - "Community 366"
 Cohesion: 0.67
@@ -2929,12 +2931,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 369 - "Community 369"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 369 - "Community 369"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.67
@@ -3013,16 +3015,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 391 - "Community 391"
+### Community 390 - "Community 390"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 391 - "Community 391"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 392 - "Community 392"
 Cohesion: 1.0
@@ -3037,20 +3039,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 395 - "Community 395"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 397 - "Community 397"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 398 - "Community 398"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 399 - "Community 399"
 Cohesion: 1.0
@@ -7132,2048 +7134,2058 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1419 - "Community 1419"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1420 - "Community 1420"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 398`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 399`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 400`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 401`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 402`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 403`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 404`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 405`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 406`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 407`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 408`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 409`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 410`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 411`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 412`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 413`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 414`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 415`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 416`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 417`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 418`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 419`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 420`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 421`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 422`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 423`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 424`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 425`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 426`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 427`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 428`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 429`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 430`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 431`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 432`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 433`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 434`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 435`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 436`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 437`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 438`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 439`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 440`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 441`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 442`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
+- **Thin community `Community 443`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 444`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 445`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 446`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 447`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 448`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 449`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 450`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 451`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 452`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 453`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 454`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 455`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 456`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 457`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 458`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 459`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 460`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 461`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 462`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 463`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 464`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 465`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 466`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 467`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 468`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 469`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 470`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 471`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 472`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 473`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 474`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 475`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 476`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 477`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 478`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 479`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 480`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 481`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 482`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 483`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 484`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 485`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 486`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 487`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 488`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 489`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 490`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 491`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 492`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 493`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 494`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 495`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 496`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 497`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 498`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 499`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 500`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 501`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 502`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 503`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 504`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 505`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 506`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 507`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `SearchResultsSection.tsx`, `SearchResultsSection()`
+- **Thin community `Community 508`** (2 nodes): `SearchResultsSection.tsx`, `SearchResultsSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 509`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 510`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 511`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 512`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 513`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 514`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 515`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 516`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 517`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 518`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 519`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 520`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 521`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 522`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 523`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 524`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 525`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 526`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 527`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 528`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 529`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 530`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 531`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 532`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 533`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 534`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 535`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 536`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 537`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 538`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 539`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 540`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 541`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 542`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 543`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 544`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 545`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 546`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 547`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 548`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 549`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 550`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 551`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 552`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 553`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 554`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 555`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 556`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 557`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 558`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 559`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 560`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 561`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 562`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 563`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 564`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 565`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 566`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 567`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 568`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 569`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 570`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 571`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 572`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 573`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 574`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 575`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 576`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 577`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 578`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 579`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 580`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 581`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 582`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 583`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 584`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 585`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 586`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 587`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 588`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 589`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 590`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 591`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 592`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 593`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 594`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 595`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 596`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 597`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 598`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 599`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 600`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 601`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 602`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 603`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 604`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 605`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 606`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 607`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 608`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 609`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 610`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 611`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 612`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 613`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 614`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 615`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 616`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 617`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 618`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 619`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 620`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 621`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 622`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 623`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 624`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 625`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 626`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 627`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 628`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 629`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 630`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 631`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 632`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 633`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 634`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 635`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 636`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 637`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 638`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 639`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 640`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 641`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 642`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 643`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 644`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 645`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 646`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 647`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 648`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 649`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 650`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 651`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 652`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 653`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 654`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 655`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 656`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 657`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 658`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 659`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 660`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 661`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 662`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 663`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 664`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 665`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 666`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 667`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 668`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 669`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 670`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 671`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 672`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 673`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 674`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 675`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 676`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 677`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 678`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 679`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 680`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 681`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 682`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 683`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 684`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 685`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 686`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 687`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 688`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 689`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 690`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 691`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 692`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 693`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 694`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 695`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 696`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 697`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 698`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 699`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 700`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 701`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 702`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 703`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 704`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 705`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 706`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 707`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 708`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 709`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 710`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 711`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 712`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 713`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 714`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 715`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 716`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 717`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 718`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 719`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 720`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 721`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 722`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 723`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 724`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 725`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 726`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 727`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 728`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 729`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 730`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 731`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 732`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 733`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 734`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 735`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 736`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 737`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 738`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 739`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 740`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 741`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 742`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 743`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 744`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 745`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `api.d.ts`
+- **Thin community `Community 746`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `api.js`
+- **Thin community `Community 747`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 748`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `server.d.ts`
+- **Thin community `Community 749`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `server.js`
+- **Thin community `Community 750`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `app.ts`
+- **Thin community `Community 751`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `auth.config.js`
+- **Thin community `Community 752`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `auth.ts`
+- **Thin community `Community 753`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 754`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `countries.ts`
+- **Thin community `Community 755`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `email.ts`
+- **Thin community `Community 756`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `ghana.ts`
+- **Thin community `Community 757`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `payment.ts`
+- **Thin community `Community 758`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `crons.ts`
+- **Thin community `Community 759`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 760`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 761`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 762`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 763`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `env.ts`
+- **Thin community `Community 764`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `analytics.ts`
+- **Thin community `Community 765`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `auth.ts`
+- **Thin community `Community 766`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 767`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `categories.ts`
+- **Thin community `Community 768`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `colors.ts`
+- **Thin community `Community 769`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `index.ts`
+- **Thin community `Community 770`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `organizations.ts`
+- **Thin community `Community 771`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `products.ts`
+- **Thin community `Community 772`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `stores.ts`
+- **Thin community `Community 773`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 774`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `index.ts`
+- **Thin community `Community 775`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `bag.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `guest.ts`
+- **Thin community `Community 776`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 777`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `me.ts`
+- **Thin community `Community 778`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `offers.ts`
+- **Thin community `Community 779`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 780`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `paystack.ts`
+- **Thin community `Community 781`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `reviews.ts`
+- **Thin community `Community 782`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `rewards.ts`
+- **Thin community `Community 783`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 784`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `security.test.ts`
+- **Thin community `Community 785`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `storefront.ts`
+- **Thin community `Community 786`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `upsells.ts`
+- **Thin community `Community 787`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `user.ts`
+- **Thin community `Community 788`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 789`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `health.test.ts`
+- **Thin community `Community 790`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `http.ts`
+- **Thin community `Community 791`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 792`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 793`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 794`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `categories.ts`
+- **Thin community `Community 795`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `colors.ts`
+- **Thin community `Community 796`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 797`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 798`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 799`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 800`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `organizations.ts`
+- **Thin community `Community 801`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `pos.ts`
+- **Thin community `Community 802`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 803`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 804`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `productSku.ts`
+- **Thin community `Community 805`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 806`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 807`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 808`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 809`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 810`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 811`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 812`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 813`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 814`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `client.test.ts`
+- **Thin community `Community 815`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `config.test.ts`
+- **Thin community `Community 816`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 817`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `types.ts`
+- **Thin community `Community 818`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 819`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 820`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 821`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 822`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 823`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `dto.ts`
+- **Thin community `Community 824`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 825`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 826`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `openDrawer.test.ts`
+- **Thin community `Community 827`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 828`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 829`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `types.ts`
+- **Thin community `Community 830`** (1 nodes): `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 831`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 832`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `catalog.ts`
+- **Thin community `Community 833`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `customers.ts`
+- **Thin community `Community 834`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `register.ts`
+- **Thin community `Community 835`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `terminals.ts`
+- **Thin community `Community 836`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `transactions.ts`
+- **Thin community `Community 837`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `schema.ts`
+- **Thin community `Community 838`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 839`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 840`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 841`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 842`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `category.ts`
+- **Thin community `Community 843`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `color.ts`
+- **Thin community `Community 844`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 845`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 846`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `index.ts`
+- **Thin community `Community 847`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 848`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `organization.ts`
+- **Thin community `Community 849`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 850`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `product.ts`
+- **Thin community `Community 851`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 852`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 853`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `store.ts`
+- **Thin community `Community 854`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 855`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `index.ts`
+- **Thin community `Community 856`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 857`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 858`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 859`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 860`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 861`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `index.ts`
+- **Thin community `Community 862`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 863`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 864`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 865`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 866`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 867`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 868`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 869`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 870`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 871`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `customer.ts`
+- **Thin community `Community 872`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 873`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 874`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 875`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 876`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `index.ts`
+- **Thin community `Community 877`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `posSession.ts`
+- **Thin community `Community 878`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 879`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 880`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 881`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 882`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `index.ts`
+- **Thin community `Community 883`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 884`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 885`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 886`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 887`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 888`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `index.ts`
+- **Thin community `Community 889`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 890`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 891`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 892`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 893`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `vendor.ts`
+- **Thin community `Community 894`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `analytics.ts`
+- **Thin community `Community 895`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `bag.ts`
+- **Thin community `Community 896`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 897`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 898`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 899`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `customer.ts`
+- **Thin community `Community 900`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `guest.ts`
+- **Thin community `Community 901`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `index.ts`
+- **Thin community `Community 902`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `offer.ts`
+- **Thin community `Community 903`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 904`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 905`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `review.ts`
+- **Thin community `Community 906`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `rewards.ts`
+- **Thin community `Community 907`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 908`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 909`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 910`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 911`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 912`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 913`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 914`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `bag.ts`
+- **Thin community `Community 915`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 916`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `customer.ts`
+- **Thin community `Community 917`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `guest.ts`
+- **Thin community `Community 918`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 919`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 920`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `payment.ts`
+- **Thin community `Community 921`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 922`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 923`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 924`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `users.ts`
+- **Thin community `Community 925`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `payment.ts`
+- **Thin community `Community 926`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `posSale.test.ts`
+- **Thin community `Community 927`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 928`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 929`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 930`** (1 nodes): `posSale.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 931`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `index.ts`
+- **Thin community `Community 932`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 933`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `auth.ts`
+- **Thin community `Community 934`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 935`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 936`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 937`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 938`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 939`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 940`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 941`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 942`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `constants.ts`
+- **Thin community `Community 943`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 944`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 945`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 946`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `types.ts`
+- **Thin community `Community 947`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 948`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 949`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 950`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 951`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 952`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 953`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 954`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 955`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `columns.tsx`
+- **Thin community `Community 956`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 957`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 958`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 959`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 960`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `columns.tsx`
+- **Thin community `Community 961`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 962`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 963`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `chart.tsx`
+- **Thin community `Community 964`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `columns.tsx`
+- **Thin community `Community 965`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 967`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 968`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `constants.ts`
+- **Thin community `Community 969`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 970`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 971`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 972`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data.ts`
+- **Thin community `Community 973`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `columns.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 976`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 977`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 979`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 980`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 981`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 982`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 984`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `constants.ts`
+- **Thin community `Community 985`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 986`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 987`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 988`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `data.ts`
+- **Thin community `Community 989`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 990`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 991`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 992`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 993`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 994`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `columns.tsx`
+- **Thin community `Community 995`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 996`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 997`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 998`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 999`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1000`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `constants.ts`
+- **Thin community `Community 1002`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1003`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1004`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1005`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1006`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1007`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1008`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1009`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1010`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1011`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1012`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1013`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1014`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1015`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1016`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1017`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1018`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1019`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1020`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1021`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1022`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1023`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1024`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `constants.ts`
+- **Thin community `Community 1025`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1026`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1027`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1028`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `data.ts`
+- **Thin community `Community 1029`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1030`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `constants.ts`
+- **Thin community `Community 1031`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1032`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1033`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1034`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1035`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `data.ts`
+- **Thin community `Community 1036`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1037`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `constants.ts`
+- **Thin community `Community 1038`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1039`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1040`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1041`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1042`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `data.ts`
+- **Thin community `Community 1043`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1044`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1045`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1046`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1047`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1048`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1049`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1050`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1051`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1052`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1053`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1054`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1055`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1056`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1057`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1058`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1059`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1060`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `RegisterSessionPanel.tsx`
+- **Thin community `Community 1061`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1062`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1063`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1064`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1065`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `WorkflowTraceLink.test.tsx`
+- **Thin community `Community 1066`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `types.ts`
+- **Thin community `Community 1067`** (1 nodes): `WorkflowTraceLink.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1068`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1069`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1070`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1071`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1072`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1073`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 1074`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1075`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1076`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1077`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1078`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1079`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1080`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1081`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1082`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1083`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1084`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1085`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1086`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `data.ts`
+- **Thin community `Community 1087`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1089`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1090`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1091`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1092`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1093`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1094`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1095`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1096`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1097`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1098`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1099`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1100`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `constants.ts`
+- **Thin community `Community 1101`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1102`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1103`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1104`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `data.ts`
+- **Thin community `Community 1105`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `types.ts`
+- **Thin community `Community 1106`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1107`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1108`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1109`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1110`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `index.tsx`
+- **Thin community `Community 1111`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1112`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1113`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1114`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1115`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `index.tsx`
+- **Thin community `Community 1116`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1117`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1118`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1119`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `button.tsx`
+- **Thin community `Community 1120`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1121`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `card.tsx`
+- **Thin community `Community 1122`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1123`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1124`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `command.tsx`
+- **Thin community `Community 1125`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1126`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1127`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1128`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `form.tsx`
+- **Thin community `Community 1129`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1130`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1131`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `input.tsx`
+- **Thin community `Community 1132`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1133`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1134`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1135`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1136`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1137`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `select.tsx`
+- **Thin community `Community 1138`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1139`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1140`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1141`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `table.tsx`
+- **Thin community `Community 1142`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1143`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1144`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1145`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1146`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1147`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1148`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1149`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1150`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `constants.ts`
+- **Thin community `Community 1151`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1152`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1153`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1154`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `data.ts`
+- **Thin community `Community 1155`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1156`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1157`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1158`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1159`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1160`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1161`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1162`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1163`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1164`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1165`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1166`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1167`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1168`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `index.ts`
+- **Thin community `Community 1169`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `config.ts`
+- **Thin community `Community 1170`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1171`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1172`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1173`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1174`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1175`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `aws.ts`
+- **Thin community `Community 1176`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `constants.ts`
+- **Thin community `Community 1177`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `countries.ts`
+- **Thin community `Community 1178`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1179`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1180`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1181`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1182`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1183`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `dto.ts`
+- **Thin community `Community 1185`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `ports.ts`
+- **Thin community `Community 1186`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `constants.ts`
+- **Thin community `Community 1187`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1188`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1189`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `index.ts`
+- **Thin community `Community 1190`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1191`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `types.ts`
+- **Thin community `Community 1192`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1195`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1196`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1197`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `category.ts`
+- **Thin community `Community 1199`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `product.ts`
+- **Thin community `Community 1200`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `store.ts`
+- **Thin community `Community 1201`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1202`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `user.ts`
+- **Thin community `Community 1203`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1204`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1206`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1207`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1208`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `index.tsx`
+- **Thin community `Community 1209`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `index.tsx`
+- **Thin community `Community 1210`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1211`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1212`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1213`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1214`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1215`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1216`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `index.tsx`
+- **Thin community `Community 1217`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1218`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1219`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1220`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `home.tsx`
+- **Thin community `Community 1221`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1222`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1223`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1224`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `index.tsx`
+- **Thin community `Community 1225`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `index.tsx`
+- **Thin community `Community 1226`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1227`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1228`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1229`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `index.tsx`
+- **Thin community `Community 1230`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1231`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1233`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1234`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1235`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1236`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1237`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `index.tsx`
+- **Thin community `Community 1238`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1239`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1240`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1241`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1242`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1243`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1244`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `index.tsx`
+- **Thin community `Community 1245`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `index.tsx`
+- **Thin community `Community 1246`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `new.tsx`
+- **Thin community `Community 1247`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1248`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1249`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1250`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1251`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `index.tsx`
+- **Thin community `Community 1252`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `new.tsx`
+- **Thin community `Community 1253`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1254`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1255`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1256`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1257`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1258`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1259`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1260`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1261`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `index.tsx`
+- **Thin community `Community 1262`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1263`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1264`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1265`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1266`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1267`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1268`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1269`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1271`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1273`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1274`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1275`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1276`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1277`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1278`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1279`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `setup.ts`
+- **Thin community `Community 1281`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1283`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `types.ts`
+- **Thin community `Community 1284`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1285`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1286`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1287`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1288`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `types.ts`
+- **Thin community `Community 1290`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1291`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1292`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1294`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1295`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1296`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1298`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1299`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `schema.ts`
+- **Thin community `Community 1300`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1301`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1302`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1305`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1306`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1307`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1308`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1309`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `types.ts`
+- **Thin community `Community 1310`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1312`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1314`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1315`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1317`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `constants.ts`
+- **Thin community `Community 1318`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1319`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `About.tsx`
+- **Thin community `Community 1320`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1321`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1322`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1323`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1324`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1325`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1326`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1327`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1328`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1329`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `types.ts`
+- **Thin community `Community 1330`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1331`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1332`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1333`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1335`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1336`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1337`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1338`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1339`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1340`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `button.tsx`
+- **Thin community `Community 1341`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `card.tsx`
+- **Thin community `Community 1342`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1343`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `command.tsx`
+- **Thin community `Community 1344`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1345`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1346`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1347`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `form.tsx`
+- **Thin community `Community 1348`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1349`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1350`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1351`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1352`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `input.tsx`
+- **Thin community `Community 1353`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `label.tsx`
+- **Thin community `Community 1354`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1355`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1356`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1357`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `index.ts`
+- **Thin community `Community 1358`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `types.ts`
+- **Thin community `Community 1359`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1360`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1361`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1362`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1363`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `select.tsx`
+- **Thin community `Community 1364`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1365`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1366`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `table.tsx`
+- **Thin community `Community 1367`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1368`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1369`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1370`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1371`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1372`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `config.ts`
+- **Thin community `Community 1373`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1374`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1375`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1376`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `constants.ts`
+- **Thin community `Community 1377`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `countries.ts`
+- **Thin community `Community 1378`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1379`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1380`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1381`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1382`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `index.ts`
+- **Thin community `Community 1383`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `store.ts`
+- **Thin community `Community 1384`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `bag.ts`
+- **Thin community `Community 1385`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1386`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `category.ts`
+- **Thin community `Community 1387`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `organization.ts`
+- **Thin community `Community 1388`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `product.ts`
+- **Thin community `Community 1389`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `store.ts`
+- **Thin community `Community 1390`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1391`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `user.ts`
+- **Thin community `Community 1392`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `states.ts`
+- **Thin community `Community 1393`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1394`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1395`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1396`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1397`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1398`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1399`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1400`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `index.tsx`
+- **Thin community `Community 1401`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1402`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1403`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1404`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1405`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1406`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1407`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1408`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `index.tsx`
+- **Thin community `Community 1409`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1410`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1411`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1412`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1413`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `index.js`
+- **Thin community `Community 1414`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1415`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1416`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1417`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1418`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1419`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1420`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -18796,6 +18796,30 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "_tgt": "cashierauthdialog_test_renderdialog",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L80",
+      "target": "cashierauthdialog_test_renderdialog",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "_tgt": "cashierauthdialog_test_submitcredentials",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L119",
+      "target": "cashierauthdialog_test_submitcredentials",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "_tgt": "cashierview_cashierview",
       "confidence": "EXTRACTED",
@@ -18971,7 +18995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L258",
+      "source_location": "L309",
       "target": "ordersummary_formatstoredamount",
       "weight": 1
     },
@@ -18983,7 +19007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L139",
+      "source_location": "L190",
       "target": "ordersummary_handlecompletetransaction",
       "weight": 1
     },
@@ -18995,7 +19019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L156",
+      "source_location": "L207",
       "target": "ordersummary_handlestartnewtransaction",
       "weight": 1
     },
@@ -19223,20 +19247,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L85",
+      "source_location": "L81",
       "target": "posregisterview_productlookupemptystate",
       "weight": 1
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "_tgt": "posregisterview_usecollapsesidebarforactivesession",
+      "_tgt": "posregisterview_usecollapsesidebarforposflow",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L22",
-      "target": "posregisterview_usecollapsesidebarforactivesession",
+      "target": "posregisterview_usecollapsesidebarforposflow",
       "weight": 1
     },
     {
@@ -19247,7 +19271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L58",
+      "source_location": "L54",
       "target": "posregisterview_uselockdocumentscroll",
       "weight": 1
     },
@@ -19285,6 +19309,18 @@
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
       "source_location": "L44",
       "target": "registerdrawergate_handlesubmit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
+      "_tgt": "registersessionpanel_registersessionpanel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L9",
+      "target": "registersessionpanel_registersessionpanel",
       "weight": 1
     },
     {
@@ -23092,6 +23128,18 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
+      "_tgt": "operatormessages_tooperatormessage",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
+      "source_location": "L44",
+      "target": "operatormessages_tooperatormessage",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "_tgt": "presentcommandtoast_presentcommandtoast",
       "confidence": "EXTRACTED",
@@ -23099,7 +23147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L5",
+      "source_location": "L6",
       "target": "presentcommandtoast_presentcommandtoast",
       "weight": 1
     },
@@ -24191,7 +24239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L85",
+      "source_location": "L86",
       "target": "useregisterviewmodel_combinepaymentsbymethod",
       "weight": 1
     },
@@ -24203,7 +24251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L105",
+      "source_location": "L106",
       "target": "useregisterviewmodel_createpaymentid",
       "weight": 1
     },
@@ -24215,7 +24263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L57",
+      "source_location": "L58",
       "target": "useregisterviewmodel_hascustomerdetails",
       "weight": 1
     },
@@ -24227,8 +24275,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L72",
+      "source_location": "L73",
       "target": "useregisterviewmodel_mapsessioncustomer",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "_tgt": "useregisterviewmodel_presentoperatorerror",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L118",
+      "target": "useregisterviewmodel_presentoperatorerror",
       "weight": 1
     },
     {
@@ -24239,7 +24299,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L112",
+      "source_location": "L113",
       "target": "useregisterviewmodel_trimoptional",
       "weight": 1
     },
@@ -24251,7 +24311,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L117",
+      "source_location": "L122",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -40487,7 +40547,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L215",
+      "source_location": "L228",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -40499,7 +40559,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_trimoptional",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L124",
+      "source_location": "L129",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -41691,68 +41751,95 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1000,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -41761,7 +41848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -41770,7 +41857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -41779,7 +41866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -41788,7 +41875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -41797,7 +41884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -41806,39 +41893,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
       "norm_label": "bulkoperationspage.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1007,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
-      "label": "CashControlsDashboard.auth.test.tsx",
-      "norm_label": "cashcontrolsdashboard.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
-      "label": "CashControlsDashboard.test.tsx",
-      "norm_label": "cashcontrolsdashboard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
-      "label": "RegisterCloseoutView.test.tsx",
-      "norm_label": "registercloseoutview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -41907,6 +41967,33 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
+      "label": "CashControlsDashboard.auth.test.tsx",
+      "norm_label": "cashcontrolsdashboard.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
+      "label": "CashControlsDashboard.test.tsx",
+      "norm_label": "cashcontrolsdashboard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
+      "label": "RegisterCloseoutView.test.tsx",
+      "norm_label": "registercloseoutview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1013,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
       "norm_label": "registersessionview.auth.test.tsx",
@@ -41914,7 +42001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -41923,7 +42010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -41932,7 +42019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -41941,7 +42028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -41950,7 +42037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -41959,39 +42046,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
       "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1017,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
-      "label": "OperationsQueueView.auth.test.tsx",
-      "norm_label": "operationsqueueview.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
-      "label": "OperationsQueueView.test.tsx",
-      "norm_label": "operationsqueueview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
-      "label": "StockAdjustmentWorkspace.test.tsx",
-      "norm_label": "stockadjustmentworkspace.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
       "source_location": "L1"
     },
     {
@@ -42060,6 +42120,33 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
+      "label": "OperationsQueueView.auth.test.tsx",
+      "norm_label": "operationsqueueview.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
+      "label": "OperationsQueueView.test.tsx",
+      "norm_label": "operationsqueueview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
+      "label": "StockAdjustmentWorkspace.test.tsx",
+      "norm_label": "stockadjustmentworkspace.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1023,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
       "norm_label": "orderstatus.test.tsx",
@@ -42067,7 +42154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -42076,7 +42163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -42085,7 +42172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -42094,7 +42181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -42103,7 +42190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -42112,39 +42199,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1027,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -42213,6 +42273,33 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1033,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -42220,7 +42307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -42229,7 +42316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42238,7 +42325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42247,7 +42334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42256,7 +42343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42265,39 +42352,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1037,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "label": "inviteColumns.tsx",
-      "norm_label": "invitecolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -42357,6 +42417,33 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
+      "label": "inviteColumns.tsx",
+      "norm_label": "invitecolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1043,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -42364,7 +42451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42373,7 +42460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42382,7 +42469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -42391,7 +42478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -42400,7 +42487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -42409,39 +42496,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
       "norm_label": "cartitems.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1047,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
-      "label": "CashierAuthDialog.test.tsx",
-      "norm_label": "cashierauthdialog.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "label": "CashierAuthDialog.tsx",
-      "norm_label": "cashierauthdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
@@ -42501,6 +42561,24 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
+      "label": "CashierAuthDialog.tsx",
+      "norm_label": "cashierauthdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
       "norm_label": "productlookup.tsx",
@@ -42508,7 +42586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -42517,7 +42595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -42526,7 +42604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -42535,7 +42613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -42544,7 +42622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -42553,7 +42631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -42562,30 +42640,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
       "norm_label": "expensereportcolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
-      "label": "POSRegisterView.test.tsx",
-      "norm_label": "posregisterview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
-      "label": "RegisterActionBar.tsx",
-      "norm_label": "registeractionbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
       "source_location": "L1"
     },
     {
@@ -42645,6 +42705,24 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
+      "label": "POSRegisterView.test.tsx",
+      "norm_label": "posregisterview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
+      "label": "RegisterActionBar.tsx",
+      "norm_label": "registeractionbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
       "norm_label": "registercheckoutpanel.tsx",
@@ -42652,16 +42730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
-      "label": "RegisterSessionPanel.tsx",
-      "norm_label": "registersessionpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -42670,7 +42739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -42679,7 +42748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -42688,7 +42757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -42697,7 +42766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_test_tsx",
       "label": "WorkflowTraceLink.test.tsx",
@@ -42706,7 +42775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -42715,21 +42784,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
       "norm_label": "procurementview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
-      "label": "ReceivingView.test.tsx",
-      "norm_label": "receivingview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -42789,6 +42849,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
+      "label": "ReceivingView.test.tsx",
+      "norm_label": "receivingview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
       "norm_label": "analyticsinsights.tsx",
@@ -42796,7 +42865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -42805,7 +42874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -42814,7 +42883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -42823,7 +42892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -42832,7 +42901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -42841,7 +42910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -42850,7 +42919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -42859,21 +42928,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "label": "UnresolvedProducts.tsx",
-      "norm_label": "unresolvedproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -42933,6 +42993,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
+      "label": "UnresolvedProducts.tsx",
+      "norm_label": "unresolvedproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
       "norm_label": "complimentaryproducts.tsx",
@@ -42940,7 +43009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -42949,7 +43018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -42958,7 +43027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42967,7 +43036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42976,7 +43045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42985,7 +43054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42994,7 +43063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -43003,21 +43072,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
       "norm_label": "productcolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
-      "label": "PromoCodeHeader.test.tsx",
-      "norm_label": "promocodeheader.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43077,6 +43137,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
+      "label": "PromoCodeHeader.test.tsx",
+      "norm_label": "promocodeheader.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
       "norm_label": "promocodes.tsx",
@@ -43084,7 +43153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -43093,7 +43162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -43102,7 +43171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -43111,7 +43180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -43120,7 +43189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -43129,7 +43198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43138,7 +43207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43147,21 +43216,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -43401,6 +43461,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -43408,7 +43477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -43417,7 +43486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43426,7 +43495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43435,7 +43504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43444,7 +43513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -43453,7 +43522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -43462,7 +43531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -43471,21 +43540,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
       "norm_label": "ratingstars.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "label": "ReviewCard.tsx",
-      "norm_label": "reviewcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1"
     },
     {
@@ -43545,6 +43605,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
+      "label": "ReviewCard.tsx",
+      "norm_label": "reviewcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
@@ -43552,7 +43621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -43561,7 +43630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -43570,7 +43639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -43579,7 +43648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -43588,7 +43657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -43597,7 +43666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -43606,7 +43675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -43615,21 +43684,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
-      "label": "button.test.tsx",
-      "norm_label": "button.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43689,6 +43749,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
+      "label": "button.test.tsx",
+      "norm_label": "button.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
@@ -43696,7 +43765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -43705,7 +43774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -43714,7 +43783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -43723,7 +43792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -43732,7 +43801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -43741,7 +43810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -43750,7 +43819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -43759,21 +43828,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
       "source_location": "L1"
     },
     {
@@ -43833,6 +43893,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
@@ -43840,7 +43909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -43849,7 +43918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -43858,7 +43927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -43867,7 +43936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -43876,7 +43945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -43885,7 +43954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -43894,7 +43963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -43903,21 +43972,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
       "source_location": "L1"
     },
     {
@@ -43977,6 +44037,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
@@ -43984,7 +44053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -43993,7 +44062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -44002,7 +44071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -44011,7 +44080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -44020,7 +44089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -44029,7 +44098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -44038,7 +44107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -44047,21 +44116,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
       "norm_label": "upload-button.tsx",
       "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "label": "BagView.tsx",
-      "norm_label": "bagview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
       "source_location": "L1"
     },
     {
@@ -44121,6 +44181,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
+      "label": "BagView.tsx",
+      "norm_label": "bagview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -44128,7 +44197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -44137,7 +44206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44146,7 +44215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44155,7 +44224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44164,7 +44233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -44173,7 +44242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -44182,7 +44251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -44191,21 +44260,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -44265,6 +44325,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -44272,7 +44341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44281,7 +44350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44290,7 +44359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44299,7 +44368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -44308,7 +44377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -44317,7 +44386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -44326,7 +44395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -44335,21 +44404,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
       "norm_label": "userbehaviorinsights.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1"
     },
     {
@@ -44409,6 +44469,15 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
@@ -44416,7 +44485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -44425,7 +44494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -44434,7 +44503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -44443,7 +44512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -44452,7 +44521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -44461,7 +44530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -44470,7 +44539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -44479,21 +44548,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
       "source_file": "packages/athena-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
-      "label": "presentCommandToast.test.ts",
-      "norm_label": "presentcommandtoast.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
       "source_location": "L1"
     },
     {
@@ -44553,6 +44613,24 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
+      "label": "operatorMessages.test.ts",
+      "norm_label": "operatormessages.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
+      "label": "presentCommandToast.test.ts",
+      "norm_label": "presentcommandtoast.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
       "norm_label": "presentunexpectederrortoast.test.ts",
@@ -44560,7 +44638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -44569,7 +44647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -44578,7 +44656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -44587,7 +44665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -44596,7 +44674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -44605,7 +44683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -44614,30 +44692,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
-      "label": "displayAmounts.test.ts",
-      "norm_label": "displayamounts.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
-      "label": "cart.test.ts",
-      "norm_label": "cart.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
       "source_location": "L1"
     },
     {
@@ -44697,6 +44757,24 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
+      "label": "cart.test.ts",
+      "norm_label": "cart.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1192,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -44704,7 +44782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -44713,7 +44791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -44722,7 +44800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -44731,7 +44809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -44740,7 +44818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -44749,7 +44827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -44758,30 +44836,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
       "norm_label": "useregisterviewmodel.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
@@ -45021,6 +45081,24 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -45028,7 +45106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -45037,7 +45115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -45046,7 +45124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -45055,7 +45133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -45064,7 +45142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -45073,7 +45151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -45082,30 +45160,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
       "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -45165,6 +45225,24 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -45172,7 +45250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -45181,7 +45259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -45190,7 +45268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -45199,7 +45277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -45208,7 +45286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -45217,7 +45295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -45226,30 +45304,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1"
     },
     {
@@ -45309,6 +45369,24 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1222,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
       "norm_label": "dashboard.index.tsx",
@@ -45316,7 +45394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -45325,7 +45403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -45334,7 +45412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -45343,7 +45421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -45352,7 +45430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -45361,7 +45439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -45370,30 +45448,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
       "norm_label": "all.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "label": "cancelled.index.tsx",
-      "norm_label": "cancelled.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1"
     },
     {
@@ -45453,6 +45513,24 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
+      "label": "cancelled.index.tsx",
+      "norm_label": "cancelled.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1232,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -45460,7 +45538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -45469,7 +45547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -45478,7 +45556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -45487,7 +45565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -45496,7 +45574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -45505,7 +45583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -45514,30 +45592,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
       "norm_label": "expense.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1"
     },
     {
@@ -45597,6 +45657,24 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1242,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
       "norm_label": "settings.index.tsx",
@@ -45604,7 +45682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -45613,7 +45691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -45622,7 +45700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -45631,7 +45709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -45640,7 +45718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -45649,7 +45727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -45658,30 +45736,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
       "source_location": "L1"
     },
     {
@@ -45741,6 +45801,24 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1252,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
       "norm_label": "unresolved.tsx",
@@ -45748,7 +45826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -45757,7 +45835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -45766,7 +45844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -45775,7 +45853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -45784,7 +45862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -45793,7 +45871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -45802,30 +45880,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
       "norm_label": "appointments.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
       "source_location": "L1"
     },
     {
@@ -45885,6 +45945,24 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1262,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
       "norm_label": "$traceid.test.tsx",
@@ -45892,7 +45970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -45901,7 +45979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -45910,7 +45988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -45919,7 +45997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -45928,7 +46006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -45937,7 +46015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -45946,30 +46024,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
       "norm_label": "storessettingsaccordion.tsx",
       "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "label": "expenseStore.ts",
-      "norm_label": "expensestore.ts",
-      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -46029,6 +46089,24 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stores_expensestore_ts",
+      "label": "expenseStore.ts",
+      "norm_label": "expensestore.ts",
+      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1272,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
       "norm_label": "foundations-content.test.tsx",
@@ -46036,7 +46114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -46045,7 +46123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -46054,7 +46132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -46063,7 +46141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -46072,7 +46150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -46081,7 +46159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -46090,30 +46168,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
       "norm_label": "dashboardworkspace.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1278,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -46173,6 +46233,24 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1282,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
       "norm_label": "reference-fixtures.test.tsx",
@@ -46180,7 +46258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -46189,7 +46267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -46198,7 +46276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -46207,7 +46285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -46216,7 +46294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -46225,7 +46303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -46234,30 +46312,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
       "norm_label": "global.d.ts",
       "source_file": "packages/storefront-webapp/global.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
       "source_location": "L1"
     },
     {
@@ -46317,6 +46377,24 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1292,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -46324,7 +46402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -46333,7 +46411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -46342,7 +46420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -46351,7 +46429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -46360,7 +46438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -46369,7 +46447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -46378,30 +46456,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
       "norm_label": "checkout.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "label": "Checkout.tsx",
-      "norm_label": "checkout.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1"
     },
     {
@@ -46632,6 +46692,24 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
+      "label": "Checkout.tsx",
+      "norm_label": "checkout.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1302,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
@@ -46639,7 +46717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -46648,7 +46726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -46657,7 +46735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -46666,7 +46744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -46675,7 +46753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -46684,7 +46762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -46693,30 +46771,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
       "norm_label": "customerdetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1308,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "label": "deliveryDetailsSchema.ts",
-      "norm_label": "deliverydetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
@@ -46776,6 +46836,24 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
+      "label": "deliveryDetailsSchema.ts",
+      "norm_label": "deliverydetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1312,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -46783,7 +46861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -46792,7 +46870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -46801,7 +46879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -46810,7 +46888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -46819,7 +46897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -46828,7 +46906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -46837,30 +46915,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
       "norm_label": "mobilemenu.tsx",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
@@ -46920,6 +46980,24 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1322,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
       "norm_label": "about.tsx",
@@ -46927,7 +47005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -46936,7 +47014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -46945,7 +47023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -46954,7 +47032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -46963,7 +47041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -46972,7 +47050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -46981,30 +47059,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
       "norm_label": "existingreviewmessage.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1328,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "label": "ReviewForm.tsx",
-      "norm_label": "reviewform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "label": "SuccessMessage.tsx",
-      "norm_label": "successmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -47064,6 +47124,24 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
+      "label": "ReviewForm.tsx",
+      "norm_label": "reviewform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
+      "label": "SuccessMessage.tsx",
+      "norm_label": "successmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1332,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -47071,7 +47149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -47080,7 +47158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -47089,7 +47167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -47098,7 +47176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -47107,7 +47185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -47116,7 +47194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -47125,30 +47203,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
       "norm_label": "animatedcard.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1338,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "label": "alert.tsx",
-      "norm_label": "alert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1"
     },
     {
@@ -47208,6 +47268,24 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
+      "label": "alert.tsx",
+      "norm_label": "alert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1342,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
       "norm_label": "breadcrumb.tsx",
@@ -47215,7 +47293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -47224,7 +47302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -47233,7 +47311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -47242,7 +47320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -47251,7 +47329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -47260,7 +47338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -47269,30 +47347,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1348,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1"
     },
     {
@@ -47352,6 +47412,24 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1352,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
       "norm_label": "image-with-fallback.tsx",
@@ -47359,7 +47437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -47368,7 +47446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -47377,7 +47455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -47386,7 +47464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -47395,7 +47473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -47404,7 +47482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -47413,30 +47491,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
       "norm_label": "welcomebackmodalanimations.ts",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1358,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1"
     },
     {
@@ -47496,6 +47556,24 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1362,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
       "norm_label": "navigation-menu.tsx",
@@ -47503,7 +47581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -47512,7 +47590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -47521,7 +47599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -47530,7 +47608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -47539,7 +47617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -47548,7 +47626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -47557,30 +47635,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1368,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1"
     },
     {
@@ -47640,6 +47700,24 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1372,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
       "norm_label": "toggle-group.tsx",
@@ -47647,7 +47725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -47656,7 +47734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -47665,7 +47743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -47674,7 +47752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -47683,7 +47761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -47692,7 +47770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -47701,30 +47779,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1378,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
-      "label": "feeUtils.test.ts",
-      "norm_label": "feeutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1"
     },
     {
@@ -47775,6 +47835,24 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
+      "label": "feeUtils.test.ts",
+      "norm_label": "feeutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1382,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
@@ -47782,7 +47860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -47791,7 +47869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -47800,7 +47878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -47809,7 +47887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -47818,7 +47896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -47827,7 +47905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -47836,30 +47914,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1388,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1"
     },
     {
@@ -47910,6 +47970,24 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1392,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -47917,7 +47995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -47926,7 +48004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -47935,7 +48013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -47944,7 +48022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -47953,7 +48031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -47962,7 +48040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -47971,30 +48049,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1398,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
-      "label": "-homePageLoader.test.ts",
-      "norm_label": "-homepageloader.test.ts",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1"
     },
     {
@@ -48216,6 +48276,24 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
+      "label": "-homePageLoader.test.ts",
+      "norm_label": "-homepageloader.test.ts",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1402,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
       "norm_label": "$orderitemid.review.tsx",
@@ -48223,7 +48301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -48232,7 +48310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -48241,7 +48319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -48250,7 +48328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -48259,7 +48337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -48268,7 +48346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -48277,30 +48355,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
       "norm_label": "complete.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1408,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
-      "label": "incomplete.tsx",
-      "norm_label": "incomplete.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
       "source_location": "L1"
     },
     {
@@ -48351,6 +48411,24 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
+      "label": "incomplete.tsx",
+      "norm_label": "incomplete.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1412,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
       "norm_label": "pending.tsx",
@@ -48358,7 +48436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -48367,7 +48445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -48376,7 +48454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -48385,7 +48463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -48394,7 +48472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1417,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -48403,7 +48481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1418,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -48412,21 +48490,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1419,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
       "norm_label": "harness-behavior-scenarios.test.ts",
       "source_file": "scripts/harness-behavior-scenarios.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1418,
-      "file_type": "code",
-      "id": "scripts_harness_repo_validation_test_ts",
-      "label": "harness-repo-validation.test.ts",
-      "norm_label": "harness-repo-validation.test.ts",
-      "source_file": "scripts/harness-repo-validation.test.ts",
       "source_location": "L1"
     },
     {
@@ -48472,6 +48541,15 @@
       "label": "approvalRequests.ts",
       "norm_label": "approvalrequests.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1420,
+      "file_type": "code",
+      "id": "scripts_harness_repo_validation_test_ts",
+      "label": "harness-repo-validation.test.ts",
+      "norm_label": "harness-repo-validation.test.ts",
+      "source_file": "scripts/harness-repo-validation.test.ts",
       "source_location": "L1"
     },
     {
@@ -52891,7 +52969,7 @@
       "label": "formatStoredAmount()",
       "norm_label": "formatstoredamount()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L258"
+      "source_location": "L309"
     },
     {
       "community": 217,
@@ -52900,7 +52978,7 @@
       "label": "handleCompleteTransaction()",
       "norm_label": "handlecompletetransaction()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L139"
+      "source_location": "L190"
     },
     {
       "community": 217,
@@ -52909,7 +52987,7 @@
       "label": "handleStartNewTransaction()",
       "norm_label": "handlestartnewtransaction()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L156"
+      "source_location": "L207"
     },
     {
       "community": 217,
@@ -52936,14 +53014,14 @@
       "label": "ProductLookupEmptyState()",
       "norm_label": "productlookupemptystate()",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L85"
+      "source_location": "L81"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforactivesession",
-      "label": "useCollapseSidebarForActiveSession()",
-      "norm_label": "usecollapsesidebarforactivesession()",
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L22"
     },
@@ -52954,7 +53032,7 @@
       "label": "useLockDocumentScroll()",
       "norm_label": "uselockdocumentscroll()",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L58"
+      "source_location": "L54"
     },
     {
       "community": 219,
@@ -57009,6 +57087,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "cashierauthdialog_test_renderdialog",
+      "label": "renderDialog()",
+      "norm_label": "renderdialog()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "cashierauthdialog_test_submitcredentials",
+      "label": "submitCredentials()",
+      "norm_label": "submitcredentials()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L119"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "label": "CashierAuthDialog.test.tsx",
+      "norm_label": "cashierauthdialog.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
       "norm_label": "registerdrawergate.tsx",
@@ -57016,7 +57121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "registerdrawergate_cashcontrolsbutton",
       "label": "CashControlsButton()",
@@ -57025,7 +57130,7 @@
       "source_location": "L11"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -57034,7 +57139,7 @@
       "source_location": "L44"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -57043,7 +57148,7 @@
       "source_location": "L36"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -57052,7 +57157,7 @@
       "source_location": "L32"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -57061,7 +57166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -57070,7 +57175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -57079,7 +57184,7 @@
       "source_location": "L20"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -57088,7 +57193,7 @@
       "source_location": "L26"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_tsx",
       "label": "WorkflowTraceLink.tsx",
@@ -57097,7 +57202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "workflowtracelink_getworkflowtracelinktarget",
       "label": "getWorkflowTraceLinkTarget()",
@@ -57106,7 +57211,7 @@
       "source_location": "L25"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "workflowtracelink_workflowtracelink",
       "label": "WorkflowTraceLink()",
@@ -57115,7 +57220,7 @@
       "source_location": "L36"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -57124,7 +57229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -57133,7 +57238,7 @@
       "source_location": "L65"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -57142,7 +57247,7 @@
       "source_location": "L20"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -57151,7 +57256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -57160,7 +57265,7 @@
       "source_location": "L16"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -57169,7 +57274,7 @@
       "source_location": "L60"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -57178,7 +57283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -57187,7 +57292,7 @@
       "source_location": "L45"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -57196,7 +57301,7 @@
       "source_location": "L19"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -57205,7 +57310,7 @@
       "source_location": "L128"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -57214,7 +57319,7 @@
       "source_location": "L40"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -57223,7 +57328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -57232,7 +57337,7 @@
       "source_location": "L24"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -57241,39 +57346,12 @@
       "source_location": "L20"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
       "norm_label": "color-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "currency_provider_currencyprovider",
-      "label": "CurrencyProvider()",
-      "norm_label": "currencyprovider()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "currency_provider_usestorecurrency",
-      "label": "useStoreCurrency()",
-      "norm_label": "usestorecurrency()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "label": "currency-provider.tsx",
-      "norm_label": "currency-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -57405,6 +57483,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "currency_provider_currencyprovider",
+      "label": "CurrencyProvider()",
+      "norm_label": "currencyprovider()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "currency_provider_usestorecurrency",
+      "label": "useStoreCurrency()",
+      "norm_label": "usestorecurrency()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
+      "label": "currency-provider.tsx",
+      "norm_label": "currency-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
       "norm_label": "serviceappointmentsview.test.tsx",
@@ -57412,7 +57517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -57421,7 +57526,7 @@
       "source_location": "L59"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -57430,7 +57535,7 @@
       "source_location": "L50"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -57439,7 +57544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -57448,7 +57553,7 @@
       "source_location": "L225"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -57457,7 +57562,7 @@
       "source_location": "L80"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -57466,7 +57571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -57475,7 +57580,7 @@
       "source_location": "L127"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -57484,7 +57589,7 @@
       "source_location": "L71"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -57493,7 +57598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -57502,7 +57607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -57511,7 +57616,7 @@
       "source_location": "L3"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -57520,7 +57625,7 @@
       "source_location": "L9"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -57529,7 +57634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -57538,7 +57643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -57547,7 +57652,7 @@
       "source_location": "L3"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -57556,7 +57661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -57565,7 +57670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -57574,7 +57679,7 @@
       "source_location": "L3"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -57583,7 +57688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -57592,7 +57697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -57601,7 +57706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -57610,7 +57715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -57619,7 +57724,7 @@
       "source_location": "L3"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -57628,7 +57733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -57637,40 +57742,13 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
       "norm_label": "transactionsskeleton()",
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "notfound_notfound",
-      "label": "NotFound()",
-      "norm_label": "notfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
-      "label": "NotFound.tsx",
-      "norm_label": "notfound.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
-      "label": "NotFound.tsx",
-      "norm_label": "notfound.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L1"
     },
     {
       "community": 32,
@@ -57801,6 +57879,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "notfound_notfound",
+      "label": "NotFound()",
+      "norm_label": "notfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
+      "label": "NotFound.tsx",
+      "norm_label": "notfound.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
+      "label": "NotFound.tsx",
+      "norm_label": "notfound.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
       "norm_label": "handletoggleallfees()",
@@ -57808,7 +57913,7 @@
       "source_location": "L120"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -57817,7 +57922,7 @@
       "source_location": "L36"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -57826,7 +57931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -57835,7 +57940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -57844,7 +57949,7 @@
       "source_location": "L23"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -57853,7 +57958,7 @@
       "source_location": "L41"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -57862,7 +57967,7 @@
       "source_location": "L20"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -57871,7 +57976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -57880,7 +57985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -57889,7 +57994,7 @@
       "source_location": "L30"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -57898,7 +58003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -57907,7 +58012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -57916,7 +58021,7 @@
       "source_location": "L9"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -57925,7 +58030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -57934,7 +58039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -57943,7 +58048,7 @@
       "source_location": "L38"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -57952,7 +58057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -57961,7 +58066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -57970,7 +58075,7 @@
       "source_location": "L20"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -57979,7 +58084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -57988,7 +58093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -57997,7 +58102,7 @@
       "source_location": "L12"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -58006,7 +58111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -58015,7 +58120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -58024,7 +58129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -58033,40 +58138,13 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
       "norm_label": "skeleton()",
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
-      "label": "sonner.tsx",
-      "norm_label": "sonner.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
-      "label": "sonner.tsx",
-      "norm_label": "sonner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "sonner_toaster",
-      "label": "Toaster()",
-      "norm_label": "toaster()",
-      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
-      "source_location": "L6"
     },
     {
       "community": 33,
@@ -58188,6 +58266,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
+      "label": "sonner.tsx",
+      "norm_label": "sonner.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
+      "label": "sonner.tsx",
+      "norm_label": "sonner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "sonner_toaster",
+      "label": "Toaster()",
+      "norm_label": "toaster()",
+      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
       "norm_label": "spinner.tsx",
@@ -58195,7 +58300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -58204,7 +58309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -58213,7 +58318,7 @@
       "source_location": "L3"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -58222,7 +58327,7 @@
       "source_location": "L44"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -58231,7 +58336,7 @@
       "source_location": "L19"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -58240,7 +58345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -58249,7 +58354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -58258,7 +58363,7 @@
       "source_location": "L159"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -58267,7 +58372,7 @@
       "source_location": "L195"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -58276,7 +58381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -58285,7 +58390,7 @@
       "source_location": "L22"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -58294,7 +58399,7 @@
       "source_location": "L45"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -58303,7 +58408,7 @@
       "source_location": "L24"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -58312,7 +58417,7 @@
       "source_location": "L38"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -58321,7 +58426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -58330,7 +58435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -58339,7 +58444,7 @@
       "source_location": "L23"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -58348,7 +58453,7 @@
       "source_location": "L51"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -58357,7 +58462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -58366,7 +58471,7 @@
       "source_location": "L54"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -58375,7 +58480,7 @@
       "source_location": "L282"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -58384,7 +58489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -58393,7 +58498,7 @@
       "source_location": "L12"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -58402,7 +58507,7 @@
       "source_location": "L37"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -58411,7 +58516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -58420,40 +58525,13 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
       "norm_label": "useauth()",
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
-      "label": "useGetActiveStore.ts",
-      "norm_label": "usegetactivestore.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "usegetactivestore_usegetactivestore",
-      "label": "useGetActiveStore()",
-      "norm_label": "usegetactivestore()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "usegetactivestore_usegetstores",
-      "label": "useGetStores()",
-      "norm_label": "usegetstores()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
-      "source_location": "L50"
     },
     {
       "community": 34,
@@ -58575,6 +58653,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
+      "label": "useGetActiveStore.ts",
+      "norm_label": "usegetactivestore.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "usegetactivestore_usegetactivestore",
+      "label": "useGetActiveStore()",
+      "norm_label": "usegetactivestore()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "usegetactivestore_usegetstores",
+      "label": "useGetStores()",
+      "norm_label": "usegetstores()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
       "norm_label": "usegetorganizations.ts",
@@ -58582,7 +58687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -58591,7 +58696,7 @@
       "source_location": "L6"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -58600,7 +58705,7 @@
       "source_location": "L31"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -58609,7 +58714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -58618,7 +58723,7 @@
       "source_location": "L5"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -58627,7 +58732,7 @@
       "source_location": "L31"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -58636,7 +58741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -58645,7 +58750,7 @@
       "source_location": "L19"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -58654,7 +58759,7 @@
       "source_location": "L33"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -58663,7 +58768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -58672,7 +58777,7 @@
       "source_location": "L18"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -58681,7 +58786,7 @@
       "source_location": "L26"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -58690,7 +58795,7 @@
       "source_location": "L7"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -58699,7 +58804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -58708,7 +58813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -58717,7 +58822,7 @@
       "source_location": "L3"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -58726,7 +58831,7 @@
       "source_location": "L10"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -58735,7 +58840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -58744,7 +58849,7 @@
       "source_location": "L18"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -58753,7 +58858,7 @@
       "source_location": "L59"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -58762,7 +58867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -58771,7 +58876,7 @@
       "source_location": "L31"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -58780,7 +58885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -58789,7 +58894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -58798,7 +58903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -58807,40 +58912,13 @@
       "source_location": "L28"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
       "norm_label": "findillegalconveximports()",
       "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
       "source_location": "L46"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "authed_authedcomponent",
-      "label": "AuthedComponent()",
-      "norm_label": "authedcomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "authed_layout",
-      "label": "Layout()",
-      "norm_label": "layout()",
-      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_tsx",
-      "label": "_authed.tsx",
-      "norm_label": "_authed.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L1"
     },
     {
       "community": 35,
@@ -58962,6 +59040,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "authed_authedcomponent",
+      "label": "AuthedComponent()",
+      "norm_label": "authedcomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "authed_layout",
+      "label": "Layout()",
+      "norm_label": "layout()",
+      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_tsx",
+      "label": "_authed.tsx",
+      "norm_label": "_authed.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
       "norm_label": "patterncard()",
@@ -58969,7 +59074,7 @@
       "source_location": "L127"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -58978,7 +59083,7 @@
       "source_location": "L106"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -58987,7 +59092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -58996,7 +59101,7 @@
       "source_location": "L66"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -59005,7 +59110,7 @@
       "source_location": "L20"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -59014,7 +59119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -59023,7 +59128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -59032,7 +59137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -59041,7 +59146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -59050,7 +59155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -59059,7 +59164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -59068,7 +59173,7 @@
       "source_location": "L16"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -59077,7 +59182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -59086,7 +59191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -59095,7 +59200,7 @@
       "source_location": "L19"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -59104,7 +59209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -59113,7 +59218,7 @@
       "source_location": "L23"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -59122,7 +59227,7 @@
       "source_location": "L24"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -59131,7 +59236,7 @@
       "source_location": "L32"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -59140,7 +59245,7 @@
       "source_location": "L3"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -59149,7 +59254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -59158,7 +59263,7 @@
       "source_location": "L7"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -59167,7 +59272,7 @@
       "source_location": "L5"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -59176,7 +59281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -59185,7 +59290,7 @@
       "source_location": "L6"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -59194,40 +59299,13 @@
       "source_location": "L18"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "upsells_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "upsells_getlastviewedproduct",
-      "label": "getLastViewedProduct()",
-      "norm_label": "getlastviewedproduct()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L5"
     },
     {
       "community": 36,
@@ -59349,6 +59427,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "upsells_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "upsells_getlastviewedproduct",
+      "label": "getLastViewedProduct()",
+      "norm_label": "getlastviewedproduct()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -59356,7 +59461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -59365,7 +59470,7 @@
       "source_location": "L18"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -59374,7 +59479,7 @@
       "source_location": "L23"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -59383,7 +59488,7 @@
       "source_location": "L22"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -59392,7 +59497,7 @@
       "source_location": "L55"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -59401,7 +59506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -59410,7 +59515,7 @@
       "source_location": "L77"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -59419,7 +59524,7 @@
       "source_location": "L11"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -59428,7 +59533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -59437,7 +59542,7 @@
       "source_location": "L11"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -59446,7 +59551,7 @@
       "source_location": "L22"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -59455,7 +59560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -59464,7 +59569,7 @@
       "source_location": "L110"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -59473,7 +59578,7 @@
       "source_location": "L89"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -59482,7 +59587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -59491,7 +59596,7 @@
       "source_location": "L4"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -59500,7 +59605,7 @@
       "source_location": "L24"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -59509,7 +59614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -59518,7 +59623,7 @@
       "source_location": "L131"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -59527,7 +59632,7 @@
       "source_location": "L12"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -59536,7 +59641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -59545,7 +59650,7 @@
       "source_location": "L20"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -59554,7 +59659,7 @@
       "source_location": "L46"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -59563,7 +59668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -59572,7 +59677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -59581,40 +59686,13 @@
       "source_location": "L20"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
       "norm_label": "promoalert()",
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "label": "RewardsAlert.tsx",
-      "norm_label": "rewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "rewardsalert_handleshopnow",
-      "label": "handleShopNow()",
-      "norm_label": "handleshopnow()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "rewardsalert_onrewardsalertclose",
-      "label": "onRewardsAlertClose()",
-      "norm_label": "onrewardsalertclose()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L20"
     },
     {
       "community": 37,
@@ -59736,6 +59814,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
+      "label": "RewardsAlert.tsx",
+      "norm_label": "rewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "rewardsalert_handleshopnow",
+      "label": "handleShopNow()",
+      "norm_label": "handleshopnow()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "rewardsalert_onrewardsalertclose",
+      "label": "onRewardsAlertClose()",
+      "norm_label": "onrewardsalertclose()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
       "norm_label": "navigationbar()",
@@ -59743,7 +59848,7 @@
       "source_location": "L30"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -59752,7 +59857,7 @@
       "source_location": "L95"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -59761,7 +59866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -59770,7 +59875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -59779,7 +59884,7 @@
       "source_location": "L61"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -59788,7 +59893,7 @@
       "source_location": "L65"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -59797,7 +59902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -59806,7 +59911,7 @@
       "source_location": "L150"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -59815,7 +59920,7 @@
       "source_location": "L157"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -59824,7 +59929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -59833,7 +59938,7 @@
       "source_location": "L63"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -59842,7 +59947,7 @@
       "source_location": "L48"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -59851,7 +59956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -59860,7 +59965,7 @@
       "source_location": "L63"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -59869,7 +59974,7 @@
       "source_location": "L76"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -59878,7 +59983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -59887,7 +59992,7 @@
       "source_location": "L51"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -59896,7 +60001,7 @@
       "source_location": "L36"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -59905,7 +60010,7 @@
       "source_location": "L16"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -59914,7 +60019,7 @@
       "source_location": "L39"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -59923,7 +60028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -59932,7 +60037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -59941,7 +60046,7 @@
       "source_location": "L25"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -59950,7 +60055,7 @@
       "source_location": "L82"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -59959,7 +60064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -59968,40 +60073,13 @@
       "source_location": "L20"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
       "norm_label": "usestorefrontobservability()",
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
     },
     {
       "community": 38,
@@ -60114,6 +60192,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
       "norm_label": "useshoppingbag.ts",
@@ -60121,7 +60226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -60130,7 +60235,7 @@
       "source_location": "L556"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -60139,7 +60244,7 @@
       "source_location": "L52"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -60148,7 +60253,7 @@
       "source_location": "L429"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -60157,7 +60262,7 @@
       "source_location": "L102"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -60166,7 +60271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -60175,7 +60280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -60184,7 +60289,7 @@
       "source_location": "L250"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -60193,7 +60298,7 @@
       "source_location": "L46"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -60202,7 +60307,7 @@
       "source_location": "L17"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -60211,7 +60316,7 @@
       "source_location": "L63"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -60220,7 +60325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -60229,7 +60334,7 @@
       "source_location": "L47"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -60238,7 +60343,7 @@
       "source_location": "L141"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -60247,7 +60352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -60256,7 +60361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -60265,7 +60370,7 @@
       "source_location": "L21"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -60274,7 +60379,7 @@
       "source_location": "L107"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -60283,7 +60388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -60292,7 +60397,7 @@
       "source_location": "L161"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -60301,7 +60406,7 @@
       "source_location": "L66"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -60310,7 +60415,7 @@
       "source_location": "L11"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -60319,7 +60424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -60328,7 +60433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -60337,7 +60442,7 @@
       "source_location": "L16"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -60346,39 +60451,12 @@
       "source_location": "L10"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
       "norm_label": "graphify-wiki.test.ts",
       "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "harness_audit_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "harness_audit_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "scripts_harness_audit_test_ts",
-      "label": "harness-audit.test.ts",
-      "norm_label": "harness-audit.test.ts",
-      "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1"
     },
     {
@@ -60492,6 +60570,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "harness_audit_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "harness_audit_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "scripts_harness_audit_test_ts",
+      "label": "harness-audit.test.ts",
+      "norm_label": "harness-audit.test.ts",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -60499,7 +60604,7 @@
       "source_location": "L21"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -60508,7 +60613,7 @@
       "source_location": "L15"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -60517,7 +60622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -60526,7 +60631,7 @@
       "source_location": "L48"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -60535,7 +60640,7 @@
       "source_location": "L42"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -60544,7 +60649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -60553,7 +60658,7 @@
       "source_location": "L16"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -60562,7 +60667,7 @@
       "source_location": "L10"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -60571,7 +60676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -60580,7 +60685,7 @@
       "source_location": "L19"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -60589,7 +60694,7 @@
       "source_location": "L13"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -60598,7 +60703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -60607,7 +60712,7 @@
       "source_location": "L16"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -60616,7 +60721,7 @@
       "source_location": "L10"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -60625,7 +60730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -60634,7 +60739,7 @@
       "source_location": "L20"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -60643,7 +60748,7 @@
       "source_location": "L14"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -60652,7 +60757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -60661,7 +60766,7 @@
       "source_location": "L26"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -60670,7 +60775,7 @@
       "source_location": "L18"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -60679,7 +60784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -60688,7 +60793,7 @@
       "source_location": "L45"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -60697,7 +60802,7 @@
       "source_location": "L20"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -60706,7 +60811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -60715,30 +60820,12 @@
       "source_location": "L8"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
       "norm_label": "closeouts.test.ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "deposits_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
-      "label": "deposits.test.ts",
-      "norm_label": "deposits.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
       "source_location": "L1"
     },
     {
@@ -61095,6 +61182,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "deposits_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
+      "label": "deposits.test.ts",
+      "norm_label": "deposits.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
       "norm_label": "paymentallocationattribution.test.ts",
@@ -61102,7 +61207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61111,7 +61216,7 @@
       "source_location": "L12"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -61120,7 +61225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -61129,7 +61234,7 @@
       "source_location": "L8"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -61138,7 +61243,7 @@
       "source_location": "L10"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -61147,7 +61252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -61156,7 +61261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -61165,7 +61270,7 @@
       "source_location": "L18"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -61174,7 +61279,7 @@
       "source_location": "L10"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -61183,7 +61288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -61192,7 +61297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61201,7 +61306,7 @@
       "source_location": "L6"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -61210,7 +61315,7 @@
       "source_location": "L110"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -61219,7 +61324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -61228,7 +61333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61237,7 +61342,7 @@
       "source_location": "L8"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -61246,31 +61351,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
       "norm_label": "usererrorfromsessionitemfailure()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L22"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "stores_tov2onlyconfig",
-      "label": "toV2OnlyConfig()",
-      "norm_label": "tov2onlyconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L29"
     },
     {
       "community": 41,
@@ -61374,6 +61461,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "stores_tov2onlyconfig",
+      "label": "toV2OnlyConfig()",
+      "norm_label": "tov2onlyconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
       "norm_label": "commandresultvalidator()",
@@ -61381,7 +61486,7 @@
       "source_location": "L22"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -61390,7 +61495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -61399,7 +61504,7 @@
       "source_location": "L4"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -61408,7 +61513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -61417,7 +61522,7 @@
       "source_location": "L3"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -61426,7 +61531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -61435,7 +61540,7 @@
       "source_location": "L3"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -61444,7 +61549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61453,7 +61558,7 @@
       "source_location": "L6"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -61462,7 +61567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -61471,7 +61576,7 @@
       "source_location": "L3"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -61480,7 +61585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -61489,7 +61594,7 @@
       "source_location": "L19"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -61498,7 +61603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -61507,7 +61612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -61516,7 +61621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -61525,30 +61630,12 @@
       "source_location": "L9"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
       "norm_label": "emailotp.ts",
       "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "inventoryholdgateway_createinventoryholdgateway",
-      "label": "createInventoryHoldGateway()",
-      "norm_label": "createinventoryholdgateway()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "label": "inventoryHoldGateway.ts",
-      "norm_label": "inventoryholdgateway.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
       "source_location": "L1"
     },
     {
@@ -61653,6 +61740,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "inventoryholdgateway_createinventoryholdgateway",
+      "label": "createInventoryHoldGateway()",
+      "norm_label": "createinventoryholdgateway()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
+      "label": "inventoryHoldGateway.ts",
+      "norm_label": "inventoryholdgateway.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
       "norm_label": "getcashierforregisterstate()",
@@ -61660,7 +61765,7 @@
       "source_location": "L6"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -61669,7 +61774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -61678,7 +61783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -61687,7 +61792,7 @@
       "source_location": "L88"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -61696,7 +61801,7 @@
       "source_location": "L9"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -61705,7 +61810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -61714,7 +61819,7 @@
       "source_location": "L4"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -61723,7 +61828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -61732,7 +61837,7 @@
       "source_location": "L15"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -61741,7 +61846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -61750,7 +61855,7 @@
       "source_location": "L7"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -61759,7 +61864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -61768,7 +61873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -61777,7 +61882,7 @@
       "source_location": "L8"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -61786,7 +61891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -61795,7 +61900,7 @@
       "source_location": "L5"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -61804,30 +61909,12 @@
       "source_location": "L15"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_test_createqueryctx",
-      "label": "createQueryCtx()",
-      "norm_label": "createqueryctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
-      "label": "customerBehaviorTimeline.test.ts",
-      "norm_label": "customerbehaviortimeline.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
       "source_location": "L1"
     },
     {
@@ -61932,6 +62019,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "customerbehaviortimeline_test_createqueryctx",
+      "label": "createQueryCtx()",
+      "norm_label": "createqueryctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
+      "label": "customerBehaviorTimeline.test.ts",
+      "norm_label": "customerbehaviortimeline.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
       "norm_label": "createanalyticsevent()",
@@ -61939,7 +62044,7 @@
       "source_location": "L17"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -61948,7 +62053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61957,7 +62062,7 @@
       "source_location": "L6"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -61966,7 +62071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -61975,7 +62080,7 @@
       "source_location": "L5"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -61984,7 +62089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -61993,7 +62098,7 @@
       "source_location": "L25"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -62002,7 +62107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -62011,7 +62116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -62020,7 +62125,7 @@
       "source_location": "L19"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -62029,7 +62134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -62038,7 +62143,7 @@
       "source_location": "L7"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -62047,7 +62152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -62056,7 +62161,7 @@
       "source_location": "L14"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -62065,7 +62170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -62074,7 +62179,7 @@
       "source_location": "L8"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -62083,31 +62188,13 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
       "norm_label": "issyntheticmonitororigin()",
       "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
-      "label": "timeQueryRefactors.test.ts",
-      "norm_label": "timequeryrefactors.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "timequeryrefactors_test_readsource",
-      "label": "readSource()",
-      "norm_label": "readsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L5"
     },
     {
       "community": 44,
@@ -62211,6 +62298,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
+      "label": "timeQueryRefactors.test.ts",
+      "norm_label": "timequeryrefactors.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "timequeryrefactors_test_readsource",
+      "label": "readSource()",
+      "norm_label": "readsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -62218,7 +62323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -62227,7 +62332,7 @@
       "source_location": "L16"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -62236,7 +62341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -62245,7 +62350,7 @@
       "source_location": "L30"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_ts",
       "label": "posSale.ts",
@@ -62254,7 +62359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "possale_buildpossaletraceseed",
       "label": "buildPosSaleTraceSeed()",
@@ -62263,7 +62368,7 @@
       "source_location": "L43"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -62272,7 +62377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -62281,7 +62386,7 @@
       "source_location": "L43"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -62290,7 +62395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -62299,7 +62404,7 @@
       "source_location": "L31"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -62308,7 +62413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -62317,7 +62422,7 @@
       "source_location": "L5"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -62326,7 +62431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -62335,7 +62440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -62344,7 +62449,7 @@
       "source_location": "L7"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -62353,7 +62458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -62362,31 +62467,13 @@
       "source_location": "L12"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
       "norm_label": "organizationsview.tsx",
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
-      "label": "PermissionGate.tsx",
-      "norm_label": "permissiongate.tsx",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "permissiongate_permissiongate",
-      "label": "PermissionGate()",
-      "norm_label": "permissiongate()",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L11"
     },
     {
       "community": 45,
@@ -62490,6 +62577,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
+      "label": "PermissionGate.tsx",
+      "norm_label": "permissiongate.tsx",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "permissiongate_permissiongate",
+      "label": "PermissionGate()",
+      "norm_label": "permissiongate()",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
       "norm_label": "protectedroute.tsx",
@@ -62497,7 +62602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -62506,7 +62611,7 @@
       "source_location": "L11"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -62515,7 +62620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -62524,7 +62629,7 @@
       "source_location": "L3"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -62533,7 +62638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -62542,7 +62647,7 @@
       "source_location": "L12"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -62551,7 +62656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -62560,7 +62665,7 @@
       "source_location": "L42"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -62569,7 +62674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -62578,7 +62683,7 @@
       "source_location": "L13"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -62587,7 +62692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -62596,7 +62701,7 @@
       "source_location": "L42"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -62605,7 +62710,7 @@
       "source_location": "L31"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -62614,7 +62719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -62623,7 +62728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -62632,7 +62737,7 @@
       "source_location": "L10"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -62641,31 +62746,13 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
       "norm_label": "isallowedattribute()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
-      "label": "ProductAvailabilityToggleGroup.tsx",
-      "norm_label": "productavailabilitytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "label": "ProductAvailabilityToggleGroup()",
-      "norm_label": "productavailabilitytogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L5"
     },
     {
       "community": 46,
@@ -62760,6 +62847,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
+      "label": "ProductAvailabilityToggleGroup.tsx",
+      "norm_label": "productavailabilitytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
+      "label": "ProductAvailabilityToggleGroup()",
+      "norm_label": "productavailabilitytogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -62767,7 +62872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -62776,7 +62881,7 @@
       "source_location": "L10"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -62785,7 +62890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -62794,7 +62899,7 @@
       "source_location": "L15"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -62803,7 +62908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -62812,7 +62917,7 @@
       "source_location": "L13"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -62821,7 +62926,7 @@
       "source_location": "L116"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -62830,7 +62935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -62839,7 +62944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -62848,7 +62953,7 @@
       "source_location": "L47"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -62857,7 +62962,7 @@
       "source_location": "L151"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -62866,7 +62971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -62875,7 +62980,7 @@
       "source_location": "L6"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -62884,7 +62989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -62893,7 +62998,7 @@
       "source_location": "L19"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -62902,7 +63007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -62911,30 +63016,12 @@
       "source_location": "L7"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
       "norm_label": "analyticsusers.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "label": "getDateRangeMilliseconds()",
-      "norm_label": "getdaterangemilliseconds()",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
-      "label": "EnhancedAnalyticsView.tsx",
-      "norm_label": "enhancedanalyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1"
     },
     {
@@ -63030,6 +63117,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "enhancedanalyticsview_getdaterangemilliseconds",
+      "label": "getDateRangeMilliseconds()",
+      "norm_label": "getdaterangemilliseconds()",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
+      "label": "EnhancedAnalyticsView.tsx",
+      "norm_label": "enhancedanalyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
       "norm_label": "storeinsights.tsx",
@@ -63037,7 +63142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -63046,7 +63151,7 @@
       "source_location": "L66"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -63055,7 +63160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -63064,7 +63169,7 @@
       "source_location": "L18"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -63073,7 +63178,7 @@
       "source_location": "L6"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -63082,7 +63187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -63091,7 +63196,7 @@
       "source_location": "L10"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -63100,7 +63205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -63109,7 +63214,7 @@
       "source_location": "L27"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -63118,7 +63223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -63127,7 +63232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -63136,7 +63241,7 @@
       "source_location": "L12"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -63145,7 +63250,7 @@
       "source_location": "L3"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -63154,7 +63259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -63163,7 +63268,7 @@
       "source_location": "L5"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -63172,7 +63277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -63181,30 +63286,12 @@
       "source_location": "L49"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
       "norm_label": "bulkoperationsfilters.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "bulkoperationspreview_test_makerow",
-      "label": "makeRow()",
-      "norm_label": "makerow()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
-      "label": "BulkOperationsPreview.test.tsx",
-      "norm_label": "bulkoperationspreview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1"
     },
     {
@@ -63300,6 +63387,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "bulkoperationspreview_test_makerow",
+      "label": "makeRow()",
+      "norm_label": "makerow()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
+      "label": "BulkOperationsPreview.test.tsx",
+      "norm_label": "bulkoperationspreview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
       "norm_label": "formatprice()",
@@ -63307,7 +63412,7 @@
       "source_location": "L50"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -63316,7 +63421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -63325,7 +63430,7 @@
       "source_location": "L13"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -63334,7 +63439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -63343,7 +63448,7 @@
       "source_location": "L11"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -63352,7 +63457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -63361,7 +63466,7 @@
       "source_location": "L31"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -63370,7 +63475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -63379,7 +63484,7 @@
       "source_location": "L29"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -63388,7 +63493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -63397,7 +63502,7 @@
       "source_location": "L37"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -63406,7 +63511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -63415,7 +63520,7 @@
       "source_location": "L25"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -63424,7 +63529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -63433,7 +63538,7 @@
       "source_location": "L83"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -63442,7 +63547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -63451,31 +63556,13 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
       "norm_label": "handleaddfeatureditem()",
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L35"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
-      "label": "ShopLookImageUploader.tsx",
-      "norm_label": "shoplookimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "shoplookimageuploader_shoplookimageuploader",
-      "label": "ShopLookImageUploader()",
-      "norm_label": "shoplookimageuploader()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L28"
     },
     {
       "community": 49,
@@ -63570,6 +63657,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
+      "label": "ShopLookImageUploader.tsx",
+      "norm_label": "shoplookimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "shoplookimageuploader_shoplookimageuploader",
+      "label": "ShopLookImageUploader()",
+      "norm_label": "shoplookimageuploader()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
       "norm_label": "jointeam()",
@@ -63577,7 +63682,7 @@
       "source_location": "L12"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -63586,7 +63691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -63595,7 +63700,7 @@
       "source_location": "L13"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -63604,7 +63709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -63613,7 +63718,7 @@
       "source_location": "L43"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -63622,7 +63727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -63631,7 +63736,7 @@
       "source_location": "L33"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -63640,7 +63745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -63649,7 +63754,7 @@
       "source_location": "L35"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -63658,7 +63763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -63667,7 +63772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -63676,7 +63781,7 @@
       "source_location": "L81"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -63685,7 +63790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -63694,7 +63799,7 @@
       "source_location": "L6"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -63703,7 +63808,7 @@
       "source_location": "L34"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -63712,7 +63817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -63721,30 +63826,12 @@
       "source_location": "L89"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
       "norm_label": "ordercolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "cashierview_cashierview",
-      "label": "CashierView()",
-      "norm_label": "cashierview()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "label": "CashierView.tsx",
-      "norm_label": "cashierview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1"
     },
     {
@@ -64092,6 +64179,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "cashierview_cashierview",
+      "label": "CashierView()",
+      "norm_label": "cashierview()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
+      "label": "CashierView.tsx",
+      "norm_label": "cashierview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
       "norm_label": "debugproducts()",
@@ -64099,7 +64204,7 @@
       "source_location": "L5"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -64108,7 +64213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -64117,7 +64222,7 @@
       "source_location": "L7"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -64126,7 +64231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -64135,7 +64240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -64144,7 +64249,7 @@
       "source_location": "L13"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -64153,7 +64258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -64162,7 +64267,7 @@
       "source_location": "L35"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -64171,7 +64276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -64180,7 +64285,7 @@
       "source_location": "L3"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -64189,7 +64294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -64198,7 +64303,7 @@
       "source_location": "L14"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -64207,7 +64312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -64216,7 +64321,7 @@
       "source_location": "L58"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -64225,7 +64330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "searchresultssection_searchresultssection",
       "label": "SearchResultsSection()",
@@ -64234,7 +64339,7 @@
       "source_location": "L15"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -64243,31 +64348,13 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
       "norm_label": "sessiondemo()",
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "expensereportsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
-      "label": "ExpenseReportsView.tsx",
-      "norm_label": "expensereportsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 51,
@@ -64362,6 +64449,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "expensereportsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
+      "label": "ExpenseReportsView.tsx",
+      "norm_label": "expensereportsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
       "norm_label": "registercustomerpanel.tsx",
@@ -64369,7 +64474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -64378,7 +64483,25 @@
       "source_location": "L8"
     },
     {
-      "community": 511,
+      "community": 512,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
+      "label": "RegisterSessionPanel.tsx",
+      "norm_label": "registersessionpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "registersessionpanel_registersessionpanel",
+      "label": "RegisterSessionPanel()",
+      "norm_label": "registersessionpanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -64387,7 +64510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
@@ -64396,7 +64519,7 @@
       "source_location": "L46"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -64405,7 +64528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -64414,7 +64537,7 @@
       "source_location": "L27"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -64423,7 +64546,7 @@
       "source_location": "L14"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -64432,7 +64555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -64441,7 +64564,7 @@
       "source_location": "L6"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -64450,7 +64573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -64459,7 +64582,7 @@
       "source_location": "L38"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -64468,7 +64591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -64477,7 +64600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -64486,7 +64609,7 @@
       "source_location": "L10"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -64495,49 +64618,13 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
       "norm_label": "usedeleteproduct()",
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
-      "label": "ProductsView.tsx",
-      "norm_label": "productsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "productsview_productsview",
-      "label": "ProductsView()",
-      "norm_label": "productsview()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "add_product_command_addproductcommand",
-      "label": "AddProductCommand()",
-      "norm_label": "addproductcommand()",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
-      "label": "add-product-command.tsx",
-      "norm_label": "add-product-command.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L1"
     },
     {
       "community": 52,
@@ -64632,6 +64719,42 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
+      "label": "ProductsView.tsx",
+      "norm_label": "productsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "productsview_productsview",
+      "label": "ProductsView()",
+      "norm_label": "productsview()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "add_product_command_addproductcommand",
+      "label": "AddProductCommand()",
+      "norm_label": "addproductcommand()",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
+      "label": "add-product-command.tsx",
+      "norm_label": "add-product-command.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
       "norm_label": "products.tsx",
@@ -64639,7 +64762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -64648,7 +64771,7 @@
       "source_location": "L4"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -64657,7 +64780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -64666,7 +64789,7 @@
       "source_location": "L84"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -64675,7 +64798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -64684,7 +64807,7 @@
       "source_location": "L23"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -64693,7 +64816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -64702,7 +64825,7 @@
       "source_location": "L37"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -64711,7 +64834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -64720,7 +64843,7 @@
       "source_location": "L9"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -64729,7 +64852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -64738,7 +64861,7 @@
       "source_location": "L23"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -64747,7 +64870,7 @@
       "source_location": "L5"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -64756,7 +64879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -64765,49 +64888,13 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
       "norm_label": "promocodespantogglegroup()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "capturedemails_capturedemails",
-      "label": "CapturedEmails()",
-      "norm_label": "capturedemails()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "label": "CapturedEmails.tsx",
-      "norm_label": "capturedemails.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
-      "label": "promo-code-modal.tsx",
-      "norm_label": "promo-code-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "promo_code_modal_promocodemodal",
-      "label": "PromoCodeModal()",
-      "norm_label": "promocodemodal()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L29"
     },
     {
       "community": 53,
@@ -64902,6 +64989,42 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "capturedemails_capturedemails",
+      "label": "CapturedEmails()",
+      "norm_label": "capturedemails()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
+      "label": "CapturedEmails.tsx",
+      "norm_label": "capturedemails.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
+      "label": "promo-code-modal.tsx",
+      "norm_label": "promo-code-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "promo_code_modal_promocodemodal",
+      "label": "PromoCodeModal()",
+      "norm_label": "promocodemodal()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
       "norm_label": "reviewactions.tsx",
@@ -64909,7 +65032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -64918,7 +65041,7 @@
       "source_location": "L20"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -64927,7 +65050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -64936,7 +65059,7 @@
       "source_location": "L63"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -64945,7 +65068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -64954,7 +65077,7 @@
       "source_location": "L30"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -64963,7 +65086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -64972,7 +65095,7 @@
       "source_location": "L59"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -64981,7 +65104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -64990,7 +65113,7 @@
       "source_location": "L45"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -64999,7 +65122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -65008,7 +65131,7 @@
       "source_location": "L47"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -65017,7 +65140,7 @@
       "source_location": "L29"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -65026,7 +65149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -65035,48 +65158,12 @@
       "source_location": "L3"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
       "norm_label": "nopermission.tsx",
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "nopermissionview_nopermissionview",
-      "label": "NoPermissionView()",
-      "norm_label": "nopermissionview()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
-      "label": "NoPermissionView.tsx",
-      "norm_label": "nopermissionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "notfoundview_notfoundview",
-      "label": "NotFoundView()",
-      "norm_label": "notfoundview()",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
-      "label": "NotFoundView.tsx",
-      "norm_label": "notfoundview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1"
     },
     {
@@ -65172,6 +65259,42 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "nopermissionview_nopermissionview",
+      "label": "NoPermissionView()",
+      "norm_label": "nopermissionview()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
+      "label": "NoPermissionView.tsx",
+      "norm_label": "nopermissionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "notfoundview_notfoundview",
+      "label": "NotFoundView()",
+      "norm_label": "notfoundview()",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
+      "label": "NotFoundView.tsx",
+      "norm_label": "notfoundview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
       "norm_label": "protectedadminsigninview.tsx",
@@ -65179,7 +65302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -65188,7 +65311,7 @@
       "source_location": "L9"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -65197,7 +65320,7 @@
       "source_location": "L9"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -65206,7 +65329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -65215,7 +65338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -65224,7 +65347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -65233,7 +65356,7 @@
       "source_location": "L11"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -65242,7 +65365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -65251,7 +65374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -65260,7 +65383,7 @@
       "source_location": "L25"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -65269,7 +65392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -65278,7 +65401,7 @@
       "source_location": "L21"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -65287,7 +65410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -65296,7 +65419,7 @@
       "source_location": "L63"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -65305,48 +65428,12 @@
       "source_location": "L7"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
       "norm_label": "calendar.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "chart_usechart",
-      "label": "useChart()",
-      "norm_label": "usechart()",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "copy_button_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "label": "copy-button.tsx",
-      "norm_label": "copy-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1"
     },
     {
@@ -65433,6 +65520,42 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "chart_usechart",
+      "label": "useChart()",
+      "norm_label": "usechart()",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "copy_button_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
+      "label": "copy-button.tsx",
+      "norm_label": "copy-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
       "norm_label": "handlecopy()",
@@ -65440,7 +65563,7 @@
       "source_location": "L21"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -65449,7 +65572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -65458,7 +65581,7 @@
       "source_location": "L6"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -65467,7 +65590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -65476,7 +65599,7 @@
       "source_location": "L25"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -65485,7 +65608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -65494,7 +65617,7 @@
       "source_location": "L49"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -65503,7 +65626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -65512,7 +65635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -65521,7 +65644,7 @@
       "source_location": "L63"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -65530,7 +65653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -65539,7 +65662,7 @@
       "source_location": "L5"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -65548,7 +65671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -65557,7 +65680,7 @@
       "source_location": "L12"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -65566,49 +65689,13 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
-      "label": "timeline-item.tsx",
-      "norm_label": "timeline-item.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "timeline_item_timelineitem",
-      "label": "TimelineItem()",
-      "norm_label": "timelineitem()",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
-      "label": "webp-image.tsx",
-      "norm_label": "webp-image.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "webp_image_webpimage",
-      "label": "WebpImage()",
-      "norm_label": "webpimage()",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -65694,6 +65781,42 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
+      "label": "timeline-item.tsx",
+      "norm_label": "timeline-item.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "timeline_item_timelineitem",
+      "label": "TimelineItem()",
+      "norm_label": "timelineitem()",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
+      "label": "webp-image.tsx",
+      "norm_label": "webp-image.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "webp_image_webpimage",
+      "label": "WebpImage()",
+      "norm_label": "webpimage()",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
       "norm_label": "bagitems()",
@@ -65701,7 +65824,7 @@
       "source_location": "L5"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -65710,7 +65833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -65719,7 +65842,7 @@
       "source_location": "L11"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -65728,7 +65851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -65737,7 +65860,7 @@
       "source_location": "L4"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -65746,7 +65869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -65755,7 +65878,7 @@
       "source_location": "L110"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -65764,7 +65887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -65773,7 +65896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -65782,7 +65905,7 @@
       "source_location": "L13"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -65791,7 +65914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -65800,7 +65923,7 @@
       "source_location": "L7"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -65809,7 +65932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -65818,7 +65941,7 @@
       "source_location": "L11"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -65827,49 +65950,13 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
       "norm_label": "userstatus()",
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userview_tsx",
-      "label": "UserView.tsx",
-      "norm_label": "userview.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "userview_useractions",
-      "label": "UserActions()",
-      "norm_label": "useractions()",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "customerjourneystage_customerjourneystagecard",
-      "label": "CustomerJourneyStageCard()",
-      "norm_label": "customerjourneystagecard()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
-      "label": "CustomerJourneyStage.tsx",
-      "norm_label": "customerjourneystage.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L1"
     },
     {
       "community": 57,
@@ -65955,6 +66042,42 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userview_tsx",
+      "label": "UserView.tsx",
+      "norm_label": "userview.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "userview_useractions",
+      "label": "UserActions()",
+      "norm_label": "useractions()",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "customerjourneystage_customerjourneystagecard",
+      "label": "CustomerJourneyStageCard()",
+      "norm_label": "customerjourneystagecard()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
+      "label": "CustomerJourneyStage.tsx",
+      "norm_label": "customerjourneystage.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
       "norm_label": "use-image-upload.ts",
@@ -65962,7 +66085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 572,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -65971,7 +66094,7 @@
       "source_location": "L7"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -65980,7 +66103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -65989,7 +66112,7 @@
       "source_location": "L5"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -65998,7 +66121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -66007,7 +66130,7 @@
       "source_location": "L5"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -66016,7 +66139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -66025,7 +66148,7 @@
       "source_location": "L7"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -66034,7 +66157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -66043,7 +66166,7 @@
       "source_location": "L9"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -66052,7 +66175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -66061,7 +66184,7 @@
       "source_location": "L6"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -66070,7 +66193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -66079,7 +66202,7 @@
       "source_location": "L168"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -66088,49 +66211,13 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
       "norm_label": "useconvexauthidentity()",
       "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
-      "label": "useCopyText.ts",
-      "norm_label": "usecopytext.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "usecopytext_usecopytext",
-      "label": "useCopyText()",
-      "norm_label": "usecopytext()",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "label": "useCreateComplimentaryProduct.ts",
-      "norm_label": "usecreatecomplimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "label": "useCreateComplimentaryProduct()",
-      "norm_label": "usecreatecomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 58,
@@ -66216,6 +66303,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
+      "label": "useCopyText.ts",
+      "norm_label": "usecopytext.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "usecopytext_usecopytext",
+      "label": "useCopyText()",
+      "norm_label": "usecopytext()",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
+      "label": "useCreateComplimentaryProduct.ts",
+      "norm_label": "usecreatecomplimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
+      "label": "useCreateComplimentaryProduct()",
+      "norm_label": "usecreatecomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
       "norm_label": "usedebounce.ts",
@@ -66223,7 +66346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 582,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -66232,7 +66355,7 @@
       "source_location": "L12"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -66241,7 +66364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -66250,7 +66373,7 @@
       "source_location": "L24"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -66259,7 +66382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -66268,7 +66391,7 @@
       "source_location": "L6"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -66277,7 +66400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -66286,7 +66409,7 @@
       "source_location": "L4"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -66295,7 +66418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -66304,7 +66427,7 @@
       "source_location": "L5"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -66313,7 +66436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -66322,7 +66445,7 @@
       "source_location": "L5"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -66331,7 +66454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -66340,7 +66463,7 @@
       "source_location": "L4"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -66349,49 +66472,13 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
       "norm_label": "usegetsubcategories()",
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
-      "label": "useGetTerminal.ts",
-      "norm_label": "usegetterminal.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "usegetterminal_usegetterminal",
-      "label": "useGetTerminal()",
-      "norm_label": "usegetterminal()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "label": "useNewOrderNotification.ts",
-      "norm_label": "usenewordernotification.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "usenewordernotification_usenewordernotification",
-      "label": "useNewOrderNotification()",
-      "norm_label": "usenewordernotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L8"
     },
     {
       "community": 59,
@@ -66477,6 +66564,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
+      "label": "useGetTerminal.ts",
+      "norm_label": "usegetterminal.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "usegetterminal_usegetterminal",
+      "label": "useGetTerminal()",
+      "norm_label": "usegetterminal()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
+      "label": "useNewOrderNotification.ts",
+      "norm_label": "usenewordernotification.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "usenewordernotification_usenewordernotification",
+      "label": "useNewOrderNotification()",
+      "norm_label": "usenewordernotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
       "norm_label": "usepermissions.ts",
@@ -66484,7 +66607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 592,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -66493,7 +66616,7 @@
       "source_location": "L13"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -66502,7 +66625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -66511,7 +66634,7 @@
       "source_location": "L3"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -66520,7 +66643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -66529,7 +66652,7 @@
       "source_location": "L26"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -66538,7 +66661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -66547,7 +66670,7 @@
       "source_location": "L7"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -66556,7 +66679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -66565,7 +66688,7 @@
       "source_location": "L5"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -66574,7 +66697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -66583,7 +66706,7 @@
       "source_location": "L12"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -66592,7 +66715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -66601,7 +66724,7 @@
       "source_location": "L12"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -66610,49 +66733,13 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
       "norm_label": "usetogglecomplimentaryproductactive()",
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
-      "label": "presentCommandToast.ts",
-      "norm_label": "presentcommandtoast.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "presentcommandtoast_presentcommandtoast",
-      "label": "presentCommandToast()",
-      "norm_label": "presentcommandtoast()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
-      "label": "presentUnexpectedErrorToast.ts",
-      "norm_label": "presentunexpectederrortoast.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "presentunexpectederrortoast_presentunexpectederrortoast",
-      "label": "presentUnexpectedErrorToast()",
-      "norm_label": "presentunexpectederrortoast()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
-      "source_location": "L7"
     },
     {
       "community": 6,
@@ -66972,6 +67059,60 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "operatormessages_tooperatormessage",
+      "label": "toOperatorMessage()",
+      "norm_label": "tooperatormessage()",
+      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
+      "label": "operatorMessages.ts",
+      "norm_label": "operatormessages.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
+      "label": "presentCommandToast.ts",
+      "norm_label": "presentcommandtoast.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "presentcommandtoast_presentcommandtoast",
+      "label": "presentCommandToast()",
+      "norm_label": "presentcommandtoast()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
+      "label": "presentUnexpectedErrorToast.ts",
+      "norm_label": "presentunexpectederrortoast.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "presentunexpectederrortoast_presentunexpectederrortoast",
+      "label": "presentUnexpectedErrorToast()",
+      "norm_label": "presentunexpectederrortoast()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
       "norm_label": "getorigin()",
@@ -66979,7 +67120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -66988,7 +67129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -66997,7 +67138,7 @@
       "source_location": "L5"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -67006,7 +67147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -67015,7 +67156,7 @@
       "source_location": "L6"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -67024,7 +67165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -67033,7 +67174,7 @@
       "source_location": "L5"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -67042,7 +67183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -67051,7 +67192,7 @@
       "source_location": "L5"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -67060,7 +67201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -67069,7 +67210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -67078,7 +67219,7 @@
       "source_location": "L5"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -67087,66 +67228,12 @@
       "source_location": "L10"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
       "norm_label": "calculations.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
-      "label": "pinHash.ts",
-      "norm_label": "pinhash.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "pinhash_hashpin",
-      "label": "hashPin()",
-      "norm_label": "hashpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "closeouts_index_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/closeouts.index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
-      "label": "closeouts.index.tsx",
-      "norm_label": "closeouts.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/closeouts.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "index_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
       "source_location": "L1"
     },
     {
@@ -67233,6 +67320,60 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
+      "label": "pinHash.ts",
+      "norm_label": "pinhash.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "pinhash_hashpin",
+      "label": "hashPin()",
+      "norm_label": "hashpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "closeouts_index_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/closeouts.index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
+      "label": "closeouts.index.tsx",
+      "norm_label": "closeouts.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/closeouts.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "index_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
       "norm_label": "$sessionid.tsx",
@@ -67240,7 +67381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 613,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -67249,7 +67390,7 @@
       "source_location": "L6"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -67258,7 +67399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -67267,7 +67408,7 @@
       "source_location": "L6"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -67276,7 +67417,7 @@
       "source_location": "L13"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -67285,7 +67426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -67294,7 +67435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -67303,7 +67444,7 @@
       "source_location": "L9"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -67312,7 +67453,7 @@
       "source_location": "L13"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -67321,7 +67462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -67330,7 +67471,7 @@
       "source_location": "L4"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -67339,7 +67480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -67348,66 +67489,12 @@
       "source_location": "L13"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
       "norm_label": "organizationssettingsaccordion.tsx",
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "overview_stories_patternsoverview",
-      "label": "PatternsOverview()",
-      "norm_label": "patternsoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "controls_stories_controlsshowcase",
-      "label": "ControlsShowcase()",
-      "norm_label": "controlsshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
-      "label": "Controls.stories.tsx",
-      "norm_label": "controls.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "dialog_stories_dialogshowcase",
-      "label": "DialogShowcase()",
-      "norm_label": "dialogshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
-      "label": "Dialog.stories.tsx",
-      "norm_label": "dialog.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -67494,6 +67581,60 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "overview_stories_patternsoverview",
+      "label": "PatternsOverview()",
+      "norm_label": "patternsoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "controls_stories_controlsshowcase",
+      "label": "ControlsShowcase()",
+      "norm_label": "controlsshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
+      "label": "Controls.stories.tsx",
+      "norm_label": "controls.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "dialog_stories_dialogshowcase",
+      "label": "DialogShowcase()",
+      "norm_label": "dialogshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
+      "label": "Dialog.stories.tsx",
+      "norm_label": "dialog.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 623,
+      "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
       "norm_label": "feedbackshowcase()",
@@ -67501,7 +67642,7 @@
       "source_location": "L12"
     },
     {
-      "community": 620,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -67510,7 +67651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -67519,7 +67660,7 @@
       "source_location": "L5"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -67528,7 +67669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -67537,7 +67678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -67546,7 +67687,7 @@
       "source_location": "L13"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -67555,7 +67696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -67564,7 +67705,7 @@
       "source_location": "L14"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -67573,7 +67714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -67582,7 +67723,7 @@
       "source_location": "L13"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -67591,7 +67732,7 @@
       "source_location": "L5"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -67600,7 +67741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -67609,67 +67750,13 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
       "norm_label": "withathenatheme()",
       "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
       "source_location": "L17"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "formatnumber_formatnumber",
-      "label": "formatNumber()",
-      "norm_label": "formatnumber()",
-      "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_formatnumber_ts",
-      "label": "formatNumber.ts",
-      "norm_label": "formatnumber.ts",
-      "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "bannermessage_getbannermessage",
-      "label": "getBannerMessage()",
-      "norm_label": "getbannermessage()",
-      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "checkoutsession_test_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
-      "label": "checkoutSession.test.ts",
-      "norm_label": "checkoutsession.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 63,
@@ -67755,6 +67842,60 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "formatnumber_formatnumber",
+      "label": "formatNumber()",
+      "norm_label": "formatnumber()",
+      "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_formatnumber_ts",
+      "label": "formatNumber.ts",
+      "norm_label": "formatnumber.ts",
+      "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "bannermessage_getbannermessage",
+      "label": "getBannerMessage()",
+      "norm_label": "getbannermessage()",
+      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "checkoutsession_test_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
+      "label": "checkoutSession.test.ts",
+      "norm_label": "checkoutsession.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
       "norm_label": "updateguest()",
@@ -67762,7 +67903,7 @@
       "source_location": "L4"
     },
     {
-      "community": 630,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -67771,7 +67912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -67780,7 +67921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -67789,7 +67930,7 @@
       "source_location": "L5"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -67798,7 +67939,7 @@
       "source_location": "L10"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -67807,7 +67948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -67816,7 +67957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -67825,7 +67966,7 @@
       "source_location": "L10"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -67834,7 +67975,7 @@
       "source_location": "L4"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -67843,7 +67984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -67852,7 +67993,7 @@
       "source_location": "L39"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -67861,7 +68002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -67870,66 +68011,12 @@
       "source_location": "L18"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
       "norm_label": "checkoutform.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "checkoutprovider_checkoutprovider",
-      "label": "CheckoutProvider()",
-      "norm_label": "checkoutprovider()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
-      "label": "CheckoutProvider.tsx",
-      "norm_label": "checkoutprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
-      "label": "PickupOptions.tsx",
-      "norm_label": "pickupoptions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "pickupoptions_iswithinrestrictiontime",
-      "label": "isWithinRestrictionTime()",
-      "norm_label": "iswithinrestrictiontime()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
-      "label": "EnteredBillingAddressDetails.tsx",
-      "norm_label": "enteredbillingaddressdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L1"
     },
     {
@@ -68007,6 +68094,60 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "checkoutprovider_checkoutprovider",
+      "label": "CheckoutProvider()",
+      "norm_label": "checkoutprovider()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
+      "label": "CheckoutProvider.tsx",
+      "norm_label": "checkoutprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
+      "label": "PickupOptions.tsx",
+      "norm_label": "pickupoptions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "pickupoptions_iswithinrestrictiontime",
+      "label": "isWithinRestrictionTime()",
+      "norm_label": "iswithinrestrictiontime()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
+      "label": "EnteredBillingAddressDetails.tsx",
+      "norm_label": "enteredbillingaddressdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
       "norm_label": "ordersummary()",
@@ -68014,7 +68155,7 @@
       "source_location": "L18"
     },
     {
-      "community": 640,
+      "community": 643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -68023,7 +68164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -68032,7 +68173,7 @@
       "source_location": "L10"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -68041,7 +68182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -68050,7 +68191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -68059,7 +68200,7 @@
       "source_location": "L8"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -68068,7 +68209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -68077,7 +68218,7 @@
       "source_location": "L27"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -68086,7 +68227,7 @@
       "source_location": "L40"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -68095,7 +68236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -68104,7 +68245,7 @@
       "source_location": "L3"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -68113,7 +68254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -68122,66 +68263,12 @@
       "source_location": "L8"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
       "norm_label": "checkoutschemas.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
-      "label": "webOrderSchema.test.ts",
-      "norm_label": "weborderschema.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "weborderschema_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "customerdetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
-      "label": "CustomerDetailsForm.tsx",
-      "norm_label": "customerdetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "deliverydetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "label": "DeliveryDetailsForm.tsx",
-      "norm_label": "deliverydetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1"
     },
     {
@@ -68259,6 +68346,60 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
+      "label": "webOrderSchema.test.ts",
+      "norm_label": "weborderschema.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "weborderschema_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "customerdetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
+      "label": "CustomerDetailsForm.tsx",
+      "norm_label": "customerdetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "deliverydetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
+      "label": "DeliveryDetailsForm.tsx",
+      "norm_label": "deliverydetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
       "norm_label": "usecountdown()",
@@ -68266,7 +68407,7 @@
       "source_location": "L3"
     },
     {
-      "community": 650,
+      "community": 653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -68275,7 +68416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -68284,7 +68425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -68293,7 +68434,7 @@
       "source_location": "L4"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -68302,7 +68443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -68311,7 +68452,7 @@
       "source_location": "L14"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -68320,7 +68461,7 @@
       "source_location": "L27"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -68329,7 +68470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -68338,7 +68479,7 @@
       "source_location": "L17"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -68347,7 +68488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -68356,7 +68497,7 @@
       "source_location": "L13"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -68365,7 +68506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -68374,66 +68515,12 @@
       "source_location": "L47"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
       "norm_label": "bagmenu.tsx",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "mobilebagmenu_mobilebagmenu",
-      "label": "MobileBagMenu()",
-      "norm_label": "mobilebagmenu()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
-      "label": "MobileBagMenu.tsx",
-      "norm_label": "mobilebagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
-      "label": "SiteBanner.tsx",
-      "norm_label": "sitebanner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "sitebanner_sitebanner",
-      "label": "SiteBanner()",
-      "norm_label": "sitebanner()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1"
     },
     {
@@ -68511,6 +68598,60 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "mobilebagmenu_mobilebagmenu",
+      "label": "MobileBagMenu()",
+      "norm_label": "mobilebagmenu()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
+      "label": "MobileBagMenu.tsx",
+      "norm_label": "mobilebagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
+      "label": "SiteBanner.tsx",
+      "norm_label": "sitebanner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "sitebanner_sitebanner",
+      "label": "SiteBanner()",
+      "norm_label": "sitebanner()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
       "norm_label": "mapvaluetolabelindex()",
@@ -68518,7 +68659,7 @@
       "source_location": "L12"
     },
     {
-      "community": 660,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -68527,7 +68668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -68536,7 +68677,7 @@
       "source_location": "L7"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -68545,7 +68686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -68554,7 +68695,7 @@
       "source_location": "L45"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -68563,7 +68704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -68572,7 +68713,7 @@
       "source_location": "L5"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -68581,7 +68722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -68590,7 +68731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -68599,7 +68740,7 @@
       "source_location": "L17"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -68608,7 +68749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -68617,7 +68758,7 @@
       "source_location": "L3"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -68626,67 +68767,13 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
       "norm_label": "showshippingpolicy()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L78"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
-      "label": "ProductReview.tsx",
-      "norm_label": "productreview.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "productreview_handlehelpful",
-      "label": "handleHelpful()",
-      "norm_label": "handlehelpful()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "label": "ReviewSummary.tsx",
-      "norm_label": "reviewsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "reviewsummary_reviewsummary",
-      "label": "ReviewSummary()",
-      "norm_label": "reviewsummary()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 67,
@@ -68763,6 +68850,60 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
+      "label": "ProductReview.tsx",
+      "norm_label": "productreview.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "productreview_handlehelpful",
+      "label": "handleHelpful()",
+      "norm_label": "handlehelpful()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
+      "label": "ReviewSummary.tsx",
+      "norm_label": "reviewsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "reviewsummary_reviewsummary",
+      "label": "ReviewSummary()",
+      "norm_label": "reviewsummary()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 673,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
       "norm_label": "ratingselector.tsx",
@@ -68770,7 +68911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 673,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -68779,7 +68920,7 @@
       "source_location": "L18"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -68788,7 +68929,7 @@
       "source_location": "L10"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -68797,7 +68938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -68806,7 +68947,7 @@
       "source_location": "L11"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -68815,7 +68956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -68824,7 +68965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -68833,7 +68974,7 @@
       "source_location": "L59"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -68842,7 +68983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -68851,7 +68992,7 @@
       "source_location": "L33"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -68860,7 +69001,7 @@
       "source_location": "L19"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -68869,7 +69010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -68878,66 +69019,12 @@
       "source_location": "L4"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
       "norm_label": "checkoutunavailable.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "errorboundary_errorboundary",
-      "label": "ErrorBoundary()",
-      "norm_label": "errorboundary()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
-      "label": "ErrorBoundary.tsx",
-      "norm_label": "errorboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
-      "label": "ScrollDownButton.tsx",
-      "norm_label": "scrolldownbutton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "scrolldownbutton_scrolldownbutton",
-      "label": "ScrollDownButton()",
-      "norm_label": "scrolldownbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "country_select_countryselect",
-      "label": "CountrySelect()",
-      "norm_label": "countryselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
-      "label": "country-select.tsx",
-      "norm_label": "country-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L1"
     },
     {
@@ -69015,6 +69102,60 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "errorboundary_errorboundary",
+      "label": "ErrorBoundary()",
+      "norm_label": "errorboundary()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
+      "label": "ErrorBoundary.tsx",
+      "norm_label": "errorboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
+      "label": "ScrollDownButton.tsx",
+      "norm_label": "scrolldownbutton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "scrolldownbutton_scrolldownbutton",
+      "label": "ScrollDownButton()",
+      "norm_label": "scrolldownbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "country_select_countryselect",
+      "label": "CountrySelect()",
+      "norm_label": "countryselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
+      "label": "country-select.tsx",
+      "norm_label": "country-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 683,
+      "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
       "norm_label": "ghanaregionselect()",
@@ -69022,7 +69163,7 @@
       "source_location": "L3"
     },
     {
-      "community": 680,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -69031,7 +69172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -69040,7 +69181,7 @@
       "source_location": "L9"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -69049,7 +69190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -69058,7 +69199,7 @@
       "source_location": "L66"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -69067,7 +69208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -69076,7 +69217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -69085,7 +69226,7 @@
       "source_location": "L19"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -69094,7 +69235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -69103,7 +69244,7 @@
       "source_location": "L13"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -69112,7 +69253,7 @@
       "source_location": "L46"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -69121,7 +69262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -69130,67 +69271,13 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
       "norm_label": "getmodalconfig()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
-      "label": "webp-jpg.tsx",
-      "norm_label": "webp-jpg.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "webp_jpg_webpimage",
-      "label": "WebpImage()",
-      "norm_label": "webpimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "formsubmissionprovider_useformsubmission",
-      "label": "useFormSubmission()",
-      "norm_label": "useformsubmission()",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
-      "label": "FormSubmissionProvider.tsx",
-      "norm_label": "formsubmissionprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
-      "label": "useCheckout.ts",
-      "norm_label": "usecheckout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "usecheckout_usecheckout",
-      "label": "useCheckout()",
-      "norm_label": "usecheckout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L5"
     },
     {
       "community": 69,
@@ -69267,6 +69354,60 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
+      "label": "webp-jpg.tsx",
+      "norm_label": "webp-jpg.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "webp_jpg_webpimage",
+      "label": "WebpImage()",
+      "norm_label": "webpimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "formsubmissionprovider_useformsubmission",
+      "label": "useFormSubmission()",
+      "norm_label": "useformsubmission()",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
+      "label": "FormSubmissionProvider.tsx",
+      "norm_label": "formsubmissionprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
+      "label": "useCheckout.ts",
+      "norm_label": "usecheckout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "usecheckout_usecheckout",
+      "label": "useCheckout()",
+      "norm_label": "usecheckout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
       "norm_label": "usediscountcodealert.tsx",
@@ -69274,7 +69415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 690,
+      "community": 693,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -69283,7 +69424,7 @@
       "source_location": "L14"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -69292,7 +69433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -69301,7 +69442,7 @@
       "source_location": "L29"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -69310,7 +69451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -69319,7 +69460,7 @@
       "source_location": "L5"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -69328,7 +69469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -69337,7 +69478,7 @@
       "source_location": "L5"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -69346,7 +69487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -69355,7 +69496,7 @@
       "source_location": "L3"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -69364,7 +69505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -69373,7 +69514,7 @@
       "source_location": "L4"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -69382,67 +69523,13 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
       "norm_label": "usegetstore()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
-      "label": "useInventoryStatus.ts",
-      "norm_label": "useinventorystatus.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "useinventorystatus_useinventorystatus",
-      "label": "useInventoryStatus()",
-      "norm_label": "useinventorystatus()",
-      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
-      "label": "useLeaveAReviewModal.tsx",
-      "norm_label": "useleaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "label": "useLeaveAReviewModal()",
-      "norm_label": "useleaveareviewmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
-      "label": "useLogout.ts",
-      "norm_label": "uselogout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "uselogout_uselogout",
-      "label": "useLogout()",
-      "norm_label": "uselogout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L5"
     },
     {
       "community": 7,
@@ -69744,6 +69831,60 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
+      "label": "useInventoryStatus.ts",
+      "norm_label": "useinventorystatus.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "useinventorystatus_useinventorystatus",
+      "label": "useInventoryStatus()",
+      "norm_label": "useinventorystatus()",
+      "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
+      "label": "useLeaveAReviewModal.tsx",
+      "norm_label": "useleaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "useleaveareviewmodal_useleaveareviewmodal",
+      "label": "useLeaveAReviewModal()",
+      "norm_label": "useleaveareviewmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
+      "label": "useLogout.ts",
+      "norm_label": "uselogout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "uselogout_uselogout",
+      "label": "useLogout()",
+      "norm_label": "uselogout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 703,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
       "norm_label": "usemodalstate.tsx",
@@ -69751,7 +69892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 703,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -69760,7 +69901,7 @@
       "source_location": "L15"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -69769,7 +69910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -69778,7 +69919,7 @@
       "source_location": "L18"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -69787,7 +69928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -69796,7 +69937,7 @@
       "source_location": "L9"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -69805,7 +69946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -69814,7 +69955,7 @@
       "source_location": "L16"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -69823,7 +69964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -69832,7 +69973,7 @@
       "source_location": "L4"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -69841,7 +69982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -69850,7 +69991,7 @@
       "source_location": "L11"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -69859,67 +70000,13 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
       "norm_label": "usescrolltotop()",
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
-      "label": "useTrackAction.ts",
-      "norm_label": "usetrackaction.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "usetrackaction_usetrackaction",
-      "label": "useTrackAction()",
-      "norm_label": "usetrackaction()",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
-      "label": "useTrackEvent.ts",
-      "norm_label": "usetrackevent.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "usetrackevent_usetrackevent",
-      "label": "useTrackEvent()",
-      "norm_label": "usetrackevent()",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
-      "label": "useUpsellModal.tsx",
-      "norm_label": "useupsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "useupsellmodal_useupsellmodal",
-      "label": "useUpsellModal()",
-      "norm_label": "useupsellmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L14"
     },
     {
       "community": 71,
@@ -69996,6 +70083,60 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
+      "label": "useTrackAction.ts",
+      "norm_label": "usetrackaction.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "usetrackaction_usetrackaction",
+      "label": "useTrackAction()",
+      "norm_label": "usetrackaction()",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
+      "label": "useTrackEvent.ts",
+      "norm_label": "usetrackevent.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "usetrackevent_usetrackevent",
+      "label": "useTrackEvent()",
+      "norm_label": "usetrackevent()",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
+      "label": "useUpsellModal.tsx",
+      "norm_label": "useupsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "useupsellmodal_useupsellmodal",
+      "label": "useUpsellModal()",
+      "norm_label": "useupsellmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 713,
+      "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
       "norm_label": "usepostanalytics()",
@@ -70003,7 +70144,7 @@
       "source_location": "L4"
     },
     {
-      "community": 710,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -70012,7 +70153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -70021,7 +70162,7 @@
       "source_location": "L7"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -70030,7 +70171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -70039,7 +70180,7 @@
       "source_location": "L6"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -70048,7 +70189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -70057,7 +70198,7 @@
       "source_location": "L10"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -70066,7 +70207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -70075,7 +70216,7 @@
       "source_location": "L6"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -70084,7 +70225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -70093,7 +70234,7 @@
       "source_location": "L5"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -70102,7 +70243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -70111,67 +70252,13 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
       "norm_label": "useproductqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "promocode_usepromocodesqueries",
-      "label": "usePromoCodesQueries()",
-      "norm_label": "usepromocodesqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "reviews_usereviewqueries",
-      "label": "useReviewQueries()",
-      "norm_label": "usereviewqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "rewards_userewardsqueries",
-      "label": "useRewardsQueries()",
-      "norm_label": "userewardsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L11"
     },
     {
       "community": 72,
@@ -70248,6 +70335,60 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "promocode_usepromocodesqueries",
+      "label": "usePromoCodesQueries()",
+      "norm_label": "usepromocodesqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "reviews_usereviewqueries",
+      "label": "useReviewQueries()",
+      "norm_label": "usereviewqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "rewards_userewardsqueries",
+      "label": "useRewardsQueries()",
+      "norm_label": "userewardsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 723,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
       "norm_label": "upsells.ts",
@@ -70255,7 +70396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 720,
+      "community": 723,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -70264,7 +70405,7 @@
       "source_location": "L6"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -70273,7 +70414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -70282,7 +70423,7 @@
       "source_location": "L5"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -70291,7 +70432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -70300,7 +70441,7 @@
       "source_location": "L6"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -70309,7 +70450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -70318,7 +70459,7 @@
       "source_location": "L10"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -70327,7 +70468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -70336,7 +70477,7 @@
       "source_location": "L15"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -70345,7 +70486,7 @@
       "source_location": "L14"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -70354,7 +70495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -70363,67 +70504,13 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
       "norm_label": "createrouter()",
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 727,
-      "file_type": "code",
-      "id": "homepageloader_loadhomepagedata",
-      "label": "loadHomePageData()",
-      "norm_label": "loadhomepagedata()",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 727,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
-      "label": "-homePageLoader.ts",
-      "norm_label": "-homepageloader.ts",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "orderslayout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
-      "label": "_ordersLayout.tsx",
-      "norm_label": "_orderslayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "contact_us_contactus",
-      "label": "ContactUs()",
-      "norm_label": "contactus()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
-      "label": "contact-us.tsx",
-      "norm_label": "contact-us.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L1"
     },
     {
       "community": 73,
@@ -70500,6 +70587,60 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "homepageloader_loadhomepagedata",
+      "label": "loadHomePageData()",
+      "norm_label": "loadhomepagedata()",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
+      "label": "-homePageLoader.ts",
+      "norm_label": "-homepageloader.ts",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "orderslayout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
+      "label": "_ordersLayout.tsx",
+      "norm_label": "_orderslayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
+      "id": "contact_us_contactus",
+      "label": "ContactUs()",
+      "norm_label": "contactus()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
+      "label": "contact-us.tsx",
+      "norm_label": "contact-us.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 733,
+      "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
       "norm_label": "onlineorderpolicy()",
@@ -70507,7 +70648,7 @@
       "source_location": "L13"
     },
     {
-      "community": 730,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -70516,7 +70657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -70525,7 +70666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -70534,7 +70675,7 @@
       "source_location": "L9"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -70543,7 +70684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -70552,7 +70693,7 @@
       "source_location": "L15"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -70561,7 +70702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -70570,7 +70711,7 @@
       "source_location": "L16"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -70579,7 +70720,7 @@
       "source_location": "L6"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -70588,7 +70729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -70597,7 +70738,7 @@
       "source_location": "L10"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -70606,7 +70747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -70615,7 +70756,7 @@
       "source_location": "L21"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -70624,7 +70765,79 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "label": "useRegisterViewModel.ts",
+      "norm_label": "useregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "useregisterviewmodel_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "useregisterviewmodel_createpaymentid",
+      "label": "createPaymentId()",
+      "norm_label": "createpaymentid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "useregisterviewmodel_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "useregisterviewmodel_presentoperatorerror",
+      "label": "presentOperatorError()",
+      "norm_label": "presentoperatorerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "useregisterviewmodel_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "useregisterviewmodel_useregisterviewmodel",
+      "label": "useRegisterViewModel()",
+      "norm_label": "useregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 740,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -70633,7 +70846,7 @@
       "source_location": "L33"
     },
     {
-      "community": 737,
+      "community": 740,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -70642,7 +70855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 741,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -70651,7 +70864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 741,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -70660,7 +70873,7 @@
       "source_location": "L193"
     },
     {
-      "community": 739,
+      "community": 742,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -70669,7 +70882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 739,
+      "community": 742,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -70678,79 +70891,7 @@
       "source_location": "L7"
     },
     {
-      "community": 74,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L317"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L193"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L221"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 740,
+      "community": 743,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -70759,7 +70900,7 @@
       "source_location": "L10"
     },
     {
-      "community": 740,
+      "community": 743,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -70768,7 +70909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -70777,7 +70918,7 @@
       "source_location": "L32"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -70786,7 +70927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -70795,7 +70936,7 @@
       "source_location": "L211"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -70804,7 +70945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -70813,7 +70954,7 @@
       "source_location": "L85"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -70822,7 +70963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -70831,7 +70972,7 @@
       "source_location": "L15"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -70840,7 +70981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -70849,7 +70990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -70858,7 +70999,79 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 75,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L258"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L189"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L317"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L193"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L221"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -70867,7 +71080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 751,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -70876,7 +71089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 749,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -70885,79 +71098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 75,
-      "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 750,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -70966,7 +71107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -70975,7 +71116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -70984,7 +71125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -70993,7 +71134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -71002,7 +71143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -71011,7 +71152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -71020,7 +71161,79 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 76,
+      "file_type": "code",
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "bag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -71029,7 +71242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 761,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -71038,7 +71251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -71047,79 +71260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "product_buildquerystring",
-      "label": "buildQueryString()",
-      "norm_label": "buildquerystring()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "product_getallproducts",
-      "label": "getAllProducts()",
-      "norm_label": "getallproducts()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "product_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "product_getbestsellers",
-      "label": "getBestSellers()",
-      "norm_label": "getbestsellers()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "product_getfeatured",
-      "label": "getFeatured()",
-      "norm_label": "getfeatured()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "product_getinventorybyskuids",
-      "label": "getInventoryBySkuIds()",
-      "norm_label": "getinventorybyskuids()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "product_getproduct",
-      "label": "getProduct()",
-      "norm_label": "getproduct()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 760,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -71128,7 +71269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -71137,7 +71278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -71146,7 +71287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -71155,7 +71296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -71164,7 +71305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -71173,7 +71314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71182,7 +71323,79 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "product_buildquerystring",
+      "label": "buildQueryString()",
+      "norm_label": "buildquerystring()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "product_getallproducts",
+      "label": "getAllProducts()",
+      "norm_label": "getallproducts()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "product_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "product_getbestsellers",
+      "label": "getBestSellers()",
+      "norm_label": "getbestsellers()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "product_getfeatured",
+      "label": "getFeatured()",
+      "norm_label": "getfeatured()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "product_getinventorybyskuids",
+      "label": "getInventoryBySkuIds()",
+      "norm_label": "getinventorybyskuids()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "product_getproduct",
+      "label": "getProduct()",
+      "norm_label": "getproduct()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -71191,7 +71404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 771,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -71200,7 +71413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -71209,79 +71422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L553"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L594"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L580"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L504"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L565"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 770,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -71290,7 +71431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -71299,7 +71440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -71308,7 +71449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -71317,7 +71458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -71326,7 +71467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -71335,7 +71476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -71344,7 +71485,79 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L553"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L594"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L580"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L504"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L565"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -71353,7 +71566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -71362,7 +71575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -71371,79 +71584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L200"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 780,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -71452,7 +71593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -71461,7 +71602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -71470,7 +71611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -71479,7 +71620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -71488,7 +71629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -71497,7 +71638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -71506,7 +71647,79 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -71515,7 +71728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -71524,7 +71737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -71533,70 +71746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "expensesessions_buildnextexpensesessionnumber",
-      "label": "buildNextExpenseSessionNumber()",
-      "norm_label": "buildnextexpensesessionnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "expensesessions_expensesessionerror",
-      "label": "expenseSessionError()",
-      "norm_label": "expensesessionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "label": "listExpenseSessionsByStatusBefore()",
-      "norm_label": "listexpensesessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "expensesessions_loadexpensesessionitems",
-      "label": "loadExpenseSessionItems()",
-      "norm_label": "loadexpensesessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "expensesessions_mapexpensesessionvalidationerror",
-      "label": "mapExpenseSessionValidationError()",
-      "norm_label": "mapexpensesessionvalidationerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "expensesessions_normalizeoptionalregisternumber",
-      "label": "normalizeOptionalRegisterNumber()",
-      "norm_label": "normalizeoptionalregisternumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "label": "expenseSessions.ts",
-      "norm_label": "expensesessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 790,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -71605,7 +71755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -71614,7 +71764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -71623,7 +71773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71632,7 +71782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -71641,7 +71791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -71650,39 +71800,12 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 797,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
       "source_location": "L1"
     },
     {
@@ -71886,68 +72009,95 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "expensesessions_buildnextexpensesessionnumber",
+      "label": "buildNextExpenseSessionNumber()",
+      "norm_label": "buildnextexpensesessionnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L76"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L190"
+      "id": "expensesessions_expensesessionerror",
+      "label": "expenseSessionError()",
+      "norm_label": "expensesessionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L46"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "expensesessions_listexpensesessionsbystatusbefore",
+      "label": "listExpenseSessionsByStatusBefore()",
+      "norm_label": "listexpensesessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L114"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L239"
+      "id": "expensesessions_loadexpensesessionitems",
+      "label": "loadExpenseSessionItems()",
+      "norm_label": "loadexpensesessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L89"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L20"
+      "id": "expensesessions_mapexpensesessionvalidationerror",
+      "label": "mapExpenseSessionValidationError()",
+      "norm_label": "mapexpensesessionvalidationerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L60"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "expensesessions_normalizeoptionalregisternumber",
+      "label": "normalizeOptionalRegisterNumber()",
+      "norm_label": "normalizeoptionalregisternumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
+      "label": "expenseSessions.ts",
+      "norm_label": "expensesessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -71956,7 +72106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -71965,7 +72115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -71974,7 +72124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -71983,7 +72133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -71992,7 +72142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -72001,7 +72151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -72010,7 +72160,70 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 81,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -72019,7 +72232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -72028,7 +72241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -72037,70 +72250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
-      "file_type": "code",
-      "id": "client_buildheaders",
-      "label": "buildHeaders()",
-      "norm_label": "buildheaders()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "client_createcollectionsaccesstoken",
-      "label": "createCollectionsAccessToken()",
-      "norm_label": "createcollectionsaccesstoken()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "client_encodebasicauth",
-      "label": "encodeBasicAuth()",
-      "norm_label": "encodebasicauth()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "client_getrequesttopaystatus",
-      "label": "getRequestToPayStatus()",
-      "norm_label": "getrequesttopaystatus()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "client_requesttopay",
-      "label": "requestToPay()",
-      "norm_label": "requesttopay()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "client_toerror",
-      "label": "toError()",
-      "norm_label": "toerror()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "label": "client.ts",
-      "norm_label": "client.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 810,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -72109,7 +72259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -72118,7 +72268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -72127,7 +72277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -72136,7 +72286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -72145,7 +72295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -72154,7 +72304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -72163,7 +72313,70 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 82,
+      "file_type": "code",
+      "id": "client_buildheaders",
+      "label": "buildHeaders()",
+      "norm_label": "buildheaders()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "client_createcollectionsaccesstoken",
+      "label": "createCollectionsAccessToken()",
+      "norm_label": "createcollectionsaccesstoken()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "client_encodebasicauth",
+      "label": "encodeBasicAuth()",
+      "norm_label": "encodebasicauth()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "client_getrequesttopaystatus",
+      "label": "getRequestToPayStatus()",
+      "norm_label": "getrequesttopaystatus()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "client_requesttopay",
+      "label": "requestToPay()",
+      "norm_label": "requesttopay()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "client_toerror",
+      "label": "toError()",
+      "norm_label": "toerror()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_client_ts",
+      "label": "client.ts",
+      "norm_label": "client.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 820,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -72172,7 +72385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 821,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -72181,7 +72394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -72190,70 +72403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 82,
-      "file_type": "code",
-      "id": "linking_buildcustomerprofiledraft",
-      "label": "buildCustomerProfileDraft()",
-      "norm_label": "buildcustomerprofiledraft()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "linking_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "linking_findmatchingcustomerprofile",
-      "label": "findMatchingCustomerProfile()",
-      "norm_label": "findmatchingcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "linking_normalizelookupvalue",
-      "label": "normalizeLookupValue()",
-      "norm_label": "normalizelookupvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "linking_normalizephonenumber",
-      "label": "normalizePhoneNumber()",
-      "norm_label": "normalizephonenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "linking_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
-      "label": "linking.ts",
-      "norm_label": "linking.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 820,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -72262,7 +72412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -72271,7 +72421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -72280,7 +72430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -72289,7 +72439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -72298,7 +72448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -72307,7 +72457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -72316,7 +72466,70 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 83,
+      "file_type": "code",
+      "id": "linking_buildcustomerprofiledraft",
+      "label": "buildCustomerProfileDraft()",
+      "norm_label": "buildcustomerprofiledraft()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "linking_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "linking_findmatchingcustomerprofile",
+      "label": "findMatchingCustomerProfile()",
+      "norm_label": "findmatchingcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "linking_normalizelookupvalue",
+      "label": "normalizeLookupValue()",
+      "norm_label": "normalizelookupvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "linking_normalizephonenumber",
+      "label": "normalizePhoneNumber()",
+      "norm_label": "normalizephonenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "linking_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
+      "label": "linking.ts",
+      "norm_label": "linking.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 830,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -72325,7 +72538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 831,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -72334,7 +72547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -72343,70 +72556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "terminals_assertregisternumberisavailable",
-      "label": "assertRegisterNumberIsAvailable()",
-      "norm_label": "assertregisternumberisavailable()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "terminals_deleteterminal",
-      "label": "deleteTerminal()",
-      "norm_label": "deleteterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "terminals_mapregisterterminalerror",
-      "label": "mapRegisterTerminalError()",
-      "norm_label": "mapregisterterminalerror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "terminals_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "terminals_registerterminal",
-      "label": "registerTerminal()",
-      "norm_label": "registerterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "terminals_updateterminal",
-      "label": "updateTerminal()",
-      "norm_label": "updateterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 830,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -72415,7 +72565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -72424,7 +72574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -72433,7 +72583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -72442,7 +72592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -72451,7 +72601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -72460,7 +72610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -72469,7 +72619,70 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "terminals_assertregisternumberisavailable",
+      "label": "assertRegisterNumberIsAvailable()",
+      "norm_label": "assertregisternumberisavailable()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "terminals_deleteterminal",
+      "label": "deleteTerminal()",
+      "norm_label": "deleteterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "terminals_mapregisterterminalerror",
+      "label": "mapRegisterTerminalError()",
+      "norm_label": "mapregisterterminalerror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "terminals_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "terminals_registerterminal",
+      "label": "registerTerminal()",
+      "norm_label": "registerterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "terminals_updateterminal",
+      "label": "updateTerminal()",
+      "norm_label": "updateterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 840,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -72478,7 +72691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 841,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -72487,7 +72700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -72496,70 +72709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
-      "label": "sessionRepository.ts",
-      "norm_label": "sessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "sessionrepository_getactivesessionforregisterstate",
-      "label": "getActiveSessionForRegisterState()",
-      "norm_label": "getactivesessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "sessionrepository_listheldsessionsforregisterstate",
-      "label": "listHeldSessionsForRegisterState()",
-      "norm_label": "listheldsessionsforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "sessionrepository_matchesregisteridentity",
-      "label": "matchesRegisterIdentity()",
-      "norm_label": "matchesregisteridentity()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "sessionrepository_querysessionsbystatus",
-      "label": "querySessionsByStatus()",
-      "norm_label": "querysessionsbystatus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "sessionrepository_selectregisterstatelookupstrategy",
-      "label": "selectRegisterStateLookupStrategy()",
-      "norm_label": "selectregisterstatelookupstrategy()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "sessionrepository_summarizeregisterstatesessions",
-      "label": "summarizeRegisterStateSessions()",
-      "norm_label": "summarizeregisterstatesessions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 840,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -72568,7 +72718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -72577,7 +72727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -72586,7 +72736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -72595,7 +72745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -72604,7 +72754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -72613,7 +72763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -72622,7 +72772,70 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
+      "label": "sessionRepository.ts",
+      "norm_label": "sessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "sessionrepository_getactivesessionforregisterstate",
+      "label": "getActiveSessionForRegisterState()",
+      "norm_label": "getactivesessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "sessionrepository_listheldsessionsforregisterstate",
+      "label": "listHeldSessionsForRegisterState()",
+      "norm_label": "listheldsessionsforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "sessionrepository_matchesregisteridentity",
+      "label": "matchesRegisterIdentity()",
+      "norm_label": "matchesregisteridentity()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "sessionrepository_querysessionsbystatus",
+      "label": "querySessionsByStatus()",
+      "norm_label": "querysessionsbystatus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "sessionrepository_selectregisterstatelookupstrategy",
+      "label": "selectRegisterStateLookupStrategy()",
+      "norm_label": "selectregisterstatelookupstrategy()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "sessionrepository_summarizeregisterstatesessions",
+      "label": "summarizeRegisterStateSessions()",
+      "norm_label": "summarizeregisterstatesessions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 850,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -72631,7 +72844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -72640,7 +72853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -72649,70 +72862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "label": "getCustomerAnalyticsQuery()",
-      "norm_label": "getcustomeranalyticsquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
-      "label": "getCustomerOperationalTimelineEvents()",
-      "norm_label": "getcustomeroperationaltimelineevents()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getproductinfomaps",
-      "label": "getProductInfoMaps()",
-      "norm_label": "getproductinfomaps()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimefilterforrange",
-      "label": "getTimeFilterForRange()",
-      "norm_label": "gettimefilterforrange()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimelineuserdata",
-      "label": "getTimelineUserData()",
-      "norm_label": "gettimelineuserdata()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
-      "label": "resolveCustomerProfileIdForTimeline()",
-      "norm_label": "resolvecustomerprofileidfortimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "label": "customerBehaviorTimeline.ts",
-      "norm_label": "customerbehaviortimeline.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 850,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -72721,7 +72871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -72730,7 +72880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -72739,7 +72889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -72748,7 +72898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -72757,7 +72907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -72766,7 +72916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -72775,7 +72925,70 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 86,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
+      "label": "getCustomerAnalyticsQuery()",
+      "norm_label": "getcustomeranalyticsquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
+      "label": "getCustomerOperationalTimelineEvents()",
+      "norm_label": "getcustomeroperationaltimelineevents()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_getproductinfomaps",
+      "label": "getProductInfoMaps()",
+      "norm_label": "getproductinfomaps()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_gettimefilterforrange",
+      "label": "getTimeFilterForRange()",
+      "norm_label": "gettimefilterforrange()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_gettimelineuserdata",
+      "label": "getTimelineUserData()",
+      "norm_label": "gettimelineuserdata()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
+      "label": "resolveCustomerProfileIdForTimeline()",
+      "norm_label": "resolvecustomerprofileidfortimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
+      "label": "customerBehaviorTimeline.ts",
+      "norm_label": "customerbehaviortimeline.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 860,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -72784,7 +72997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -72793,7 +73006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -72802,70 +73015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
-      "file_type": "code",
-      "id": "onlineorder_clearbagitems",
-      "label": "clearBagItems()",
-      "norm_label": "clearbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "onlineorder_createorderfromcheckoutsession",
-      "label": "createOrderFromCheckoutSession()",
-      "norm_label": "createorderfromcheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "onlineorder_findorderbyexternalreference",
-      "label": "findOrderByExternalReference()",
-      "norm_label": "findorderbyexternalreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "onlineorder_findorderbyexternaltransactionid",
-      "label": "findOrderByExternalTransactionId()",
-      "norm_label": "findorderbyexternaltransactionid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "onlineorder_generateordernumber",
-      "label": "generateOrderNumber()",
-      "norm_label": "generateordernumber()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "onlineorder_returnorderitemstostock",
-      "label": "returnOrderItemsToStock()",
-      "norm_label": "returnorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 860,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -72874,7 +73024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -72883,7 +73033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -72892,7 +73042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -72901,7 +73051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -72910,7 +73060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -72919,7 +73069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -72928,7 +73078,70 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 87,
+      "file_type": "code",
+      "id": "onlineorder_clearbagitems",
+      "label": "clearBagItems()",
+      "norm_label": "clearbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "onlineorder_createorderfromcheckoutsession",
+      "label": "createOrderFromCheckoutSession()",
+      "norm_label": "createorderfromcheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "onlineorder_findorderbyexternalreference",
+      "label": "findOrderByExternalReference()",
+      "norm_label": "findorderbyexternalreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "onlineorder_findorderbyexternaltransactionid",
+      "label": "findOrderByExternalTransactionId()",
+      "norm_label": "findorderbyexternaltransactionid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "onlineorder_generateordernumber",
+      "label": "generateOrderNumber()",
+      "norm_label": "generateordernumber()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "onlineorder_returnorderitemstostock",
+      "label": "returnOrderItemsToStock()",
+      "norm_label": "returnorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 870,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -72937,7 +73150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 871,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -72946,7 +73159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 869,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -72955,70 +73168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 87,
-      "file_type": "code",
-      "id": "orderupdateemails_formatorderitems",
-      "label": "formatOrderItems()",
-      "norm_label": "formatorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "orderupdateemails_getdeliveryaddress",
-      "label": "getDeliveryAddress()",
-      "norm_label": "getdeliveryaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "orderupdateemails_getlocationdetails",
-      "label": "getLocationDetails()",
-      "norm_label": "getlocationdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "orderupdateemails_getpickuplocation",
-      "label": "getPickupLocation()",
-      "norm_label": "getpickuplocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "orderupdateemails_handleorderstatusupdate",
-      "label": "handleOrderStatusUpdate()",
-      "norm_label": "handleorderstatusupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "orderupdateemails_processorderupdateemail",
-      "label": "processOrderUpdateEmail()",
-      "norm_label": "processorderupdateemail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "label": "orderUpdateEmails.ts",
-      "norm_label": "orderupdateemails.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 870,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -73027,7 +73177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -73036,7 +73186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -73045,7 +73195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -73054,7 +73204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -73063,7 +73213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -73072,7 +73222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -73081,7 +73231,70 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 88,
+      "file_type": "code",
+      "id": "orderupdateemails_formatorderitems",
+      "label": "formatOrderItems()",
+      "norm_label": "formatorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "orderupdateemails_getdeliveryaddress",
+      "label": "getDeliveryAddress()",
+      "norm_label": "getdeliveryaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "orderupdateemails_getlocationdetails",
+      "label": "getLocationDetails()",
+      "norm_label": "getlocationdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "orderupdateemails_getpickuplocation",
+      "label": "getPickupLocation()",
+      "norm_label": "getpickuplocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "orderupdateemails_handleorderstatusupdate",
+      "label": "handleOrderStatusUpdate()",
+      "norm_label": "handleorderstatusupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "orderupdateemails_processorderupdateemail",
+      "label": "processOrderUpdateEmail()",
+      "norm_label": "processorderupdateemail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
+      "label": "orderUpdateEmails.ts",
+      "norm_label": "orderupdateemails.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 880,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -73090,7 +73303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 881,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -73099,7 +73312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 879,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -73108,70 +73321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 88,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 880,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -73180,7 +73330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -73189,7 +73339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -73198,7 +73348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -73207,7 +73357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -73216,7 +73366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -73225,7 +73375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -73234,7 +73384,70 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 89,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 890,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -73243,7 +73456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 891,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -73252,7 +73465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 889,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -73261,70 +73474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 89,
-      "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "onlineorder_mapupdateordererror",
-      "label": "mapUpdateOrderError()",
-      "norm_label": "mapupdateordererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 890,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -73333,7 +73483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -73342,7 +73492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -73351,7 +73501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -73360,7 +73510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -73369,7 +73519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -73378,39 +73528,12 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 897,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "label": "checkoutSessionItem.ts",
-      "norm_label": "checkoutsessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
       "source_location": "L1"
     },
     {
@@ -73605,68 +73728,95 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "core_appendworkflowtraceeventwithctx",
-      "label": "appendWorkflowTraceEventWithCtx()",
-      "norm_label": "appendworkflowtraceeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L134"
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L61"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "core_createworkflowtracewithctx",
-      "label": "createWorkflowTraceWithCtx()",
-      "norm_label": "createworkflowtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L81"
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L85"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "core_getworkflowtracebyidwithctx",
-      "label": "getWorkflowTraceByIdWithCtx()",
-      "norm_label": "getworkflowtracebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L17"
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L206"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "core_getworkflowtracebylookupwithctx",
-      "label": "getWorkflowTraceByLookupWithCtx()",
-      "norm_label": "getworkflowtracebylookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L32"
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L214"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "core_listworkflowtraceeventswithctx",
-      "label": "listWorkflowTraceEventsWithCtx()",
-      "norm_label": "listworkflowtraceeventswithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L65"
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L51"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "core_registerworkflowtracelookupwithctx",
-      "label": "registerWorkflowTraceLookupWithCtx()",
-      "norm_label": "registerworkflowtracelookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L104"
+      "id": "onlineorder_mapupdateordererror",
+      "label": "mapUpdateOrderError()",
+      "norm_label": "mapupdateordererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L221"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
-      "label": "core.ts",
-      "norm_label": "core.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
     },
     {
       "community": 900,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
+      "label": "checkoutSessionItem.ts",
+      "norm_label": "checkoutsessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -73675,7 +73825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -73684,7 +73834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -73693,7 +73843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -73702,7 +73852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -73711,7 +73861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -73720,7 +73870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -73729,7 +73879,70 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 91,
+      "file_type": "code",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 910,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -73738,7 +73951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 911,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -73747,7 +73960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 909,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -73756,70 +73969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L97"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_summarystrip",
-      "label": "SummaryStrip()",
-      "norm_label": "summarystrip()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 910,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -73828,7 +73978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -73837,7 +73987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -73846,7 +73996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -73855,7 +74005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -73864,7 +74014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -73873,7 +74023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -73882,7 +74032,70 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 92,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_summarystrip",
+      "label": "SummaryStrip()",
+      "norm_label": "summarystrip()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 920,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -73891,7 +74104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 921,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -73900,7 +74113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 919,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -73909,70 +74122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 92,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handlemodechange",
-      "label": "handleModeChange()",
-      "norm_label": "handlemodechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L165"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L170"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 920,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -73981,7 +74131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -73990,7 +74140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -73999,7 +74149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -74008,7 +74158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -74017,7 +74167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -74026,7 +74176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -74035,7 +74185,70 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 93,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handlemodechange",
+      "label": "handleModeChange()",
+      "norm_label": "handlemodechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L165"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L170"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 930,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_test_ts",
       "label": "posSale.test.ts",
@@ -74044,7 +74257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 931,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -74053,7 +74266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 929,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -74062,70 +74275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L378"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L207"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L188"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentview_handlekeypadpress",
-      "label": "handleKeypadPress()",
-      "norm_label": "handlekeypadpress()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L229"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentview_setamountfromtouch",
-      "label": "setAmountFromTouch()",
-      "norm_label": "setamountfromtouch()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 930,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -74134,7 +74284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -74143,7 +74293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -74152,7 +74302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -74161,7 +74311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -74170,7 +74320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -74179,7 +74329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -74188,7 +74338,70 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L378"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L207"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L188"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentview_handlekeypadpress",
+      "label": "handleKeypadPress()",
+      "norm_label": "handlekeypadpress()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L229"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentview_setamountfromtouch",
+      "label": "setAmountFromTouch()",
+      "norm_label": "setamountfromtouch()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 940,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -74197,7 +74410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 941,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -74206,7 +74419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 939,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -74215,70 +74428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 94,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
-    },
-    {
-      "community": 940,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -74287,7 +74437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -74296,7 +74446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -74305,7 +74455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -74314,7 +74464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74323,7 +74473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74332,7 +74482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74341,7 +74491,70 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 95,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
+    },
+    {
+      "community": 950,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -74350,7 +74563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 951,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -74359,7 +74572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 949,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -74368,70 +74581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 950,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -74440,7 +74590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -74449,7 +74599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74458,7 +74608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74467,7 +74617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -74476,7 +74626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74485,7 +74635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -74494,7 +74644,70 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 960,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74503,7 +74716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 961,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74512,7 +74725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 959,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -74521,70 +74734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 96,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
-      "label": "useRegisterViewModel.ts",
-      "norm_label": "useregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "useregisterviewmodel_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "useregisterviewmodel_createpaymentid",
-      "label": "createPaymentId()",
-      "norm_label": "createpaymentid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "useregisterviewmodel_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "useregisterviewmodel_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "useregisterviewmodel_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "useregisterviewmodel_useregisterviewmodel",
-      "label": "useRegisterViewModel()",
-      "norm_label": "useregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 960,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74593,7 +74743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -74602,7 +74752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74611,7 +74761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74620,7 +74770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -74629,7 +74779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -74638,39 +74788,12 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 967,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -74739,6 +74862,33 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 973,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -74746,7 +74896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74755,7 +74905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74764,7 +74914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -74773,7 +74923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -74782,7 +74932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74791,7 +74941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74800,7 +74950,70 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 98,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 980,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -74809,7 +75022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 981,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -74818,7 +75031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 979,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74827,70 +75040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 98,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 980,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74899,7 +75049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -74908,7 +75058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74917,7 +75067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -74926,7 +75076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -74935,7 +75085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -74944,7 +75094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -74953,7 +75103,70 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
+    },
+    {
+      "community": 990,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -74962,7 +75175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 991,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74971,7 +75184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 989,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -74980,70 +75193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 990,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -75052,7 +75202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -75061,7 +75211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -75070,7 +75220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -75079,7 +75229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -75088,7 +75238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -75097,39 +75247,12 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1504
-- Graph nodes: 3830
-- Graph edges: 3388
-- Communities: 1419
+- Code files discovered: 1506
+- Graph nodes: 3837
+- Graph edges: 3393
+- Communities: 1421
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/AGENTS.md
+++ b/packages/athena-webapp/AGENTS.md
@@ -5,4 +5,5 @@
 - Read [docs/agent/architecture.md](./docs/agent/architecture.md) before changing router, auth-shell, or Convex boundaries.
 - Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
 - Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing ownership across `src/` and `convex/`.
+- For product-copy changes, follow the repo guide at [../../docs/product-copy-tone.md](../../docs/product-copy-tone.md) and normalize operator-facing system text instead of surfacing raw backend phrasing.
 - When generated Convex client artifacts need to refresh, start `bunx convex dev` from `packages/athena-webapp`. Do not use `bunx convex codegen` in this repo's normal agent flow because local workspaces may not have `CONVEX_DEPLOYMENT` configured.

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 40 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 5 file(s); key children: OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx, ThemeContext.tsx, UserContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 74 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 76 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 8 file(s); key children: auth.ts, commandResult.test.ts, commandResult.ts, registerSessionStatus.test.ts, registerSessionStatus.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -139,6 +139,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/hooks/useAuth.test.tsx`](../../src/hooks/useAuth.test.tsx)
 - [`src/hooks/useBulkOperations.test.ts`](../../src/hooks/useBulkOperations.test.ts)
 - [`src/hooks/useExpenseSessions.test.ts`](../../src/hooks/useExpenseSessions.test.ts)
+- [`src/lib/errors/operatorMessages.test.ts`](../../src/lib/errors/operatorMessages.test.ts)
 - [`src/lib/errors/presentCommandToast.test.ts`](../../src/lib/errors/presentCommandToast.test.ts)
 - [`src/lib/errors/presentUnexpectedErrorToast.test.ts`](../../src/lib/errors/presentUnexpectedErrorToast.test.ts)
 - [`src/lib/errors/runCommand.test.ts`](../../src/lib/errors/runCommand.test.ts)

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -57,13 +57,8 @@ vi.mock("./PinInput", () => ({
 }));
 
 vi.mock("../ui/dialog", () => ({
-  Dialog: ({
-    children,
-    open,
-  }: {
-    children: React.ReactNode;
-    open: boolean;
-  }) => (open ? <div>{children}</div> : null),
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
   DialogContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -73,7 +68,9 @@ vi.mock("../ui/dialog", () => ({
   DialogHeader: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
 }));
 
 const storeId = "store-1" as Id<"store">;
@@ -92,9 +89,9 @@ function renderDialog({
   mocks.useMutation.mockImplementation(() => {
     mutationCallCount += 1;
 
-    return (mutationCallCount % 2 === 1
-      ? authenticateMutation
-      : expireMutation) as never;
+    return (
+      mutationCallCount % 2 === 1 ? authenticateMutation : expireMutation
+    ) as never;
   });
 
   const onAuthenticated = vi.fn();
@@ -129,9 +126,7 @@ async function submitCredentials(
     username?: string;
   } = {},
 ) {
-  await waitFor(() =>
-    expect(screen.getByLabelText(/username/i)).toHaveFocus(),
-  );
+  await waitFor(() => expect(screen.getByLabelText(/username/i)).toHaveFocus());
   await user.type(screen.getByLabelText(/username/i), username);
   await user.type(screen.getByLabelText(/pin/i), pin);
 }
@@ -159,7 +154,9 @@ describe("CashierAuthDialog", () => {
     await submitCredentials(user);
 
     await waitFor(() =>
-      expect(mocks.toastError).toHaveBeenCalledWith("Invalid staff credentials."),
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Sign-in details not recognized. Enter the username and PIN again.",
+      ),
     );
     expect(onAuthenticated).not.toHaveBeenCalled();
     expect(mocks.toastError).not.toHaveBeenCalledWith(
@@ -181,7 +178,7 @@ describe("CashierAuthDialog", () => {
 
     await waitFor(() =>
       expect(mocks.toastError).toHaveBeenCalledWith(
-        "This staff member has an active session on another terminal.",
+        "Register sign-in already active at another register. Sign out there before starting here.",
       ),
     );
     expect(onAuthenticated).not.toHaveBeenCalled();
@@ -229,7 +226,9 @@ describe("CashierAuthDialog", () => {
     await submitCredentials(user);
 
     await waitFor(() =>
-      expect(mocks.toastSuccess).toHaveBeenCalledWith("Logged in as Ama Mensah."),
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        "Signed in as Ama Mensah.",
+      ),
     );
     expect(onAuthenticated).toHaveBeenCalledWith(staffProfileId);
     expect(mocks.toastError).not.toHaveBeenCalled();

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -5,14 +5,7 @@ import { Id } from "~/convex/_generated/dataModel";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "../ui/dialog";
-import { InputOTP, InputOTPGroup, InputOTPSlot } from "../ui/input-otp";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { LoadingButton } from "../ui/loading-button";
 import { toast } from "sonner";
 import { hashPin } from "~/src/lib/security/pinHash";
@@ -46,11 +39,11 @@ export const CashierAuthDialog = ({
   const usernameInputRef = useRef<HTMLInputElement>(null);
 
   const authenticateStaffCredentialForTerminal = useMutation(
-    api.operations.staffCredentials.authenticateStaffCredentialForTerminal
+    api.operations.staffCredentials.authenticateStaffCredentialForTerminal,
   );
 
   const expireAllSessionsForStaff = useMutation(
-    api.inventory.posSessions.expireAllSessionsForStaff
+    api.inventory.posSessions.expireAllSessionsForStaff,
   );
 
   // Auto-focus username field when dialog opens
@@ -81,12 +74,12 @@ export const CashierAuthDialog = ({
 
   const handleSubmit = async () => {
     if (!username.trim()) {
-      toast.error("Please enter your username");
+      toast.error("Username required. Enter a username to continue.");
       return;
     }
 
     if (pin.length !== 6) {
-      toast.error("Please enter your 6-digit PIN");
+      toast.error("PIN required. Enter all 6 digits to continue.");
       return;
     }
 
@@ -121,7 +114,7 @@ export const CashierAuthDialog = ({
             .join(" ");
 
         if (state === "auth") {
-          toast.success(`Logged in as ${staffDisplayName}.`);
+          toast.success(`Signed in as ${staffDisplayName}.`);
           onAuthenticated(result.staffProfileId);
         } else {
           const expireResult = await expireAllSessionsForStaff({
@@ -130,9 +123,9 @@ export const CashierAuthDialog = ({
           });
 
           if (expireResult.success) {
-            toast.success("Signed out of all terminals");
+            toast.success("Signed out from all registers.");
           } else {
-            toast.error("Failed to sign out of all terminals");
+            toast.error("Other register sign-outs not completed. Try again.");
             setPin("");
             return;
           }
@@ -160,12 +153,17 @@ export const CashierAuthDialog = ({
   };
 
   const header =
-    state === "auth" ? "Start session" : "Sign out of all terminals";
+    state === "auth"
+      ? "Start register session"
+      : "Sign out from other registers";
 
   const switchStateButtonText =
-    state === "auth" ? "Sign out of all terminals" : "Start session";
+    state === "auth"
+      ? "Sign out from other registers"
+      : "Start register session";
 
-  const mainButtonText = state === "auth" ? "Sign In" : "Sign Out";
+  const mainButtonText =
+    state === "auth" ? "Sign in" : "Sign out from all registers";
 
   return (
     <Dialog open={open} onOpenChange={onDismiss}>

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -11,7 +11,6 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { CardHeader, CardTitle } from "@/components/ui/card";
 import {
   calculatePosRemainingDue,
   calculatePosTotalPaid,
@@ -73,6 +72,8 @@ export function OrderSummary({
   cartItems,
   customerInfo,
   registerNumber,
+  subtotal: propSubtotal,
+  tax: propTax,
   total: propTotal,
   payments = [],
   hasTerminal = true,
@@ -106,6 +107,9 @@ export function OrderSummary({
       : cartItems;
   const effectiveCustomerInfo =
     completedTransactionData?.customerInfo ?? customerInfo;
+  const summarySubtotal =
+    completedTransactionData?.subtotal ?? propSubtotal ?? 0;
+  const summaryTax = completedTransactionData?.tax ?? propTax ?? 0;
   const total = completedTransactionData?.total ?? propTotal ?? 0;
   const totalPaid = calculatePosTotalPaid(payments);
   const remainingDue = calculatePosRemainingDue(totalPaid, total);
@@ -113,6 +117,53 @@ export function OrderSummary({
     (sum, item) => sum + item.quantity,
     0,
   );
+  const completedAtDate = completedTransactionData?.completedAt
+    ? completedTransactionData.completedAt instanceof Date
+      ? completedTransactionData.completedAt
+      : new Date(completedTransactionData.completedAt)
+    : null;
+  const completedDateLabel = completedAtDate
+    ? completedAtDate.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "Pending";
+  const completedTimeLabel = completedAtDate
+    ? completedAtDate.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      })
+    : "Pending";
+  const summaryPaymentMethod =
+    completedTransactionData?.paymentMethod ?? payments[0]?.method ?? "cash";
+  const receiptLabel = readOnly
+    ? (receiptNumberOverride ?? completedOrderNumber ?? "Transaction")
+    : (completedOrderNumber ?? "Transaction");
+  const summaryRows = [
+    { label: "Transaction", value: `#${receiptLabel}` },
+    {
+      label: "Completed",
+      value: `${completedDateLabel} • ${completedTimeLabel}`,
+    },
+    {
+      label: "Payment",
+      value: formatPaymentMethod(summaryPaymentMethod),
+    },
+    {
+      label: "Register",
+      value: registerNumber ? `Register ${registerNumber}` : "Unassigned",
+    },
+    {
+      label: "Cashier",
+      value: cashierName || "Unassigned",
+    },
+    {
+      label: "Items",
+      value: `${cartItemsCount} item${cartItemsCount === 1 ? "" : "s"}`,
+    },
+  ];
 
   const showPaymentButtons =
     !readOnly &&
@@ -274,24 +325,175 @@ export function OrderSummary({
     }
   };
 
+  if (readOnly || isTransactionCompleted) {
+    return (
+      <div
+        className={cn(
+          "grid h-full min-h-0 flex-1 auto-rows-[minmax(0,1fr)] gap-5 lg:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.9fr)]",
+          !hasTerminal && !readOnly && "opacity-60 transition-all duration-300",
+        )}
+      >
+        <section className="flex h-full min-h-0">
+          <div className="relative flex h-full min-h-[36rem] flex-1 flex-col overflow-hidden rounded-[1.75rem] border border-border/80 bg-[linear-gradient(145deg,hsl(var(--surface-raised))_0%,hsl(var(--surface))_52%,hsl(var(--muted)/0.72)_100%)] p-8 shadow-[var(--shadow-surface)] md:p-10">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent"
+            />
+
+            <div className="flex flex-1 flex-col">
+              <div className="space-y-10">
+                <div className="inline-flex h-16 w-16 items-center justify-center rounded-[1.4rem] bg-[hsl(var(--success))] text-[hsl(var(--success-foreground))] shadow-[0_20px_40px_-24px_hsl(var(--success)/0.75)] animate-[presence-lift_var(--motion-standard)_var(--ease-emphasized)_both]">
+                  <Check className="h-7 w-7" />
+                </div>
+
+                <div className="max-w-2xl space-y-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+                    Sale complete
+                  </p>
+                  <h2 className="text-3xl font-semibold tracking-tight text-foreground md:text-[3rem]">
+                    {readOnly ? "Sale recorded." : "Ready for next sale."}
+                  </h2>
+                </div>
+              </div>
+
+              <div className="mt-auto space-y-5">
+                <div className="grid gap-3 md:grid-cols-3 md:gap-4">
+                  <div className="rounded-[1.35rem] border border-border/70 bg-white/80 p-4 backdrop-blur-sm">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                      Total
+                    </p>
+                    <p className="mt-3 text-2xl font-semibold text-foreground">
+                      {formatStoredAmount(formatter, total)}
+                    </p>
+                  </div>
+                  <div className="rounded-[1.35rem] border border-border/70 bg-white/70 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                      Customer
+                    </p>
+                    <p className="mt-3 text-sm font-medium text-foreground">
+                      {effectiveCustomerInfo?.name ||
+                        effectiveCustomerInfo?.email ||
+                        "Walk-in customer"}
+                    </p>
+                  </div>
+                  <div className="rounded-[1.35rem] border border-border/70 bg-white/70 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                      Paid with
+                    </p>
+                    <p className="mt-3 text-sm font-medium text-foreground">
+                      {formatPaymentMethod(summaryPaymentMethod)}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  <Button
+                    onClick={handlePrintReceipt}
+                    variant="outline"
+                    className="h-14 rounded-2xl border-[hsl(var(--foreground))] bg-[hsl(var(--foreground))] px-5 text-sm font-semibold text-white shadow-[hsl(var(--foreground))/0.18] hover:border-[hsl(var(--primary))] hover:bg-[hsl(var(--primary))] hover:text-[hsl(var(--primary-foreground))]"
+                  >
+                    <Printer className="h-4 w-4" />
+                    Print receipt
+                  </Button>
+                  {!readOnly && (
+                    <Button
+                      onClick={handleStartNewTransaction}
+                      variant="outline"
+                      className="h-14 rounded-2xl border-border bg-background px-5 text-sm font-semibold"
+                    >
+                      <Plus className="h-4 w-4" />
+                      New sale
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <aside className="grid h-full min-h-0 gap-5">
+          <section className="flex h-full min-h-0 flex-col rounded-[1.5rem] border border-border/80 bg-white p-5 shadow-[var(--shadow-surface)]">
+            <div className="border-b border-border/70 pb-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                Transaction summary
+              </p>
+            </div>
+
+            <dl className="flex-1 space-y-5 py-6">
+              {summaryRows.map((row) => (
+                <div
+                  key={row.label}
+                  className="flex items-start justify-between gap-4 text-sm"
+                >
+                  <dt className="text-muted-foreground">{row.label}</dt>
+                  <dd className="max-w-[60%] text-right font-medium text-foreground">
+                    {row.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+
+            <div className="mt-auto space-y-3 border-t border-border/70 pt-6">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Subtotal</span>
+                <span className="font-medium text-foreground">
+                  {formatStoredAmount(formatter, summarySubtotal)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Tax</span>
+                <span className="font-medium text-foreground">
+                  {formatStoredAmount(formatter, summaryTax)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between pt-2">
+                <span className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Total
+                </span>
+                <span className="text-3xl font-semibold tracking-tight text-foreground">
+                  {formatStoredAmount(formatter, total)}
+                </span>
+              </div>
+            </div>
+          </section>
+
+          {(effectiveCustomerInfo?.name ||
+            effectiveCustomerInfo?.email ||
+            effectiveCustomerInfo?.phone) && (
+            <section className="rounded-[1.5rem] border border-border/80 bg-[hsl(var(--surface))] p-5 shadow-[var(--shadow-surface)]">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                Customer
+              </p>
+              <div className="mt-4 space-y-1">
+                <p className="text-lg font-semibold text-foreground">
+                  {effectiveCustomerInfo.name || "Guest checkout"}
+                </p>
+                {effectiveCustomerInfo.email && (
+                  <p className="text-sm text-muted-foreground">
+                    {effectiveCustomerInfo.email}
+                  </p>
+                )}
+                {effectiveCustomerInfo.phone && (
+                  <p className="text-sm text-muted-foreground">
+                    {effectiveCustomerInfo.phone}
+                  </p>
+                )}
+              </div>
+            </section>
+          )}
+        </aside>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
         "min-h-0",
         isPaymentFlowActive && "flex flex-1 flex-col",
-        isTransactionCompleted && "border rounded-lg",
         !hasTerminal && !readOnly && "opacity-60 transition-all duration-300",
       )}
     >
-      {isTransactionCompleted && (
-        <CardHeader className="space-y-4 mt-8 mb-16">
-          <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mb-4">
-            <Check className="w-6 h-6 text-green-600" />
-          </div>
-          <CardTitle className="text-green-600">Transaction complete</CardTitle>
-        </CardHeader>
-      )}
-
       <div
         className={cn(
           "flex flex-col gap-5 p-0",

--- a/packages/athena-webapp/src/components/pos/SessionManager.test.tsx
+++ b/packages/athena-webapp/src/components/pos/SessionManager.test.tsx
@@ -31,13 +31,21 @@ vi.mock("@/components/ui/button", () => ({
 }));
 
 vi.mock("@/components/ui/badge", () => ({
-  Badge: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  Badge: ({ children }: { children?: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
 }));
 
 vi.mock("@/components/ui/popover", () => ({
-  Popover: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  PopoverTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  PopoverContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Popover: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverContent: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 vi.mock("../common/FadeIn", () => ({
@@ -70,7 +78,9 @@ describe("SessionManager", () => {
 
     expect(screen.getByText("SES-001")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /hold/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /void/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear sale/i }),
+    ).toBeInTheDocument();
   });
 
   it("does not render trace navigation when trace metadata is absent", () => {
@@ -92,6 +102,8 @@ describe("SessionManager", () => {
       />,
     );
 
-    expect(screen.queryByRole("link", { name: "View trace" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "View trace" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/pos/SessionManager.tsx
+++ b/packages/athena-webapp/src/components/pos/SessionManager.tsx
@@ -59,7 +59,7 @@ export function SessionManager({ sessionPanel }: SessionManagerProps) {
           onClick={() => void sessionPanel.onVoidCurrentSession()}
         >
           <Ban className="h-4 w-4 text-destructive" />
-          Void
+          Clear sale
         </Button>
       )}
 
@@ -72,7 +72,7 @@ export function SessionManager({ sessionPanel }: SessionManagerProps) {
               className="flex h-10 items-center gap-2 px-4"
             >
               <PlayCircle className="h-4 w-4" />
-              Resume
+              Resume sale
               <Badge variant="secondary" className="ml-1">
                 {sessionPanel.heldSessions.length}
               </Badge>
@@ -96,7 +96,7 @@ export function SessionManager({ sessionPanel }: SessionManagerProps) {
         className="flex h-10 items-center gap-2 px-4"
       >
         <Plus className="h-4 w-4" />
-        New
+        New sale
       </Button>
     </div>
   );

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -17,13 +17,9 @@ vi.mock("@/components/ui/sidebar", () => ({
 }));
 
 vi.mock("@tanstack/react-router", () => ({
-  Link: ({
-    children,
-    to,
-  }: {
-    children: ReactNode;
-    to: string;
-  }) => <a href={to}>{children}</a>,
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
 }));
 
 vi.mock("@/components/View", () => ({
@@ -195,10 +191,12 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Open drawer before selling")).toBeInTheDocument();
+    expect(screen.getByText("Drawer closed")).toBeInTheDocument();
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
     expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
   });
 
@@ -230,7 +228,8 @@ describe("POSRegisterView", () => {
         currency: "GHS",
         openingFloat: "50.00",
         notes: "",
-        errorMessage: "A register session is already open for this terminal.",
+        errorMessage:
+          "Drawer already open for this register. Return to the active sale or review it in Cash Controls.",
         isSubmitting: false,
         onOpeningFloatChange: vi.fn(),
         onNotesChange: vi.fn(),
@@ -248,16 +247,18 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
+    expect(screen.getByText("Drawer closed")).toBeInTheDocument();
     expect(
-      screen.getByText("Sale paused until a drawer is open"),
+      screen.getByText(/needs an open drawer before this sale can continue/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/cart, customer, and payment draft/i)).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "A register session is already open for this terminal.",
+      "Drawer already open for this register. Return to the active sale or review it in Cash Controls.",
     );
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
     expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
@@ -311,12 +312,18 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Finish drawer closeout before selling")).toBeInTheDocument();
+    expect(screen.getByText("Closeout in progress")).toBeInTheDocument();
     expect(
-      screen.getByText(/Front Counter is already in closeout/i),
+      screen.getByText(
+        /Front Counter is already in closeout. Finish it in Cash Controls before selling here again./i,
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /cash controls/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /cash controls/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign out/i }),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText(/opening float/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/notes/i)).not.toBeInTheDocument();
     expect(
@@ -324,7 +331,9 @@ describe("POSRegisterView", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
     expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /sign out/i }));

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -19,9 +19,9 @@ import { RegisterCheckoutPanel } from "./RegisterCheckoutPanel";
 import { RegisterCustomerPanel } from "./RegisterCustomerPanel";
 import { RegisterDrawerGate } from "./RegisterDrawerGate";
 
-function useCollapseSidebarForActiveSession(isSessionActive: boolean) {
+function useCollapseSidebarForPosFlow() {
   const { isMobile, open, setOpen } = useSidebar();
-  const collapsedForActiveSessionRef = useRef(false);
+  const collapsedForPosFlowRef = useRef(false);
   const previousSidebarOpenRef = useRef<boolean | null>(null);
   const setOpenRef = useRef(setOpen);
 
@@ -30,23 +30,19 @@ function useCollapseSidebarForActiveSession(isSessionActive: boolean) {
   }, [setOpen]);
 
   useEffect(() => {
-    if (isMobile || collapsedForActiveSessionRef.current) {
-      return;
-    }
-
-    if (!isSessionActive) {
+    if (isMobile || collapsedForPosFlowRef.current) {
       return;
     }
 
     previousSidebarOpenRef.current = open;
     setOpen(false);
-    collapsedForActiveSessionRef.current = true;
-  }, [isMobile, isSessionActive, open, setOpen]);
+    collapsedForPosFlowRef.current = true;
+  }, [isMobile, open, setOpen]);
 
   useEffect(() => {
     return () => {
       if (
-        collapsedForActiveSessionRef.current &&
+        collapsedForPosFlowRef.current &&
         previousSidebarOpenRef.current !== null
       ) {
         setOpenRef.current(previousSidebarOpenRef.current);
@@ -55,9 +51,9 @@ function useCollapseSidebarForActiveSession(isSessionActive: boolean) {
   }, []);
 }
 
-function useLockDocumentScroll(isSessionActive: boolean) {
+function useLockDocumentScroll(shouldLockScroll: boolean) {
   useEffect(() => {
-    if (!isSessionActive) {
+    if (!shouldLockScroll) {
       return;
     }
 
@@ -79,7 +75,7 @@ function useLockDocumentScroll(isSessionActive: boolean) {
       bodyStyle.overflow = previousBodyOverflow;
       bodyStyle.overscrollBehaviorY = previousBodyOverscrollBehaviorY;
     };
-  }, [isSessionActive]);
+  }, [shouldLockScroll]);
 }
 
 function ProductLookupEmptyState() {
@@ -113,14 +109,16 @@ function ProductLookupEmptyState() {
 export function POSRegisterView() {
   const viewModel = useRegisterViewModel();
   const [isPaymentInputActive, setIsPaymentInputActive] = useState(false);
-  useCollapseSidebarForActiveSession(viewModel.header.isSessionActive);
+  useCollapseSidebarForPosFlow();
   const isSessionActive = viewModel.header.isSessionActive;
-  useLockDocumentScroll(isSessionActive);
+  const isAuthDialogOpen = Boolean(viewModel.authDialog?.open);
+  const shouldUseFullscreenRegisterShell = isSessionActive || isAuthDialogOpen;
+  useLockDocumentScroll(shouldUseFullscreenRegisterShell);
   const registerViewWidth = "full";
   const registerContentClassName = cn(
     "w-full px-6 py-5",
-    isSessionActive ? "h-full min-h-0" : "h-auto",
-    isSessionActive && "overflow-hidden",
+    shouldUseFullscreenRegisterShell ? "h-full min-h-0" : "h-auto",
+    shouldUseFullscreenRegisterShell && "overflow-hidden",
   );
   const canSearchProducts =
     !viewModel.checkout.isTransactionCompleted && !viewModel.drawerGate;
@@ -154,15 +152,17 @@ export function POSRegisterView() {
     <View
       width={registerViewWidth}
       className={cn(
-        isSessionActive &&
+        shouldUseFullscreenRegisterShell &&
           "h-[calc(100dvh-2.5rem)] max-h-[calc(100dvh-2.5rem)] overflow-hidden",
       )}
       contentClassName={cn(
-        isSessionActive &&
+        shouldUseFullscreenRegisterShell &&
           "flex h-full max-h-full flex-col overflow-hidden rounded-2xl border border-border/80 bg-white",
       )}
-      headerClassName={cn(isSessionActive && "shrink-0")}
-      mainClassName={cn(isSessionActive && "min-h-0 flex-1 overflow-hidden")}
+      headerClassName={cn(shouldUseFullscreenRegisterShell && "shrink-0")}
+      mainClassName={cn(
+        shouldUseFullscreenRegisterShell && "min-h-0 flex-1 overflow-hidden",
+      )}
       header={
         <ComposedPageHeader
           width={registerViewWidth}
@@ -171,6 +171,11 @@ export function POSRegisterView() {
           leadingContent={
             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-8">
               <div className="flex shrink-0 items-center gap-3">
+                {isSessionActive && (
+                  <FadeIn className="flex items-center gap-2">
+                    <div className="w-2 h-2 bg-green-600 rounded-full animate-pulse" />
+                  </FadeIn>
+                )}
                 <p className="text-lg font-semibold text-gray-900">
                   {viewModel.header.title}
                 </p>
@@ -193,7 +198,6 @@ export function POSRegisterView() {
           trailingContent={
             canSearchProducts ? (
               <RegisterActionBar
-                isSessionActive={viewModel.header.isSessionActive}
                 registerInfo={viewModel.registerInfo}
                 sessionPanel={viewModel.sessionPanel}
               />
@@ -261,7 +265,7 @@ export function POSRegisterView() {
               <div
                 className={cn(
                   "flex h-full min-h-0 overflow-hidden",
-                  viewModel.checkout.isTransactionCompleted && "lg:col-span-3",
+                  viewModel.checkout.isTransactionCompleted && "lg:col-span-2",
                 )}
               >
                 <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
@@ -279,7 +283,8 @@ export function POSRegisterView() {
                   <div
                     className={cn(
                       "rounded-lg bg-white p-4",
-                      isPaymentInputActive
+                      isPaymentInputActive ||
+                        viewModel.checkout.isTransactionCompleted
                         ? "flex min-h-0 flex-1 flex-col overflow-hidden"
                         : "shrink-0",
                     )}

--- a/packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx
@@ -13,22 +13,17 @@ import { RegisterSessionPanel } from "./RegisterSessionPanel";
 import { FadeIn } from "../../common/FadeIn";
 
 interface RegisterActionBarProps {
-  isSessionActive: boolean;
   registerInfo: RegisterInfoState;
   sessionPanel: RegisterSessionPanelState | null;
 }
 
 export function RegisterActionBar({
-  isSessionActive,
   registerInfo,
   sessionPanel,
 }: RegisterActionBarProps) {
   return (
     <div className="flex items-center gap-4">
-      <RegisterSessionPanel
-        isSessionActive={isSessionActive}
-        sessionPanel={sessionPanel}
-      />
+      <RegisterSessionPanel sessionPanel={sessionPanel} />
 
       <div
         className={cn(

--- a/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
@@ -18,7 +18,7 @@ export function RegisterCheckoutPanel({
   onPaymentFlowChange,
 }: RegisterCheckoutPanelProps) {
   return (
-    <div className="flex h-full min-h-0 flex-col gap-6">
+    <div className="flex h-full min-h-0 flex-1 flex-col gap-6">
       <OrderSummary
         cartItems={checkout.cartItems}
         customerInfo={checkout.customerInfo}

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -53,15 +53,15 @@ export function RegisterDrawerGate({
       <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
         <div className="space-y-3">
           <p className="text-sm font-medium uppercase tracking-[0.2em] text-stone-500">
-            Drawer closeout
+            Register closeout
           </p>
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold text-stone-900">
-              Finish drawer closeout before selling
+              Closeout in progress
             </h2>
             <p className="text-sm text-stone-600">
-              {drawerGate.registerLabel} is already in closeout. Finish the
-              register closeout in Cash Controls before returning to POS.
+              {drawerGate.registerLabel} is already in closeout. Finish it in
+              Cash Controls before selling here again.
             </p>
             <p className="text-sm text-stone-500">
               Register {drawerGate.registerNumber}
@@ -96,16 +96,16 @@ export function RegisterDrawerGate({
     <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
       <div className="space-y-3">
         <p className="text-sm font-medium uppercase tracking-[0.2em] text-stone-500">
-          {isRecovery ? "Drawer recovery" : "Drawer setup"}
+          Drawer status
         </p>
         <div className="space-y-1">
           <h2 className="text-2xl font-semibold text-stone-900">
-            {isRecovery ? "Sale paused until a drawer is open" : "Open drawer before selling"}
+            Drawer closed
           </h2>
           <p className="text-sm text-stone-600">
             {isRecovery
-              ? `${drawerGate.registerLabel} needs an active cash drawer before this sale can continue. The cart, customer, and payment draft will be preserved after drawer setup.`
-              : `${drawerGate.registerLabel} must have an active cash drawer before POS can start or resume a live session.`}
+              ? `${drawerGate.registerLabel} needs an open drawer before this sale can continue.`
+              : `${drawerGate.registerLabel} needs an open drawer before you can start selling.`}
           </p>
           <p className="text-sm text-stone-500">
             Register {drawerGate.registerNumber}
@@ -137,7 +137,7 @@ export function RegisterDrawerGate({
           <Textarea
             disabled={drawerGate.isSubmitting}
             onChange={(event) => drawerGate.onNotesChange?.(event.target.value)}
-            placeholder="Add a quick note for this drawer opening"
+            placeholder="Add a note for this drawer opening"
             rows={4}
             value={drawerGate.notes ?? ""}
           />
@@ -155,7 +155,7 @@ export function RegisterDrawerGate({
             disabled={drawerGate.isSubmitting}
             type="submit"
           >
-            {drawerGate.isSubmitting ? "Opening drawer..." : "Open drawer"}
+            {drawerGate.isSubmitting ? "Opening drawer" : "Open drawer"}
           </Button>
 
           <Button

--- a/packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx
@@ -3,12 +3,10 @@ import { SessionManager } from "../SessionManager";
 import type { RegisterSessionPanelState } from "@/lib/pos/presentation/register/registerUiState";
 
 interface RegisterSessionPanelProps {
-  isSessionActive: boolean;
   sessionPanel: RegisterSessionPanelState | null;
 }
 
 export function RegisterSessionPanel({
-  isSessionActive,
   sessionPanel,
 }: RegisterSessionPanelProps) {
   if (!sessionPanel) {
@@ -17,12 +15,6 @@ export function RegisterSessionPanel({
 
   return (
     <div className="flex items-center gap-3 px-3 py-2 bg-gray-50 rounded-lg border">
-      {isSessionActive && (
-        <FadeIn className="flex items-center gap-2">
-          <div className="w-2 h-2 bg-green-600 rounded-full animate-pulse" />
-          <p className="text-sm text-green-600 font-medium">Active Session</p>
-        </FadeIn>
-      )}
       <SessionManager sessionPanel={sessionPanel} />
     </div>
   );

--- a/packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx
+++ b/packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx
@@ -24,7 +24,7 @@ export function HeldSessionsList({
   if (sessions.length === 0) {
     return (
       <div className="text-center py-6 text-muted-foreground">
-        No held sessions
+        No held sales
       </div>
     );
   }
@@ -45,7 +45,7 @@ export function HeldSessionsList({
 
   return (
     <div className="space-y-4">
-      <h4 className="font-medium">Held Sessions</h4>
+      <h4 className="font-medium">Held sales</h4>
       <div className="space-y-2 max-h-96 overflow-y-auto">
         {sessions.map((session) => (
           <Card key={session._id} className="p-3">
@@ -104,7 +104,7 @@ export function HeldSessionsList({
                   size="sm"
                   disabled={hasExpired(session.expiresAt)}
                   onClick={() => void onResumeSession(session._id)}
-                  title="Resume session"
+                  title="Resume sale"
                 >
                   <PlayCircle className="h-4 w-4" />
                 </Button>
@@ -112,7 +112,7 @@ export function HeldSessionsList({
                   variant="ghost"
                   size="sm"
                   onClick={() => void onVoidSession(session._id)}
-                  title="Void session"
+                  title="Clear sale"
                 >
                   <Ban className="h-4 w-4 text-destructive" />
                 </Button>

--- a/packages/athena-webapp/src/lib/errors/operatorMessages.test.ts
+++ b/packages/athena-webapp/src/lib/errors/operatorMessages.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { toOperatorMessage } from "./operatorMessages";
+
+describe("toOperatorMessage", () => {
+  it("normalizes known backend phrasing into operator copy", () => {
+    expect(
+      toOperatorMessage("Open the cash drawer before modifying this sale."),
+    ).toBe("Drawer closed. Open the drawer before updating this sale.");
+  });
+
+  it("passes through messages that already fit the tone guide", () => {
+    expect(
+      toOperatorMessage("Barcode not found. Scan again or search by name."),
+    ).toBe("Barcode not found. Scan again or search by name.");
+  });
+});

--- a/packages/athena-webapp/src/lib/errors/operatorMessages.ts
+++ b/packages/athena-webapp/src/lib/errors/operatorMessages.ts
@@ -1,0 +1,57 @@
+const OPERATOR_MESSAGE_REWRITES: Array<[RegExp, string]> = [
+  [
+    /^Invalid staff credentials\.?$/i,
+    "Sign-in details not recognized. Enter the username and PIN again.",
+  ],
+  [
+    /^This staff (member|profile) has an active session on another terminal\.?$/i,
+    "Register sign-in already active at another register. Sign out there before starting here.",
+  ],
+  [
+    /^A register session is already open for this terminal\.?$/i,
+    "Drawer already open for this register. Return to the active sale or review it in Cash Controls.",
+  ],
+  [
+    /^A register session is already open for this register number\.?$/i,
+    "Drawer already open for this register number. Review it in Cash Controls before opening another drawer.",
+  ],
+  [
+    /^Open the cash drawer before starting a sale\.?$/i,
+    "Drawer closed. Open the drawer before starting a sale.",
+  ],
+  [
+    /^Open the cash drawer before resuming this sale\.?$/i,
+    "Drawer closed. Open the drawer before resuming this sale.",
+  ],
+  [
+    /^Open the cash drawer before recovering this sale\.?$/i,
+    "Drawer closed. Open the drawer before continuing this sale.",
+  ],
+  [
+    /^Open the cash drawer before modifying this sale\.?$/i,
+    "Drawer closed. Open the drawer before updating this sale.",
+  ],
+  [
+    /^Open the cash drawer before completing this sale\.?$/i,
+    "Drawer closed. Open the drawer before completing this sale.",
+  ],
+  [
+    /^This sale is already assigned to a different cash drawer\.?$/i,
+    "Sale assigned to a different drawer. Open that drawer before continuing.",
+  ],
+];
+
+export function toOperatorMessage(message: string): string {
+  const normalized = message.trim();
+  if (!normalized) {
+    return normalized;
+  }
+
+  for (const [pattern, replacement] of OPERATOR_MESSAGE_REWRITES) {
+    if (pattern.test(normalized)) {
+      return replacement;
+    }
+  }
+
+  return normalized;
+}

--- a/packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts
+++ b/packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts
@@ -17,16 +17,32 @@ describe("presentCommandToast", () => {
     mocks.toastError.mockClear();
   });
 
-  it("shows trusted user error copy", () => {
+  it("normalizes known user error copy for operators", () => {
     presentCommandToast({
       kind: "user_error",
       error: {
         code: "authentication_failed",
-        message: "Your session has expired",
+        message: "Invalid staff credentials.",
       },
     });
 
-    expect(mocks.toastError).toHaveBeenCalledWith("Your session has expired");
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Sign-in details not recognized. Enter the username and PIN again.",
+    );
+  });
+
+  it("passes through user error copy that already matches the guide", () => {
+    presentCommandToast({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Barcode not found. Scan again or search by name.",
+      },
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Barcode not found. Scan again or search by name.",
+    );
   });
 
   it("shows a generic fallback for unexpected errors", () => {

--- a/packages/athena-webapp/src/lib/errors/presentCommandToast.ts
+++ b/packages/athena-webapp/src/lib/errors/presentCommandToast.ts
@@ -1,12 +1,13 @@
 import { toast } from "sonner";
 
 import type { NormalizedCommandResult } from "./runCommand";
+import { toOperatorMessage } from "./operatorMessages";
 
 export function presentCommandToast<T>(
   result: Exclude<NormalizedCommandResult<T>, { kind: "ok" }>,
 ): void {
   if (result.kind === "user_error") {
-    toast.error(result.error.message);
+    toast.error(toOperatorMessage(result.error.message));
     return;
   }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -75,14 +75,12 @@ let mockActiveSession:
         amount: number;
         timestamp: number;
       }>;
-      customer:
-        | {
-            _id: Id<"posCustomer">;
-            name: string;
-            email?: string;
-            phone?: string;
-          }
-        | null;
+      customer: {
+        _id: Id<"posCustomer">;
+        name: string;
+        email?: string;
+        phone?: string;
+      } | null;
     }
   | null
   | undefined;
@@ -284,8 +282,8 @@ describe("useRegisterViewModel", () => {
     mockUpdateSession.mockReset();
     mockUpdateSession.mockResolvedValue(
       ok({
-      sessionId: "session-1" as Id<"posSession">,
-      expiresAt: Date.now() + 60_000,
+        sessionId: "session-1" as Id<"posSession">,
+        expiresAt: Date.now() + 60_000,
       }),
     );
     mockSyncSessionCheckoutState.mockReset();
@@ -322,7 +320,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.header.isSessionActive).toBe(true);
@@ -339,7 +339,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     await act(async () => {
@@ -378,7 +380,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.drawerGate).not.toBeNull();
@@ -411,7 +415,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.drawerGate).not.toBeNull();
@@ -441,7 +447,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.drawerGate).not.toBeNull();
@@ -475,7 +483,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.drawerGate).not.toBeNull();
@@ -514,13 +524,15 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.drawerGate).not.toBeNull();
     expect(result.current.drawerGate?.mode).toBe("recovery");
     expect(result.current.drawerGate?.errorMessage).toBe(
-      "This sale is assigned to a different cash drawer.",
+      "Sale assigned to a different drawer. Open that drawer before continuing.",
     );
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockBindSessionToRegisterSession).not.toHaveBeenCalled();
@@ -550,7 +562,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     await act(async () => {
@@ -567,7 +581,7 @@ describe("useRegisterViewModel", () => {
 
     expect(mockAddItem).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
-      "Open the cash drawer before adding products",
+      "Drawer closed. Open the drawer before adding items.",
     );
   });
 
@@ -586,7 +600,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.drawerGate).not.toBeNull();
@@ -609,7 +625,9 @@ describe("useRegisterViewModel", () => {
     const { result, rerender } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     act(() => {
@@ -679,7 +697,9 @@ describe("useRegisterViewModel", () => {
     const { result, rerender } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     act(() => {
@@ -741,7 +761,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     act(() => {
@@ -754,13 +776,13 @@ describe("useRegisterViewModel", () => {
 
     expect(result.current.drawerGate).not.toBeNull();
     expect(result.current.drawerGate?.errorMessage).toBe(
-      "A register session is already open for this terminal.",
+      "Drawer already open for this register. Return to the active sale or review it in Cash Controls.",
     );
     expect(toast.error).not.toHaveBeenCalled();
     expect(mockStartSession).not.toHaveBeenCalled();
   });
 
-  it("does not void an empty active session when navigating away", async () => {
+  it("voids an empty active session when navigating away/unmounting", async () => {
     mockActiveSession = {
       ...mockActiveSession!,
       cartItems: [],
@@ -768,18 +790,26 @@ describe("useRegisterViewModel", () => {
     };
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
-    const { result } = renderHook(() => useRegisterViewModel());
+    const { result, unmount } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     await act(async () => {
       await result.current.onNavigateBack();
     });
 
+    await act(async () => {
+      unmount();
+    });
+
     expect(mockHoldSession).not.toHaveBeenCalled();
-    expect(mockVoidSession).not.toHaveBeenCalled();
+    expect(mockVoidSession).toHaveBeenCalledWith({
+      sessionId: "session-1" as Id<"posSession">,
+    });
     expect(mockNavigateBack).toHaveBeenCalled();
   });
 
@@ -804,7 +834,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     await act(async () => {
@@ -837,7 +869,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     expect(result.current.sessionPanel?.canHoldSession).toBe(false);
@@ -847,12 +881,18 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(mockHoldSession).not.toHaveBeenCalled();
+    expect(mockVoidSession).toHaveBeenCalledWith({
+      sessionId: "session-1" as Id<"posSession">,
+    });
     expect(mockNavigateBack).toHaveBeenCalled();
   });
 
   it("does not require the legacy register store or orchestration hooks", () => {
     const currentDir = dirname(fileURLToPath(import.meta.url));
-    const source = readFileSync(join(currentDir, "useRegisterViewModel.ts"), "utf8");
+    const source = readFileSync(
+      join(currentDir, "useRegisterViewModel.ts"),
+      "utf8",
+    );
 
     expect(source).not.toContain("usePOSStore");
     expect(source).not.toContain("useCartOperations");
@@ -878,7 +918,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     await act(async () => {
@@ -896,7 +938,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     act(() => {
@@ -926,7 +970,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     act(() => {
@@ -935,10 +981,9 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.checkout.payments).toHaveLength(2);
-    expect(result.current.checkout.payments.map((payment) => payment.method)).toEqual([
-      "cash",
-      "card",
-    ]);
+    expect(
+      result.current.checkout.payments.map((payment) => payment.method),
+    ).toEqual(["cash", "card"]);
     expect(mockSyncSessionCheckoutState).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -970,7 +1015,9 @@ describe("useRegisterViewModel", () => {
     const { result, rerender } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     mockActiveSession = {
@@ -997,7 +1044,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     act(() => {
@@ -1021,7 +1070,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated("staff-1" as Id<"staffProfile">);
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
     });
 
     await act(async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -32,6 +32,7 @@ import {
   POS_SEARCH_DEBOUNCE_MS,
 } from "@/lib/pos/constants";
 import { parseDisplayAmountInput } from "@/lib/pos/displayAmounts";
+import { toOperatorMessage } from "@/lib/errors/operatorMessages";
 import { logger } from "@/lib/logger";
 import { useConvexCommandGateway } from "@/lib/pos/infrastructure/convex/commandGateway";
 import { useConvexRegisterState } from "@/lib/pos/infrastructure/convex/registerGateway";
@@ -114,6 +115,10 @@ function trimOptional(value: string): string | undefined {
   return trimmedValue.length > 0 ? trimmedValue : undefined;
 }
 
+function presentOperatorError(message: string): void {
+  toast.error(toOperatorMessage(message));
+}
+
 export function useRegisterViewModel(): RegisterViewModel {
   const { activeStore } = useGetActiveStore();
   const terminal = useGetTerminal();
@@ -147,6 +152,8 @@ export function useRegisterViewModel(): RegisterViewModel {
   const paymentsRef = useRef<Payment[]>([]);
   const checkoutStateVersionRef = useRef(0);
   const drawerBindingRequestRef = useRef<string | null>(null);
+  const unmountSessionRef = useRef<Id<"posSession"> | null>(null);
+  const unmountSessionCartItemCountRef = useRef(0);
 
   const registerState = useConvexRegisterState({
     storeId: activeStore?._id,
@@ -206,8 +213,14 @@ export function useRegisterViewModel(): RegisterViewModel {
     releaseSessionInventoryHoldsAndDeleteItems,
     removeItem,
   } = useConvexSessionActions();
+  const voidSessionRef = useRef<typeof voidSession>(voidSession);
 
   const activeCartItems = activeSession?.cartItems ?? [];
+  if (activeSession?._id) {
+    unmountSessionRef.current = activeSession._id as Id<"posSession">;
+    unmountSessionCartItemCountRef.current = activeCartItems.length;
+  }
+  voidSessionRef.current = voidSession;
   const activeTotals = useMemo(
     () => calculatePosCartTotals(activeCartItems),
     [activeCartItems],
@@ -317,6 +330,35 @@ export function useRegisterViewModel(): RegisterViewModel {
     setIsOpeningDrawer(false);
   }, [registerState?.activeRegisterSession?._id]);
 
+  useEffect(() => {
+    return () => {
+      const sessionId = unmountSessionRef.current;
+      const hasCartItems = unmountSessionCartItemCountRef.current > 0;
+
+      if (!sessionId || hasCartItems) {
+        return;
+      }
+
+      const sessionVoidOperation = voidSessionRef.current;
+      if (!sessionVoidOperation) {
+        return;
+      }
+
+      void (async () => {
+        const result = await sessionVoidOperation({
+          sessionId,
+        });
+
+        if (result.kind !== "ok") {
+          logger.warn("[POS] Failed to void empty session on unmount", {
+            sessionId,
+            error: result.error.message,
+          });
+        }
+      })();
+    };
+  }, []);
+
   const handleSessionExpired = useCallback(() => {
     logger.warn(
       "[POS] Session expired, clearing cashier and local draft state",
@@ -406,12 +448,12 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     if (!activeRegisterSessionId) {
-      toast.error("Open the drawer before adding products");
+      toast.error("Drawer closed. Open the drawer before adding items.");
       return null;
     }
 
     if (!activeStore?._id || !terminal?._id || !staffProfileId) {
-      toast.error("Sign in at a registered terminal before adding products");
+      toast.error("Register sign-in required. Sign in before adding items.");
       return null;
     }
 
@@ -429,7 +471,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
 
     if (!result.ok) {
-      toast.error(result.message);
+      presentOperatorError(result.message);
       return null;
     }
 
@@ -479,7 +521,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         );
       }
 
-      toast.error(result.error.message);
+      presentOperatorError(result.error.message);
       return false;
     },
     [
@@ -614,7 +656,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   const holdCurrentSession = useCallback(
     async (reason?: string) => {
       if (!activeSession || !staffProfileId) {
-        toast.error("No active session to hold");
+        toast.error(
+          "No sale in progress. Start a sale before placing it on hold.",
+        );
         return false;
       }
 
@@ -635,14 +679,14 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (!result.ok) {
-        toast.error(result.message);
+        presentOperatorError(result.message);
         return false;
       }
 
       resetDraftState({
         keepCashier: true,
       });
-      toast.success("Session held");
+      toast.success("Sale placed on hold.");
       return true;
     },
     [
@@ -656,7 +700,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const voidCurrentSession = useCallback(async () => {
     if (!activeSession) {
-      toast.error("No active session to void");
+      toast.error("No sale in progress. Start a sale before clearing it.");
       return false;
     }
 
@@ -665,14 +709,14 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
 
     if (result.kind !== "ok") {
-      toast.error(result.error.message);
+      presentOperatorError(result.error.message);
       return false;
     }
 
     resetDraftState({
       keepCashier: true,
     });
-    toast.success("Session voided");
+    toast.success("Sale cleared.");
     return true;
   }, [activeSession, resetDraftState, voidSession]);
 
@@ -680,7 +724,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     async (sessionId: Id<"posSession">) => {
       if (!staffProfileId || !terminal?._id) {
         toast.error(
-          "Sign in at a registered terminal before resuming a session",
+          "Register sign-in required. Sign in before resuming a sale.",
         );
         return;
       }
@@ -705,14 +749,14 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (result.kind !== "ok") {
-        toast.error(result.error.message);
+        presentOperatorError(result.error.message);
         return;
       }
 
       setPaymentState([]);
       setShowCustomerPanel(false);
       bootstrapInitialized.current = true;
-      toast.success("Session resumed");
+      toast.success("Sale resumed.");
     },
     [
       activeSession,
@@ -726,12 +770,12 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const handleStartNewSession = useCallback(async () => {
     if (!activeStore?._id || !terminal?._id || !staffProfileId) {
-      toast.error("Sign in at a registered terminal before starting a session");
+      toast.error("Register sign-in required. Sign in before starting a sale.");
       return;
     }
 
     if (!activeRegisterSessionId) {
-      toast.error("Open the drawer before starting a session");
+      toast.error("Drawer closed. Open the drawer before starting a sale.");
       return;
     }
 
@@ -760,7 +804,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
 
     if (!result.ok) {
-      toast.error(result.message);
+      presentOperatorError(result.message);
       return;
     }
 
@@ -768,7 +812,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       keepCashier: true,
     });
     bootstrapInitialized.current = true;
-    toast.success("New session created");
+    toast.success("Sale started.");
   }, [
     activeSession,
     activeRegisterSessionId,
@@ -785,14 +829,16 @@ export function useRegisterViewModel(): RegisterViewModel {
   const handleOpenDrawer = useCallback(async () => {
     if (!activeStore?._id || !terminal?._id || !staffProfileId) {
       setDrawerErrorMessage(
-        "Sign in at a registered terminal before opening the drawer",
+        "Register sign-in required. Sign in before opening the drawer.",
       );
       return;
     }
 
     const parsedOpeningFloat = parseDisplayAmountInput(drawerOpeningFloat);
     if (parsedOpeningFloat === undefined || parsedOpeningFloat <= 0) {
-      setDrawerErrorMessage("Enter a valid opening float");
+      setDrawerErrorMessage(
+        "Opening float required. Enter an amount greater than 0.",
+      );
       return;
     }
 
@@ -815,12 +861,12 @@ export function useRegisterViewModel(): RegisterViewModel {
     setIsOpeningDrawer(false);
 
     if (!result.ok) {
-      setDrawerErrorMessage(result.message);
+      setDrawerErrorMessage(toOperatorMessage(result.message));
       return;
     }
 
     requestBootstrap();
-    toast.success("Drawer opened");
+    toast.success("Drawer open. You can start selling.");
   }, [
     activeStore?._id,
     staffProfileId,
@@ -858,7 +904,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       if (result.kind !== "ok") {
         drawerBindingRequestRef.current = null;
-        setDrawerErrorMessage(result.error.message);
+        setDrawerErrorMessage(toOperatorMessage(result.error.message));
         return;
       }
 
@@ -912,7 +958,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         });
 
         if (result.kind !== "ok") {
-          toast.error(result.error.message);
+          presentOperatorError(result.error.message);
           bootstrapInitialized.current = false;
         }
 
@@ -933,7 +979,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (!result.ok) {
-        toast.error(result.message);
+        presentOperatorError(result.message);
         bootstrapInitialized.current = false;
       }
     })();
@@ -985,17 +1031,17 @@ export function useRegisterViewModel(): RegisterViewModel {
   const handleAddProduct = useCallback(
     async (product: Product) => {
       if (!staffProfileId) {
-        toast.error("A cashier must sign in before products can be added");
+        toast.error("Register sign-in required. Sign in before adding items.");
         return;
       }
 
       if (!product.productId || !product.skuId) {
-        toast.error("Product is missing SKU details");
+        toast.error("Item details unavailable. Try another item.");
         return;
       }
 
       if (activeSessionHasBlockedRegisterBinding) {
-        toast.error("Open the cash drawer before adding products");
+        toast.error("Drawer closed. Open the drawer before adding items.");
         return;
       }
 
@@ -1032,7 +1078,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (!result.ok) {
-        toast.error(result.message);
+        presentOperatorError(result.message);
         return;
       }
 
@@ -1054,7 +1100,9 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (activeSessionHasBlockedRegisterBinding) {
-        toast.error("Open the cash drawer before modifying this sale");
+        toast.error(
+          "Drawer closed. Open the drawer before updating this sale.",
+        );
         return;
       }
 
@@ -1073,14 +1121,14 @@ export function useRegisterViewModel(): RegisterViewModel {
         });
 
         if (result.kind !== "ok") {
-          toast.error(result.error.message);
+          presentOperatorError(result.error.message);
         }
 
         return;
       }
 
       if (!item.productId || !item.skuId) {
-        toast.error("Item is missing product details");
+        toast.error("Item details unavailable. Remove it and add it again.");
         return;
       }
 
@@ -1107,7 +1155,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (!result.ok) {
-        toast.error(result.message);
+        presentOperatorError(result.message);
       }
     },
     [
@@ -1126,7 +1174,9 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (activeSessionHasBlockedRegisterBinding) {
-        toast.error("Open the cash drawer before modifying this sale");
+        toast.error(
+          "Drawer closed. Open the drawer before updating this sale.",
+        );
         return;
       }
 
@@ -1137,7 +1187,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (result.kind !== "ok") {
-        toast.error(result.error.message);
+        presentOperatorError(result.error.message);
       }
     },
     [
@@ -1154,7 +1204,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     if (activeSessionHasBlockedRegisterBinding) {
-      toast.error("Open the cash drawer before modifying this sale");
+      toast.error("Drawer closed. Open the drawer before updating this sale.");
       return;
     }
 
@@ -1166,12 +1216,12 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
 
     if (result.kind !== "ok") {
-      toast.error(result.error.message);
+      presentOperatorError(result.error.message);
       return;
     }
 
     setPaymentState([]);
-    toast.success("Cart cleared");
+    toast.success("Sale cleared.");
   }, [
     activeSession,
     activeSessionHasBlockedRegisterBinding,
@@ -1259,7 +1309,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           barcode: extractedValue,
           storeId: activeStore?._id,
         });
-        toast.error("Barcode not found");
+        toast.error("Barcode not found. Scan again or search by name.");
       }
     },
     [
@@ -1300,7 +1350,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       const handled = hasDraftState
         ? await holdCurrentSession("Navigating away from register")
-        : true;
+        : await voidCurrentSession();
 
       if (!handled) {
         return;
@@ -1311,8 +1361,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     navigateBack();
   }, [
     activeSession,
-    customerInfo,
     holdCurrentSession,
+    voidCurrentSession,
     navigateBack,
     resetDraftState,
   ]);
@@ -1341,7 +1391,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const handleCompleteTransaction = useCallback(async () => {
     if (!activeSession) {
-      toast.error("No active session to complete");
+      toast.error("No sale in progress. Start a sale before taking payment.");
       return false;
     }
 
@@ -1371,7 +1421,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
 
     if (!result.ok) {
-      toast.error(result.message);
+      presentOperatorError(result.message);
       return false;
     }
 
@@ -1393,7 +1443,9 @@ export function useRegisterViewModel(): RegisterViewModel {
           }
         : undefined,
     });
-    toast.success(`Transaction completed: ${result.data.transactionNumber}`);
+    toast.success(
+      `Sale completed. Transaction ${result.data.transactionNumber} recorded.`,
+    );
     return true;
   }, [
     activeCartItems,
@@ -1586,11 +1638,11 @@ export function useRegisterViewModel(): RegisterViewModel {
           onVoidHeldSession: async (sessionId: Id<"posSession">) => {
             const result = await voidSession({ sessionId });
             if (result.kind !== "ok") {
-              toast.error(result.error.message);
+              presentOperatorError(result.error.message);
               return;
             }
 
-            toast.success("Held session voided");
+            toast.success("Held sale cleared.");
           },
           onStartNewSession: handleStartNewSession,
         }
@@ -1625,7 +1677,7 @@ export function useRegisterViewModel(): RegisterViewModel {
             errorMessage:
               drawerErrorMessage ??
               (activeSessionHasMismatchedRegisterBinding
-                ? "This sale is assigned to a different cash drawer."
+                ? "Sale assigned to a different drawer. Open that drawer before continuing."
                 : null),
             isSubmitting: isOpeningDrawer,
             onOpeningFloatChange: (value: string) => {


### PR DESCRIPTION
## Summary
- add a repo-level product copy tone guide and hook both AGENTS surfaces to it
- normalize operator-facing command messages before display and rewrite POS session-flow copy to follow the new tone
- carry the updated voice through the register completion workflow, drawer gate, cashier auth, and session controls

## Validation
- `bun run --filter '@athena/webapp' test -- src/lib/errors/operatorMessages.test.ts src/lib/errors/presentCommandToast.test.ts src/lib/errors/presentUnexpectedErrorToast.test.ts src/components/pos/CashierAuthDialog.test.tsx src/components/pos/register/POSRegisterView.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- repo pre-push suite via `git push -u origin codex/pos-tone-foundation` including harness review, `@athena/webapp` test/build/typecheck coverage, targeted POS validation, and runtime behavior scenarios
