### PR TITLE
fix(pos): stabilize register search and payment workspace

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19055,7 +19055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L307",
+      "source_location": "L309",
       "target": "ordersummary_formatstoredamount",
       "weight": 1
     },
@@ -19067,7 +19067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L188",
+      "source_location": "L190",
       "target": "ordersummary_handlecompletetransaction",
       "weight": 1
     },
@@ -19079,7 +19079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L205",
+      "source_location": "L207",
       "target": "ordersummary_handlestartnewtransaction",
       "weight": 1
     },
@@ -53167,7 +53167,7 @@
       "label": "formatStoredAmount()",
       "norm_label": "formatstoredamount()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L307"
+      "source_location": "L309"
     },
     {
       "community": 218,
@@ -53176,7 +53176,7 @@
       "label": "handleCompleteTransaction()",
       "norm_label": "handlecompletetransaction()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L188"
+      "source_location": "L190"
     },
     {
       "community": 218,
@@ -53185,7 +53185,7 @@
       "label": "handleStartNewTransaction()",
       "norm_label": "handlestartnewtransaction()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L205"
+      "source_location": "L207"
     },
     {
       "community": 218,

--- a/packages/athena-webapp/src/components/pos/CartItems.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.tsx
@@ -79,7 +79,7 @@ export function CartItems({
       )}
       <div
         className={cn(
-          "min-h-0 flex-1 overflow-hidden p-4",
+          "flex min-h-0 flex-1 flex-col overflow-hidden p-4",
           isCompact && "flex-1 pt-0",
         )}
       >
@@ -94,8 +94,8 @@ export function CartItems({
         ) : (
           <div
             className={cn(
-              "min-h-0 space-y-3 overflow-y-auto",
-              isCompact && "h-full pr-1",
+              "min-h-0 flex-1 space-y-3 overflow-y-auto pr-1",
+              isCompact && "h-full",
             )}
           >
             {cartItems.map((item) => (

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -66,6 +66,7 @@ interface OrderSummaryProps {
   onCompleteTransaction?: () => Promise<boolean>;
   onStartNewTransaction?: () => void;
   onPaymentFlowChange?: (isActive: boolean) => void;
+  onPaymentEntryStart?: () => void;
 }
 
 export function OrderSummary({
@@ -89,6 +90,7 @@ export function OrderSummary({
   onCompleteTransaction,
   onStartNewTransaction,
   onPaymentFlowChange,
+  onPaymentEntryStart,
 }: OrderSummaryProps) {
   const { activeStore } = useGetActiveStore();
   const formatter = currencyFormatter(activeStore?.currency || "GHS");
@@ -577,6 +579,7 @@ export function OrderSummary({
             >
               <Button
                 onClick={() => {
+                  onPaymentEntryStart?.();
                   setSelectedPaymentMethod("cash");
                   setIsSelectingPaymentMethod(false);
                 }}
@@ -590,6 +593,7 @@ export function OrderSummary({
               </Button>
               <Button
                 onClick={() => {
+                  onPaymentEntryStart?.();
                   setSelectedPaymentMethod("card");
                   setIsSelectingPaymentMethod(false);
                 }}
@@ -603,6 +607,7 @@ export function OrderSummary({
               </Button>
               <Button
                 onClick={() => {
+                  onPaymentEntryStart?.();
                   setSelectedPaymentMethod("mobile_money");
                   setIsSelectingPaymentMethod(false);
                 }}

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -81,13 +81,16 @@ vi.mock("./RegisterCustomerPanel", () => ({
 vi.mock("./RegisterCheckoutPanel", () => ({
   RegisterCheckoutPanel: ({
     onPaymentFlowChange,
+    onPaymentEntryStart,
   }: {
     onPaymentFlowChange: (active: boolean) => void;
+    onPaymentEntryStart: () => void;
   }) => (
     <div>
       <button onClick={() => onPaymentFlowChange(true)}>
         activate-payment-flow
       </button>
+      <button onClick={onPaymentEntryStart}>start-payment-entry</button>
       <div>register-checkout-panel</div>
     </div>
   ),
@@ -158,6 +161,7 @@ describe("POSRegisterView", () => {
   });
 
   it("returns to product entry when a paid sale starts a new product search", async () => {
+    const setProductSearchQuery = vi.fn();
     const baseViewModel = {
       hasActiveStore: true,
       header: {
@@ -173,7 +177,7 @@ describe("POSRegisterView", () => {
       productEntry: {
         disabled: false,
         productSearchQuery: "",
-        setProductSearchQuery: vi.fn(),
+        setProductSearchQuery,
         onBarcodeSubmit: vi.fn(),
       },
       cart: {
@@ -213,6 +217,14 @@ describe("POSRegisterView", () => {
     await waitFor(() => {
       expect(screen.getByText("product-entry")).toBeInTheDocument();
     });
+
+    await userEvent.click(screen.getByText("activate-payment-flow"));
+
+    expect(setProductSearchQuery).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByText("start-payment-entry"));
+
+    expect(setProductSearchQuery).toHaveBeenCalledWith("");
   });
 
   it("renders the drawer gate instead of the selling surface while drawer setup is pending", async () => {

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -79,7 +79,18 @@ vi.mock("./RegisterCustomerPanel", () => ({
 }));
 
 vi.mock("./RegisterCheckoutPanel", () => ({
-  RegisterCheckoutPanel: () => <div>register-checkout-panel</div>,
+  RegisterCheckoutPanel: ({
+    onPaymentFlowChange,
+  }: {
+    onPaymentFlowChange: (active: boolean) => void;
+  }) => (
+    <div>
+      <button onClick={() => onPaymentFlowChange(true)}>
+        activate-payment-flow
+      </button>
+      <div>register-checkout-panel</div>
+    </div>
+  ),
 }));
 
 describe("POSRegisterView", () => {
@@ -144,6 +155,64 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
     expect(screen.getByText("cashier-auth-dialog")).toBeInTheDocument();
+  });
+
+  it("returns to product entry when a paid sale starts a new product search", async () => {
+    const baseViewModel = {
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        customerName: "Ama Serwa",
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {},
+      cashierCard: {},
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    };
+    mockUseRegisterViewModel.mockReturnValue(baseViewModel);
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    const { rerender } = render(<POSRegisterView />);
+
+    await userEvent.click(screen.getByText("activate-payment-flow"));
+
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
+    expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
+
+    mockUseRegisterViewModel.mockReturnValue({
+      ...baseViewModel,
+      productEntry: {
+        ...baseViewModel.productEntry,
+        productSearchQuery: "water",
+      },
+    });
+
+    rerender(<POSRegisterView />);
+
+    await waitFor(() => {
+      expect(screen.getByText("product-entry")).toBeInTheDocument();
+    });
   });
 
   it("renders the drawer gate instead of the selling surface while drawer setup is pending", async () => {

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -120,9 +120,19 @@ export function POSRegisterView() {
     shouldUseFullscreenRegisterShell ? "h-full min-h-0" : "h-auto",
     shouldUseFullscreenRegisterShell && "overflow-hidden",
   );
+  const hasProductSearchIntent =
+    (viewModel.productEntry?.productSearchQuery ?? "").trim().length > 0;
+  const shouldShowPaymentWorkspace =
+    isPaymentInputActive && !hasProductSearchIntent;
   const canSearchProducts =
     !viewModel.checkout.isTransactionCompleted && !viewModel.drawerGate;
   const shouldShowHeaderProductSearch = isSessionActive && canSearchProducts;
+
+  useEffect(() => {
+    if (hasProductSearchIntent && isPaymentInputActive) {
+      setIsPaymentInputActive(false);
+    }
+  }, [hasProductSearchIntent, isPaymentInputActive]);
 
   if (!viewModel.hasActiveStore) {
     return (
@@ -218,7 +228,7 @@ export function POSRegisterView() {
             <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-[minmax(0,2fr)_minmax(340px,1fr)]">
               {!viewModel.checkout.isTransactionCompleted && (
                 <div className="flex min-h-0 flex-col overflow-hidden pr-1">
-                  {isPaymentInputActive ? (
+                  {shouldShowPaymentWorkspace ? (
                     <CartItems
                       cartItems={viewModel.cart.items}
                       onUpdateQuantity={viewModel.cart.onUpdateQuantity}
@@ -226,7 +236,7 @@ export function POSRegisterView() {
                       clearCart={viewModel.cart.onClearCart}
                       density="comfortable"
                     />
-                  ) : viewModel.productEntry.productSearchQuery ? (
+                  ) : hasProductSearchIntent ? (
                     <div className="min-h-0 flex-1">
                       <ProductEntry
                         disabled={viewModel.productEntry.disabled}
@@ -270,7 +280,7 @@ export function POSRegisterView() {
               >
                 <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
                   {!viewModel.checkout.isTransactionCompleted &&
-                    !isPaymentInputActive && (
+                    !shouldShowPaymentWorkspace && (
                       <CartItems
                         cartItems={viewModel.cart.items}
                         onUpdateQuantity={viewModel.cart.onUpdateQuantity}
@@ -283,7 +293,7 @@ export function POSRegisterView() {
                   <div
                     className={cn(
                       "rounded-lg bg-white p-4",
-                      isPaymentInputActive ||
+                      shouldShowPaymentWorkspace ||
                         viewModel.checkout.isTransactionCompleted
                         ? "flex min-h-0 flex-1 flex-col overflow-hidden"
                         : "shrink-0",

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -10,7 +10,7 @@ import { useSidebar } from "@/components/ui/sidebar";
 import View from "@/components/View";
 import { cn } from "~/src/lib/utils";
 import { ScanBarcode, Search } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useRegisterViewModel } from "@/lib/pos/presentation/register/useRegisterViewModel";
 
@@ -133,6 +133,18 @@ export function POSRegisterView() {
       setIsPaymentInputActive(false);
     }
   }, [hasProductSearchIntent, isPaymentInputActive]);
+
+  const handlePaymentFlowChange = useCallback((isActive: boolean) => {
+    setIsPaymentInputActive(isActive);
+  }, []);
+
+  const handlePaymentEntryStart = useCallback(() => {
+    if (hasProductSearchIntent) {
+      viewModel.productEntry?.setProductSearchQuery?.("");
+    }
+
+    setIsPaymentInputActive(true);
+  }, [hasProductSearchIntent, viewModel.productEntry]);
 
   if (!viewModel.hasActiveStore) {
     return (
@@ -302,7 +314,8 @@ export function POSRegisterView() {
                     <RegisterCheckoutPanel
                       checkout={viewModel.checkout}
                       cashierCard={viewModel.cashierCard}
-                      onPaymentFlowChange={setIsPaymentInputActive}
+                      onPaymentFlowChange={handlePaymentFlowChange}
+                      onPaymentEntryStart={handlePaymentEntryStart}
                     />
                   </div>
                 </div>

--- a/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
@@ -10,12 +10,14 @@ interface RegisterCheckoutPanelProps {
   checkout: RegisterCheckoutState;
   cashierCard: RegisterCashierCardState | null;
   onPaymentFlowChange?: (isActive: boolean) => void;
+  onPaymentEntryStart?: () => void;
 }
 
 export function RegisterCheckoutPanel({
   checkout,
   cashierCard,
   onPaymentFlowChange,
+  onPaymentEntryStart,
 }: RegisterCheckoutPanelProps) {
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col gap-6">
@@ -39,6 +41,7 @@ export function RegisterCheckoutPanel({
         onCompleteTransaction={checkout.onCompleteTransaction}
         onStartNewTransaction={checkout.onStartNewTransaction}
         onPaymentFlowChange={onPaymentFlowChange}
+        onPaymentEntryStart={onPaymentEntryStart}
       />
 
       {!checkout.isTransactionCompleted && cashierCard && (


### PR DESCRIPTION
## Summary

POS register search now reclaims the left workspace from payment entry when a cashier starts adding another product, without clearing that search just because the sale already has payments. Starting a new payment entry deliberately clears product lookup intent so the cart returns to the left side.

The payment-flow cart item list is also contained as its own scroll region so longer carts do not push the payment controls out of place.

## Validation

- `bun run --filter '@athena/webapp' test -- src/components/pos/register/POSRegisterView.test.tsx src/components/pos/OrderSummary.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild`
- `git push` pre-push suite: graphify check, architecture check, harness review, build, runtime behavior scenarios
