### PR TITLE
Handle SKU visibility in product status and not-found scenarios

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1510 files · ~0 words
+- 1512 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3860 nodes · 3410 edges · 1425 communities detected
+- 3865 nodes · 3413 edges · 1427 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1435,6 +1435,8 @@
 - [[_COMMUNITY_Community 1422|Community 1422]]
 - [[_COMMUNITY_Community 1423|Community 1423]]
 - [[_COMMUNITY_Community 1424|Community 1424]]
+- [[_COMMUNITY_Community 1425|Community 1425]]
+- [[_COMMUNITY_Community 1426|Community 1426]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1939,16 +1941,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 119 - "Community 119"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 120 - "Community 120"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 121 - "Community 121"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 122 - "Community 122"
 Cohesion: 0.33
@@ -1963,16 +1965,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 125 - "Community 125"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 126 - "Community 126"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
-
-### Community 127 - "Community 127"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 128 - "Community 128"
 Cohesion: 0.33
@@ -1983,36 +1985,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 131 - "Community 131"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 132 - "Community 132"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 137 - "Community 137"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 138 - "Community 138"
 Cohesion: 0.53
@@ -2227,48 +2229,48 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 191 - "Community 191"
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
+
+### Community 192 - "Community 192"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 196 - "Community 196"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 197 - "Community 197"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 198 - "Community 198"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 199 - "Community 199"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 200 - "Community 200"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 201 - "Community 201"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.5
@@ -2279,16 +2281,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 204 - "Community 204"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 205 - "Community 205"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 206 - "Community 206"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 207 - "Community 207"
 Cohesion: 0.5
@@ -2315,36 +2317,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 213 - "Community 213"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 214 - "Community 214"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 214 - "Community 214"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 215 - "Community 215"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 216 - "Community 216"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 217 - "Community 217"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 217 - "Community 217"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 219 - "Community 219"
-Cohesion: 0.67
-Nodes (2): handleClearSearch(), handleQuickAddSubmit()
-
-### Community 220 - "Community 220"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 220 - "Community 220"
+Cohesion: 0.67
+Nodes (2): handleClearSearch(), handleQuickAddSubmit()
 
 ### Community 221 - "Community 221"
 Cohesion: 0.5
@@ -2367,24 +2369,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 227 - "Community 227"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 227 - "Community 227"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 229 - "Community 229"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 230 - "Community 230"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 230 - "Community 230"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.5
@@ -2395,36 +2397,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 233 - "Community 233"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 234 - "Community 234"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 240 - "Community 240"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 241 - "Community 241"
 Cohesion: 0.5
@@ -2451,8 +2453,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 247 - "Community 247"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 248 - "Community 248"
 Cohesion: 0.67
@@ -2740,79 +2742,79 @@ Nodes (0):
 
 ### Community 319 - "Community 319"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 321 - "Community 321"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 327 - "Community 327"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 328 - "Community 328"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 336 - "Community 336"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 337 - "Community 337"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 338 - "Community 338"
 Cohesion: 0.67
@@ -2840,11 +2842,11 @@ Nodes (0):
 
 ### Community 344 - "Community 344"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.67
@@ -2859,16 +2861,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 349 - "Community 349"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 350 - "Community 350"
 Cohesion: 1.0
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 350 - "Community 350"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 351 - "Community 351"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 352 - "Community 352"
 Cohesion: 0.67
@@ -2876,63 +2878,63 @@ Nodes (0):
 
 ### Community 353 - "Community 353"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 354 - "Community 354"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 355 - "Community 355"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 357 - "Community 357"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 358 - "Community 358"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 360 - "Community 360"
-Cohesion: 0.67
-Nodes (1): manualChunks()
-
 ### Community 361 - "Community 361"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 363 - "Community 363"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 364 - "Community 364"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 365 - "Community 365"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 366 - "Community 366"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 367 - "Community 367"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
@@ -2943,12 +2945,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 370 - "Community 370"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 371 - "Community 371"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 371 - "Community 371"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 372 - "Community 372"
 Cohesion: 0.67
@@ -2959,12 +2961,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 374 - "Community 374"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 375 - "Community 375"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 375 - "Community 375"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.67
@@ -3039,16 +3041,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 394 - "Community 394"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 395 - "Community 395"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 396 - "Community 396"
+### Community 395 - "Community 395"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 396 - "Community 396"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 1.0
@@ -3063,20 +3065,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 401 - "Community 401"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 402 - "Community 402"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 403 - "Community 403"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 404 - "Community 404"
 Cohesion: 1.0
@@ -7162,2050 +7164,2060 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1425 - "Community 1425"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1426 - "Community 1426"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 403`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 404`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 405`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 406`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 407`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 408`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 409`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 410`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 411`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 412`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 413`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 414`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 415`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 416`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 417`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 418`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 419`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 420`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 421`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 422`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 423`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 424`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 425`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 426`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 427`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 428`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 429`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 430`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 431`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 432`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 433`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 434`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 435`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 436`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 437`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 438`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 439`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 440`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 441`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 442`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 443`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 444`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 445`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 446`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 447`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 448`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 449`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 450`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 451`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 452`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 453`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 454`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 455`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 456`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 457`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 458`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 459`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 460`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 461`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 462`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 463`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 464`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 465`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 466`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 467`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 468`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 469`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 470`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 471`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 472`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 473`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 474`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 475`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 476`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 477`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 478`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 479`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 480`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 481`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 482`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 483`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 484`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 485`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 486`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 487`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 488`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 489`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 490`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 491`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 492`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 493`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 494`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 495`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 496`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 497`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 498`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 499`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 500`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 501`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 502`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 503`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 504`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 505`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 506`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 507`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 508`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 509`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 510`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 511`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 512`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 513`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 514`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 515`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 516`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 517`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 518`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 519`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 520`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 521`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 522`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 523`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 524`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 525`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 526`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 527`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 528`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 529`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 530`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 531`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 532`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 533`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 534`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 535`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 536`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 537`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 538`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 539`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 540`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 541`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 542`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 543`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 544`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 545`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 546`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 547`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 548`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 549`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 550`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 551`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 552`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 553`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 554`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 555`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 556`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 557`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 558`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 559`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 560`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 561`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 562`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 563`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 564`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 565`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 566`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 567`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 568`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 569`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 570`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 571`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 572`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 573`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 574`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 575`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 576`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 577`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 578`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 579`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 580`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 581`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 582`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 583`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 584`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 585`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 586`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 587`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 588`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 589`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 590`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 591`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 592`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 593`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 594`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 595`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 596`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 597`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 598`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 599`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 600`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 601`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 602`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 603`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 604`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 605`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 606`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 607`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 608`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 609`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 610`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 611`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 612`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 613`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 614`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 615`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 616`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 617`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 618`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 619`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 620`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 621`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 622`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 623`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 624`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 625`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 626`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 627`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 628`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 629`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 630`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 631`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 632`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 633`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 634`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 635`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 636`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 637`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 638`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 639`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 640`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 641`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 642`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 643`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 644`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 645`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 646`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 647`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 648`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 649`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 650`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 651`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 652`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 653`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 654`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 655`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 656`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 657`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 658`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 659`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 660`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 661`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 662`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 663`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 664`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 665`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 666`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 667`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 668`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 669`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 670`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 671`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 672`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 673`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 674`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 675`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 676`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 677`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 678`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 679`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 680`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 681`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 682`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 683`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 684`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 685`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 686`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 687`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 688`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 689`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 690`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 691`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 692`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 693`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 694`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 695`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 696`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 697`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 698`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 699`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 700`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 701`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 702`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 703`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 704`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 705`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 706`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 707`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 708`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 709`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 710`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 711`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 712`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 713`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 714`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 715`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 716`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 717`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 718`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 719`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 720`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 721`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 722`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 723`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 724`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 725`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 726`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 727`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 728`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 729`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 730`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 731`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 732`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 733`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 734`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 735`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 736`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 737`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 738`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 739`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 740`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 741`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 742`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 743`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 744`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 745`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 746`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 747`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 748`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 749`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 750`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 751`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 752`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `api.d.ts`
+- **Thin community `Community 753`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `api.js`
+- **Thin community `Community 754`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 755`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `server.d.ts`
+- **Thin community `Community 756`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `server.js`
+- **Thin community `Community 757`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `app.ts`
+- **Thin community `Community 758`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `auth.config.js`
+- **Thin community `Community 759`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `auth.ts`
+- **Thin community `Community 760`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 761`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `countries.ts`
+- **Thin community `Community 762`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `email.ts`
+- **Thin community `Community 763`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `ghana.ts`
+- **Thin community `Community 764`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `payment.ts`
+- **Thin community `Community 765`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `crons.ts`
+- **Thin community `Community 766`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 767`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 768`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 769`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 770`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `env.ts`
+- **Thin community `Community 771`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `analytics.ts`
+- **Thin community `Community 772`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `auth.ts`
+- **Thin community `Community 773`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 774`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `colors.ts`
+- **Thin community `Community 775`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `index.ts`
+- **Thin community `Community 776`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `organizations.ts`
+- **Thin community `Community 777`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `products.ts`
+- **Thin community `Community 778`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 779`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `stores.ts`
+- **Thin community `Community 780`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `index.ts`
+- **Thin community `Community 781`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `bag.ts`
+- **Thin community `Community 782`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `guest.ts`
+- **Thin community `Community 783`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `index.ts`
+- **Thin community `Community 784`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `me.ts`
+- **Thin community `Community 785`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `offers.ts`
+- **Thin community `Community 786`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 787`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `paystack.ts`
+- **Thin community `Community 788`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `reviews.ts`
+- **Thin community `Community 789`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `rewards.ts`
+- **Thin community `Community 790`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 791`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `security.test.ts`
+- **Thin community `Community 792`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `storefront.ts`
+- **Thin community `Community 793`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `upsells.ts`
+- **Thin community `Community 794`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `user.ts`
+- **Thin community `Community 795`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 796`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `health.test.ts`
+- **Thin community `Community 797`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `http.ts`
+- **Thin community `Community 798`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 799`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 800`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 801`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `categories.ts`
+- **Thin community `Community 802`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `colors.ts`
+- **Thin community `Community 803`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 804`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 805`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 806`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 807`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `organizations.ts`
+- **Thin community `Community 808`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `pos.ts`
+- **Thin community `Community 809`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 810`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 811`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `productSku.ts`
+- **Thin community `Community 812`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 813`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 814`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 815`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 816`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 817`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 818`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 819`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 820`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 821`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `client.test.ts`
+- **Thin community `Community 822`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `config.test.ts`
+- **Thin community `Community 823`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 824`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `types.ts`
+- **Thin community `Community 825`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 826`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 827`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 828`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 829`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 830`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `dto.ts`
+- **Thin community `Community 831`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 832`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 833`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `openDrawer.test.ts`
+- **Thin community `Community 834`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 835`** (1 nodes): `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 836`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `types.ts`
+- **Thin community `Community 837`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 838`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 839`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `catalog.ts`
+- **Thin community `Community 840`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `customers.ts`
+- **Thin community `Community 841`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `register.ts`
+- **Thin community `Community 842`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `terminals.ts`
+- **Thin community `Community 843`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `transactions.ts`
+- **Thin community `Community 844`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `schema.ts`
+- **Thin community `Community 845`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 846`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 847`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 848`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 849`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `category.ts`
+- **Thin community `Community 850`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `color.ts`
+- **Thin community `Community 851`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 852`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 853`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `index.ts`
+- **Thin community `Community 854`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 855`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `organization.ts`
+- **Thin community `Community 856`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 857`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `product.ts`
+- **Thin community `Community 858`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 859`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 860`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `store.ts`
+- **Thin community `Community 861`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 862`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `index.ts`
+- **Thin community `Community 863`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 864`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 865`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 866`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 867`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 868`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `index.ts`
+- **Thin community `Community 869`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 870`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 871`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 872`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 873`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 874`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 875`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 876`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 877`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 878`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `customer.ts`
+- **Thin community `Community 879`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 880`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 881`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 882`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 883`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `index.ts`
+- **Thin community `Community 884`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `posSession.ts`
+- **Thin community `Community 885`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 886`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 887`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 888`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 889`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `index.ts`
+- **Thin community `Community 890`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 891`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 892`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 893`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 894`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 895`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `index.ts`
+- **Thin community `Community 896`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 897`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 898`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 899`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 900`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `vendor.ts`
+- **Thin community `Community 901`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `analytics.ts`
+- **Thin community `Community 902`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `bag.ts`
+- **Thin community `Community 903`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 904`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 905`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 906`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `customer.ts`
+- **Thin community `Community 907`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `guest.ts`
+- **Thin community `Community 908`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `index.ts`
+- **Thin community `Community 909`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `offer.ts`
+- **Thin community `Community 910`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 911`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 912`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `review.ts`
+- **Thin community `Community 913`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `rewards.ts`
+- **Thin community `Community 914`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 915`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 916`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 917`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 918`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 919`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 920`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 921`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `bag.ts`
+- **Thin community `Community 922`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 923`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `customer.ts`
+- **Thin community `Community 924`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `guest.ts`
+- **Thin community `Community 925`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 926`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 927`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `payment.ts`
+- **Thin community `Community 928`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 929`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 930`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 931`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `users.ts`
+- **Thin community `Community 932`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `payment.ts`
+- **Thin community `Community 933`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 934`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 935`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 936`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 937`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `index.ts`
+- **Thin community `Community 938`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 939`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `auth.ts`
+- **Thin community `Community 940`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 941`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 942`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 943`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 944`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 945`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 946`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 947`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 948`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `constants.ts`
+- **Thin community `Community 949`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 950`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 951`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 952`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `types.ts`
+- **Thin community `Community 953`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 954`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 955`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 956`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 957`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 958`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 959`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 960`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 961`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `columns.tsx`
+- **Thin community `Community 962`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 963`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 964`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 965`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `columns.tsx`
+- **Thin community `Community 967`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 968`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 969`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `chart.tsx`
+- **Thin community `Community 970`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `columns.tsx`
+- **Thin community `Community 971`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 972`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 973`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `columns.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `constants.ts`
+- **Thin community `Community 975`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 976`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data.ts`
+- **Thin community `Community 979`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `columns.tsx`
+- **Thin community `Community 980`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 981`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 982`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `columns.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 984`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 985`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 986`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 987`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 988`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 989`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 990`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `constants.ts`
+- **Thin community `Community 991`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 992`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 994`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `data.ts`
+- **Thin community `Community 995`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 996`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 997`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 998`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 999`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1000`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1001`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1002`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1003`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1004`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1005`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1006`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1007`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `constants.ts`
+- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1009`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1011`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1012`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1013`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1014`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1015`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1016`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1017`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1018`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1019`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1020`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1021`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1022`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1023`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1024`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1025`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1026`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1027`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1028`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1029`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1030`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1031`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `constants.ts`
+- **Thin community `Community 1032`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1033`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1034`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1035`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data.ts`
+- **Thin community `Community 1036`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1037`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `constants.ts`
+- **Thin community `Community 1038`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1039`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1040`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1041`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1042`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `data.ts`
+- **Thin community `Community 1043`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1044`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `constants.ts`
+- **Thin community `Community 1045`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1046`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1047`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1048`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1049`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `data.ts`
+- **Thin community `Community 1050`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1051`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1052`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1053`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1054`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `OrderSummary.test.tsx`
+- **Thin community `Community 1055`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1056`** (1 nodes): `OrderSummary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1057`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1058`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1059`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1060`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1061`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1062`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1063`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1064`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1065`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1066`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1067`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1068`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1069`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1070`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1071`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1072`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `types.ts`
+- **Thin community `Community 1073`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1074`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1075`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1076`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1077`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1078`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1079`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1080`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1081`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1082`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1083`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1084`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1085`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1086`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1087`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1089`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1090`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1091`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `data.ts`
+- **Thin community `Community 1092`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1093`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1094`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1095`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1096`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1097`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1098`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1099`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1100`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1101`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1102`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1103`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1104`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1105`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `constants.ts`
+- **Thin community `Community 1106`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1107`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1108`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1109`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `data.ts`
+- **Thin community `Community 1110`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `types.ts`
+- **Thin community `Community 1111`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1112`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1113`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1114`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1115`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `index.tsx`
+- **Thin community `Community 1116`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1117`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1118`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1119`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1120`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `index.tsx`
+- **Thin community `Community 1121`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1122`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1123`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1124`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `button.tsx`
+- **Thin community `Community 1125`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1126`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `card.tsx`
+- **Thin community `Community 1127`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1128`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1129`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `command.tsx`
+- **Thin community `Community 1130`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1131`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1132`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1133`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `form.tsx`
+- **Thin community `Community 1134`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1135`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1136`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `input.tsx`
+- **Thin community `Community 1137`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1138`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1139`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1140`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1141`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1142`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `select.tsx`
+- **Thin community `Community 1143`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1144`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1145`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1146`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `table.tsx`
+- **Thin community `Community 1147`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1148`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1149`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1150`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1151`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1152`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1153`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1154`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1155`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `constants.ts`
+- **Thin community `Community 1156`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1157`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1158`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1159`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `data.ts`
+- **Thin community `Community 1160`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1161`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1162`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1163`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1164`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1165`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1166`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1167`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1168`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1169`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1170`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1171`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1172`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1173`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `index.ts`
+- **Thin community `Community 1174`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `config.ts`
+- **Thin community `Community 1175`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1176`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1177`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1178`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1179`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1180`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `aws.ts`
+- **Thin community `Community 1181`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `constants.ts`
+- **Thin community `Community 1182`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `countries.ts`
+- **Thin community `Community 1183`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1185`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1188`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1189`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1190`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `dto.ts`
+- **Thin community `Community 1191`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `ports.ts`
+- **Thin community `Community 1192`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `constants.ts`
+- **Thin community `Community 1193`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `index.ts`
+- **Thin community `Community 1196`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1197`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `types.ts`
+- **Thin community `Community 1198`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1199`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1201`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1202`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1204`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `category.ts`
+- **Thin community `Community 1205`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `product.ts`
+- **Thin community `Community 1206`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `store.ts`
+- **Thin community `Community 1207`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1208`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `user.ts`
+- **Thin community `Community 1209`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1212`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1213`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1214`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `index.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `index.tsx`
+- **Thin community `Community 1215`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1216`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1217`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1218`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1219`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1220`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1221`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `index.tsx`
+- **Thin community `Community 1222`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1223`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1224`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1225`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `home.tsx`
+- **Thin community `Community 1226`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1227`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1228`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1229`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `index.tsx`
+- **Thin community `Community 1230`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `index.tsx`
+- **Thin community `Community 1231`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1233`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1234`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `index.tsx`
+- **Thin community `Community 1235`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1236`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1237`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1238`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1239`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1240`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1241`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1242`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `index.tsx`
+- **Thin community `Community 1243`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1244`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1245`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1246`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1247`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1248`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1249`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `index.tsx`
+- **Thin community `Community 1250`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `index.tsx`
+- **Thin community `Community 1251`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `new.tsx`
+- **Thin community `Community 1252`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1253`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1254`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1255`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1256`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `index.tsx`
+- **Thin community `Community 1257`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `new.tsx`
+- **Thin community `Community 1258`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1259`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1260`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1261`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1262`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1263`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1264`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1265`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1266`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `index.tsx`
+- **Thin community `Community 1267`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1268`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1269`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1272`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1273`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1274`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1275`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1276`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1278`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1279`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1281`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1282`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1283`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1284`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `setup.ts`
+- **Thin community `Community 1286`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1288`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `types.ts`
+- **Thin community `Community 1289`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1290`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1291`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1292`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1293`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `types.ts`
+- **Thin community `Community 1295`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1296`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1297`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1298`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1299`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1300`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1301`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1302`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1303`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1304`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `schema.ts`
+- **Thin community `Community 1305`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1306`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1307`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1310`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1311`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1312`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1313`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1314`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `types.ts`
+- **Thin community `Community 1315`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1317`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1319`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1320`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1322`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `constants.ts`
+- **Thin community `Community 1323`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1324`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `About.tsx`
+- **Thin community `Community 1325`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1326`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `MobileProductActions.test.tsx`
+- **Thin community `Community 1327`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1328`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1329`** (1 nodes): `MobileProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1330`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1331`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1332`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1333`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1334`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1335`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `types.ts`
+- **Thin community `Community 1336`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1337`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1338`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1339`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1341`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1342`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1343`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1344`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1345`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1346`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `button.tsx`
+- **Thin community `Community 1347`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `card.tsx`
+- **Thin community `Community 1348`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1349`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `command.tsx`
+- **Thin community `Community 1350`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1351`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1352`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1353`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `form.tsx`
+- **Thin community `Community 1354`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1355`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1356`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1357`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1358`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `input.tsx`
+- **Thin community `Community 1359`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `label.tsx`
+- **Thin community `Community 1360`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1361`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1362`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1363`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `index.ts`
+- **Thin community `Community 1364`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `types.ts`
+- **Thin community `Community 1365`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1366`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1367`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1368`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1369`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `select.tsx`
+- **Thin community `Community 1370`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1371`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1372`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `table.tsx`
+- **Thin community `Community 1373`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1374`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1375`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1376`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1377`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1378`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `config.ts`
+- **Thin community `Community 1379`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1380`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1381`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1382`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `constants.ts`
+- **Thin community `Community 1383`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `countries.ts`
+- **Thin community `Community 1384`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1385`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1386`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1387`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1388`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `index.ts`
+- **Thin community `Community 1389`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `store.ts`
+- **Thin community `Community 1390`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `bag.ts`
+- **Thin community `Community 1391`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1392`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `category.ts`
+- **Thin community `Community 1393`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `organization.ts`
+- **Thin community `Community 1394`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `product.ts`
+- **Thin community `Community 1395`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `store.ts`
+- **Thin community `Community 1396`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1397`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `user.ts`
+- **Thin community `Community 1398`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `states.ts`
+- **Thin community `Community 1399`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1400`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1401`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1402`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1403`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1404`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1405`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1406`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `index.tsx`
+- **Thin community `Community 1407`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1408`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1409`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1410`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1411`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1412`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1413`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1414`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `index.tsx`
+- **Thin community `Community 1415`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1416`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1417`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1418`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1419`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `index.js`
+- **Thin community `Community 1420`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1421`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1422`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1423`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1424`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1425`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1426`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19672,6 +19672,30 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
+      "_tgt": "productstatus_test_makeproduct",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L8",
+      "target": "productstatus_test_makeproduct",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
+      "_tgt": "productstatus_test_makevariant",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L18",
+      "target": "productstatus_test_makevariant",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "_tgt": "productstatus_productstatus",
       "confidence": "EXTRACTED",
@@ -28573,6 +28597,18 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "target": "productdetails_shippingpolicy",
+      "weight": 1
+    },
+    {
+      "_src": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
+      "_tgt": "productpage_test_makepagestate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
+      "source_location": "L37",
+      "target": "productpage_test_makepagestate",
       "weight": 1
     },
     {
@@ -42018,6 +42054,24 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
+      "label": "LoginForm.test.tsx",
+      "norm_label": "loginform.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
+      "label": "LoginForm.tsx",
+      "norm_label": "loginform.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -42025,7 +42079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -42034,7 +42088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42043,7 +42097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42052,7 +42106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42061,7 +42115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42070,7 +42124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -42079,30 +42133,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -42171,6 +42207,24 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -42178,7 +42232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -42187,7 +42241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -42196,7 +42250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -42205,7 +42259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -42214,7 +42268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -42223,7 +42277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -42232,30 +42286,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
       "norm_label": "registersessionview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -42324,6 +42360,24 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -42331,7 +42385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -42340,7 +42394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -42349,7 +42403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -42358,7 +42412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -42367,7 +42421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -42376,7 +42430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -42385,30 +42439,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
       "norm_label": "orderstatus.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1"
     },
     {
@@ -42477,6 +42513,24 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
       "norm_label": "returnexchangeview.test.tsx",
@@ -42484,7 +42538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -42493,7 +42547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42502,7 +42556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42511,7 +42565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42520,7 +42574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -42529,7 +42583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -42538,30 +42592,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -42630,6 +42666,24 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -42637,7 +42691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42646,7 +42700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -42655,7 +42709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -42664,7 +42718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -42673,7 +42727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42682,7 +42736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42691,30 +42745,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -42774,6 +42810,24 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
       "norm_label": "memberscolumns.tsx",
@@ -42781,7 +42835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -42790,7 +42844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -42799,7 +42853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -42808,7 +42862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -42817,7 +42871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -42826,7 +42880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -42835,30 +42889,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
       "norm_label": "registeractions.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "label": "SearchResultsSection.tsx",
-      "norm_label": "searchresultssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
-      "label": "SessionManager.test.tsx",
-      "norm_label": "sessionmanager.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
       "source_location": "L1"
     },
     {
@@ -42918,6 +42954,24 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
+      "label": "SearchResultsSection.tsx",
+      "norm_label": "searchresultssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
+      "label": "SessionManager.test.tsx",
+      "norm_label": "sessionmanager.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
       "norm_label": "sessionmanager.tsx",
@@ -42925,7 +42979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -42934,7 +42988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -42943,7 +42997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -42952,7 +43006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -42961,7 +43015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -42970,7 +43024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -42979,30 +43033,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
       "norm_label": "registercheckoutpanel.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
-      "label": "HeldSessionsList.test.tsx",
-      "norm_label": "heldsessionslist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
-      "label": "TransactionView.test.tsx",
-      "norm_label": "transactionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43062,6 +43098,24 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
+      "label": "HeldSessionsList.test.tsx",
+      "norm_label": "heldsessionslist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
+      "label": "TransactionView.test.tsx",
+      "norm_label": "transactionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
       "norm_label": "transactionview.tsx",
@@ -43069,7 +43123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -43078,7 +43132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -43087,7 +43141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -43096,7 +43150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -43105,7 +43159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -43114,7 +43168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -43123,30 +43177,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
       "norm_label": "detailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "label": "CategoryListView.tsx",
-      "norm_label": "categorylistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1"
     },
     {
@@ -43206,6 +43242,24 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
+      "label": "CategoryListView.tsx",
+      "norm_label": "categorylistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
       "norm_label": "productsubcategorytogglegroup.tsx",
@@ -43213,7 +43267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -43222,7 +43276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -43231,7 +43285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -43240,7 +43294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -43249,7 +43303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -43258,7 +43312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -43267,30 +43321,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -43350,6 +43386,24 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -43357,7 +43411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -43366,7 +43420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -43375,7 +43429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -43384,7 +43438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -43393,7 +43447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -43402,7 +43456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -43411,30 +43465,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
       "norm_label": "promocodemoney.test.ts",
       "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -43674,6 +43710,24 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -43681,7 +43735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43690,7 +43744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -43699,7 +43753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43708,7 +43762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -43717,7 +43771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -43726,7 +43780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43735,30 +43789,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
       "source_location": "L1"
     },
     {
@@ -43818,6 +43854,24 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -43825,7 +43879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -43834,7 +43888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -43843,7 +43897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -43852,7 +43906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -43861,7 +43915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -43870,7 +43924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -43879,30 +43933,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
       "norm_label": "maintenanceview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
-      "label": "MtnMomoView.test.tsx",
-      "norm_label": "mtnmomoview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
-      "label": "useStoreConfigUpdate.test.tsx",
-      "norm_label": "usestoreconfigupdate.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43962,6 +43998,24 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
+      "label": "MtnMomoView.test.tsx",
+      "norm_label": "mtnmomoview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
+      "label": "useStoreConfigUpdate.test.tsx",
+      "norm_label": "usestoreconfigupdate.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -43969,7 +44023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -43978,7 +44032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -43987,7 +44041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -43996,7 +44050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -44005,7 +44059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -44014,7 +44068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -44023,30 +44077,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
-      "label": "collapsible.tsx",
-      "norm_label": "collapsible.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
       "source_location": "L1"
     },
     {
@@ -44106,6 +44142,24 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
+      "label": "collapsible.tsx",
+      "norm_label": "collapsible.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
@@ -44113,7 +44167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -44122,7 +44176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -44131,7 +44185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -44140,7 +44194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -44149,7 +44203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -44158,7 +44212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -44167,30 +44221,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
-      "label": "primitives.test.tsx",
-      "norm_label": "primitives.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
       "source_location": "L1"
     },
     {
@@ -44250,6 +44286,24 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
+      "label": "primitives.test.tsx",
+      "norm_label": "primitives.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
@@ -44257,7 +44311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -44266,7 +44320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -44275,7 +44329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -44284,7 +44338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -44293,7 +44347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -44302,7 +44356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -44311,30 +44365,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1"
     },
     {
@@ -44394,6 +44430,24 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1152,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
@@ -44401,7 +44455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -44410,7 +44464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -44419,7 +44473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -44428,7 +44482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -44437,7 +44491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -44446,7 +44500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44455,30 +44509,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1"
     },
     {
@@ -44538,6 +44574,24 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1162,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
       "norm_label": "bag-columns.tsx",
@@ -44545,7 +44599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -44554,7 +44608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -44563,7 +44617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -44572,7 +44626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44581,7 +44635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44590,7 +44644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44599,30 +44653,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "label": "LinkedAccounts.tsx",
-      "norm_label": "linkedaccounts.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "label": "TimelineEventCard.test.tsx",
-      "norm_label": "timelineeventcard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1"
     },
     {
@@ -44682,6 +44718,24 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
+      "label": "LinkedAccounts.tsx",
+      "norm_label": "linkedaccounts.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
+      "label": "TimelineEventCard.test.tsx",
+      "norm_label": "timelineeventcard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1172,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
       "norm_label": "usercheckoutsession.tsx",
@@ -44689,7 +44743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -44698,7 +44752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -44707,7 +44761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -44716,7 +44770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -44725,7 +44779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -44734,7 +44788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -44743,30 +44797,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
       "norm_label": "useauth.test.tsx",
       "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
-      "label": "useExpenseSessions.test.ts",
-      "norm_label": "useexpensesessions.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1"
     },
     {
@@ -44826,6 +44862,24 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
+      "label": "useExpenseSessions.test.ts",
+      "norm_label": "useexpensesessions.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
@@ -44833,7 +44887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -44842,7 +44896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -44851,7 +44905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -44860,7 +44914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -44869,7 +44923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -44878,7 +44932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -44887,7 +44941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -44896,7 +44950,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 119,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1190,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -44905,7 +45013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -44914,61 +45022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 1190,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -44977,7 +45031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -44986,7 +45040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -44995,7 +45049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -45004,7 +45058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -45013,7 +45067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -45022,7 +45076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -45031,30 +45085,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
-      "label": "sessionGateway.test.ts",
-      "norm_label": "sessiongateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
       "source_location": "L1"
     },
     {
@@ -45240,59 +45276,77 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
+      "label": "sessionGateway.test.ts",
+      "norm_label": "sessiongateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -45301,7 +45355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -45310,7 +45364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -45319,7 +45373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -45328,7 +45382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -45337,7 +45391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -45346,7 +45400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -45355,7 +45409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -45364,7 +45418,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 1210,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -45373,7 +45481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -45382,61 +45490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 1210,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -45445,7 +45499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -45454,7 +45508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -45463,7 +45517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -45472,7 +45526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -45481,7 +45535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -45490,7 +45544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -45499,7 +45553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -45508,7 +45562,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 1220,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -45517,7 +45625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -45526,61 +45634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 1220,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -45589,7 +45643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -45598,7 +45652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -45607,7 +45661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -45616,7 +45670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -45625,7 +45679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -45634,7 +45688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -45643,7 +45697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -45652,7 +45706,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 1230,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -45661,7 +45769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1229,
+      "community": 1231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -45670,61 +45778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1230,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -45733,7 +45787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -45742,7 +45796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -45751,7 +45805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -45760,7 +45814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -45769,7 +45823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -45778,7 +45832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -45787,7 +45841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -45796,7 +45850,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 124,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1240,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -45805,7 +45913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1239,
+      "community": 1241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -45814,61 +45922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 1240,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -45877,7 +45931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -45886,7 +45940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -45895,7 +45949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -45904,7 +45958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -45913,7 +45967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -45922,7 +45976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -45931,7 +45985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -45940,7 +45994,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 1250,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -45949,7 +46057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1249,
+      "community": 1251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -45958,61 +46066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 1250,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -46021,7 +46075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -46030,7 +46084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -46039,7 +46093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -46048,7 +46102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -46057,7 +46111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -46066,7 +46120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -46075,7 +46129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -46084,7 +46138,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 1260,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -46093,7 +46201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -46102,61 +46210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
-      "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1260,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -46165,7 +46219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -46174,7 +46228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -46183,7 +46237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -46192,7 +46246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -46201,7 +46255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -46210,7 +46264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -46219,7 +46273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -46228,7 +46282,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 127,
+      "file_type": "code",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1270,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -46237,7 +46345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 1271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -46246,61 +46354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 1270,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -46309,7 +46363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -46318,7 +46372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -46327,7 +46381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -46336,7 +46390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -46345,7 +46399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -46354,7 +46408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -46363,7 +46417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -46372,7 +46426,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 1280,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -46381,7 +46489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1279,
+      "community": 1281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -46390,61 +46498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 1280,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -46453,7 +46507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -46462,7 +46516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -46471,7 +46525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -46480,7 +46534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -46489,7 +46543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -46498,7 +46552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -46507,7 +46561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -46516,7 +46570,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 1290,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -46525,7 +46633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1289,
+      "community": 1291,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -46534,61 +46642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 1290,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -46597,7 +46651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -46606,7 +46660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -46615,7 +46669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -46624,7 +46678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -46633,7 +46687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -46642,7 +46696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -46651,30 +46705,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
       "norm_label": "defaultcatchboundary.tsx",
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
       "source_location": "L1"
     },
     {
@@ -46851,59 +46887,77 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
     },
     {
+      "community": 130,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
+    },
+    {
       "community": 1300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -46912,7 +46966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -46921,7 +46975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -46930,7 +46984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -46939,7 +46993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -46948,7 +47002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -46957,7 +47011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -46966,7 +47020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -46975,7 +47029,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 131,
+      "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1310,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -46984,7 +47092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1309,
+      "community": 1311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -46993,61 +47101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 1310,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -47056,7 +47110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -47065,7 +47119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -47074,7 +47128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -47083,7 +47137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -47092,7 +47146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -47101,7 +47155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -47110,7 +47164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -47119,7 +47173,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 1320,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -47128,7 +47236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1319,
+      "community": 1321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -47137,61 +47245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 1320,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -47200,7 +47254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -47209,7 +47263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -47218,7 +47272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -47227,7 +47281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -47236,7 +47290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -47245,7 +47299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -47254,7 +47308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_test_tsx",
       "label": "MobileProductActions.test.tsx",
@@ -47263,7 +47317,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 1330,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -47272,7 +47380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1329,
+      "community": 1331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -47281,61 +47389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 1330,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -47344,7 +47398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -47353,7 +47407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -47362,7 +47416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -47371,7 +47425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -47380,7 +47434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -47389,7 +47443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -47398,7 +47452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -47407,7 +47461,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1340,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -47416,7 +47524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1339,
+      "community": 1341,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -47425,61 +47533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1340,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -47488,7 +47542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -47497,7 +47551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -47506,7 +47560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -47515,7 +47569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -47524,7 +47578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -47533,7 +47587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -47542,7 +47596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -47551,7 +47605,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 135,
+      "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1350,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -47560,7 +47668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1349,
+      "community": 1351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -47569,61 +47677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
-      "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L124"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L142"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1350,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -47632,7 +47686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -47641,7 +47695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -47650,7 +47704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -47659,7 +47713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -47668,7 +47722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -47677,7 +47731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -47686,7 +47740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -47695,7 +47749,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 136,
+      "file_type": "code",
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L124"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L142"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1360,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -47704,7 +47812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1359,
+      "community": 1361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -47713,61 +47821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1360,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -47776,7 +47830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -47785,7 +47839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -47794,7 +47848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -47803,7 +47857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -47812,7 +47866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -47821,7 +47875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -47830,7 +47884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -47839,7 +47893,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 137,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1370,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -47848,7 +47956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1369,
+      "community": 1371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -47857,61 +47965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1370,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -47920,7 +47974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -47929,7 +47983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -47938,7 +47992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -47947,7 +48001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -47956,7 +48010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -47965,7 +48019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -47974,30 +48028,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1378,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1"
     },
     {
@@ -48057,6 +48093,24 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1382,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
@@ -48064,7 +48118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -48073,7 +48127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -48082,7 +48136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -48091,7 +48145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -48100,7 +48154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -48109,7 +48163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -48118,30 +48172,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
       "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1388,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "label": "maintenanceUtils.test.ts",
-      "norm_label": "maintenanceutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
       "source_location": "L1"
     },
     {
@@ -48201,6 +48237,24 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
+      "label": "maintenanceUtils.test.ts",
+      "norm_label": "maintenanceutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1392,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -48208,7 +48262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -48217,7 +48271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -48226,7 +48280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -48235,7 +48289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -48244,7 +48298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -48253,7 +48307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -48262,30 +48316,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1398,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_states_ts",
-      "label": "states.ts",
-      "norm_label": "states.ts",
-      "source_file": "packages/storefront-webapp/src/lib/states.ts",
       "source_location": "L1"
     },
     {
@@ -48516,6 +48552,24 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_states_ts",
+      "label": "states.ts",
+      "norm_label": "states.ts",
+      "source_file": "packages/storefront-webapp/src/lib/states.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1402,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
       "norm_label": "storefrontfailureobservability.test.ts",
@@ -48523,7 +48577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -48532,7 +48586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -48541,7 +48595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -48550,7 +48604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -48559,7 +48613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -48568,7 +48622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -48577,30 +48631,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1408,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "label": "$subcategorySlug.tsx",
-      "norm_label": "$subcategoryslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -48660,6 +48696,24 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
+      "label": "$subcategorySlug.tsx",
+      "norm_label": "$subcategoryslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1412,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
       "norm_label": "rewards.index.tsx",
@@ -48667,7 +48721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -48676,7 +48730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -48685,7 +48739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -48694,7 +48748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -48703,7 +48757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -48712,7 +48766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -48721,30 +48775,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
       "norm_label": "tailwind.config.js",
       "source_file": "packages/storefront-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1418,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/storefront-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/storefront-webapp/vitest.setup.ts",
       "source_location": "L1"
     },
     {
@@ -48795,6 +48831,24 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/storefront-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1422,
+      "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
       "norm_label": "index.js",
@@ -48802,7 +48856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1423,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -48811,7 +48865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1424,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -48820,7 +48874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1425,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -48829,7 +48883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1426,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -51720,6 +51774,42 @@
     {
       "community": 191,
       "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -51727,7 +51817,7 @@
       "source_location": "L26"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -51736,7 +51826,7 @@
       "source_location": "L79"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -51745,7 +51835,7 @@
       "source_location": "L33"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -51754,7 +51844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -51763,7 +51853,7 @@
       "source_location": "L10"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -51772,7 +51862,7 @@
       "source_location": "L18"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -51781,7 +51871,7 @@
       "source_location": "L52"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -51790,7 +51880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -51799,7 +51889,7 @@
       "source_location": "L28"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -51808,7 +51898,7 @@
       "source_location": "L42"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -51817,7 +51907,7 @@
       "source_location": "L73"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -51826,7 +51916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -51835,7 +51925,7 @@
       "source_location": "L8"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -51844,7 +51934,7 @@
       "source_location": "L32"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -51853,7 +51943,7 @@
       "source_location": "L64"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -51862,7 +51952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -51871,7 +51961,7 @@
       "source_location": "L18"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -51880,7 +51970,7 @@
       "source_location": "L25"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -51889,7 +51979,7 @@
       "source_location": "L11"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -51898,7 +51988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -51907,7 +51997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -51916,7 +52006,7 @@
       "source_location": "L33"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -51925,7 +52015,7 @@
       "source_location": "L19"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -51934,7 +52024,7 @@
       "source_location": "L42"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -51943,7 +52033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -51952,7 +52042,7 @@
       "source_location": "L31"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -51961,7 +52051,7 @@
       "source_location": "L48"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -51970,7 +52060,7 @@
       "source_location": "L131"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -51979,7 +52069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -51988,7 +52078,7 @@
       "source_location": "L37"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -51997,49 +52087,13 @@
       "source_location": "L24"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
       "source_location": "L19"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
-      "label": "register.ts",
-      "norm_label": "register.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "register_mapopendrawerusererror",
-      "label": "mapOpenDrawerUserError()",
-      "norm_label": "mapopendrawerusererror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "register_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "register_opendrawer",
-      "label": "openDrawer()",
-      "norm_label": "opendrawer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L51"
     },
     {
       "community": 2,
@@ -52494,6 +52548,42 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
+      "label": "register.ts",
+      "norm_label": "register.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "register_mapopendrawerusererror",
+      "label": "mapOpenDrawerUserError()",
+      "norm_label": "mapopendrawerusererror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "register_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "register_opendrawer",
+      "label": "openDrawer()",
+      "norm_label": "opendrawer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
       "norm_label": "searchcatalog.ts",
@@ -52501,7 +52591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -52510,7 +52600,7 @@
       "source_location": "L122"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -52519,7 +52609,7 @@
       "source_location": "L34"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -52528,7 +52618,7 @@
       "source_location": "L72"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -52537,7 +52627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -52546,7 +52636,7 @@
       "source_location": "L162"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -52555,7 +52645,7 @@
       "source_location": "L56"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
@@ -52564,7 +52654,7 @@
       "source_location": "L180"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -52573,7 +52663,7 @@
       "source_location": "L31"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -52582,7 +52672,7 @@
       "source_location": "L176"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -52591,7 +52681,7 @@
       "source_location": "L27"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -52600,7 +52690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -52609,7 +52699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -52618,7 +52708,7 @@
       "source_location": "L23"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -52627,7 +52717,7 @@
       "source_location": "L9"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -52636,7 +52726,7 @@
       "source_location": "L13"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -52645,7 +52735,7 @@
       "source_location": "L19"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -52654,7 +52744,7 @@
       "source_location": "L26"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -52663,7 +52753,7 @@
       "source_location": "L12"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -52672,7 +52762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -52681,7 +52771,7 @@
       "source_location": "L21"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -52690,7 +52780,7 @@
       "source_location": "L63"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -52699,7 +52789,7 @@
       "source_location": "L71"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -52708,7 +52798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -52717,7 +52807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -52726,7 +52816,7 @@
       "source_location": "L13"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -52735,7 +52825,7 @@
       "source_location": "L31"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -52744,7 +52834,7 @@
       "source_location": "L9"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -52753,7 +52843,7 @@
       "source_location": "L51"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -52762,7 +52852,7 @@
       "source_location": "L37"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -52771,7 +52861,7 @@
       "source_location": "L44"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -52780,7 +52870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -52789,7 +52879,7 @@
       "source_location": "L227"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -52798,7 +52888,7 @@
       "source_location": "L46"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -52807,48 +52897,12 @@
       "source_location": "L27"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
       "norm_label": "attributesmanager.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "attributestable_getproductattribute",
-      "label": "getProductAttribute()",
-      "norm_label": "getproductattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "attributestable_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "attributestable_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L211"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "label": "AttributesTable.tsx",
-      "norm_label": "attributestable.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1"
     },
     {
@@ -53007,6 +53061,42 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "attributestable_getproductattribute",
+      "label": "getProductAttribute()",
+      "norm_label": "getproductattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "attributestable_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "attributestable_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L211"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
+      "label": "AttributesTable.tsx",
+      "norm_label": "attributestable.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
       "norm_label": "categorymanager()",
@@ -53014,7 +53104,7 @@
       "source_location": "L52"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -53023,7 +53113,7 @@
       "source_location": "L27"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -53032,7 +53122,7 @@
       "source_location": "L288"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -53041,7 +53131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -53050,7 +53140,7 @@
       "source_location": "L48"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -53059,7 +53149,7 @@
       "source_location": "L88"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -53068,7 +53158,7 @@
       "source_location": "L14"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -53077,7 +53167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -53086,7 +53176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -53095,7 +53185,7 @@
       "source_location": "L15"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -53104,7 +53194,7 @@
       "source_location": "L28"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -53113,7 +53203,7 @@
       "source_location": "L19"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -53122,7 +53212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -53131,7 +53221,7 @@
       "source_location": "L52"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -53140,7 +53230,7 @@
       "source_location": "L3"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -53149,7 +53239,7 @@
       "source_location": "L90"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -53158,7 +53248,7 @@
       "source_location": "L86"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -53167,7 +53257,7 @@
       "source_location": "L76"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -53176,7 +53266,7 @@
       "source_location": "L52"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -53185,7 +53275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -53194,7 +53284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -53203,7 +53293,7 @@
       "source_location": "L67"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -53212,7 +53302,7 @@
       "source_location": "L90"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -53221,7 +53311,7 @@
       "source_location": "L73"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -53230,7 +53320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -53239,7 +53329,7 @@
       "source_location": "L105"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -53248,7 +53338,7 @@
       "source_location": "L97"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -53257,7 +53347,7 @@
       "source_location": "L83"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -53266,7 +53356,7 @@
       "source_location": "L91"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -53275,7 +53365,7 @@
       "source_location": "L68"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -53284,7 +53374,7 @@
       "source_location": "L22"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -53293,7 +53383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "ordersummary_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -53302,7 +53392,7 @@
       "source_location": "L309"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -53311,7 +53401,7 @@
       "source_location": "L190"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -53320,49 +53410,13 @@
       "source_location": "L207"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "label": "ProductEntry.tsx",
-      "norm_label": "productentry.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "productentry_handleclearsearch",
-      "label": "handleClearSearch()",
-      "norm_label": "handleclearsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "productentry_handleopenquickadd",
-      "label": "handleOpenQuickAdd()",
-      "norm_label": "handleopenquickadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L184"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "productentry_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L198"
     },
     {
       "community": 22,
@@ -53520,6 +53574,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "label": "ProductEntry.tsx",
+      "norm_label": "productentry.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "productentry_handleclearsearch",
+      "label": "handleClearSearch()",
+      "norm_label": "handleclearsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "productentry_handleopenquickadd",
+      "label": "handleOpenQuickAdd()",
+      "norm_label": "handleopenquickadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L184"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "productentry_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
       "norm_label": "posregisterview.tsx",
@@ -53527,7 +53617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "posregisterview_productlookupemptystate",
       "label": "ProductLookupEmptyState()",
@@ -53536,7 +53626,7 @@
       "source_location": "L81"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "posregisterview_usecollapsesidebarforposflow",
       "label": "useCollapseSidebarForPosFlow()",
@@ -53545,7 +53635,7 @@
       "source_location": "L22"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "posregisterview_uselockdocumentscroll",
       "label": "useLockDocumentScroll()",
@@ -53554,7 +53644,7 @@
       "source_location": "L54"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -53563,7 +53653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -53572,7 +53662,7 @@
       "source_location": "L312"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -53581,7 +53671,7 @@
       "source_location": "L364"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -53590,7 +53680,7 @@
       "source_location": "L219"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -53599,7 +53689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -53608,7 +53698,7 @@
       "source_location": "L78"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -53617,7 +53707,7 @@
       "source_location": "L118"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -53626,7 +53716,7 @@
       "source_location": "L89"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -53635,7 +53725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -53644,7 +53734,7 @@
       "source_location": "L63"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -53653,7 +53743,7 @@
       "source_location": "L54"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -53662,7 +53752,7 @@
       "source_location": "L11"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -53671,7 +53761,7 @@
       "source_location": "L16"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -53680,7 +53770,7 @@
       "source_location": "L35"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -53689,7 +53779,7 @@
       "source_location": "L6"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -53698,7 +53788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -53707,7 +53797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -53716,7 +53806,7 @@
       "source_location": "L5"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -53725,7 +53815,7 @@
       "source_location": "L30"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -53734,7 +53824,7 @@
       "source_location": "L21"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -53743,7 +53833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -53752,7 +53842,7 @@
       "source_location": "L178"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -53761,7 +53851,7 @@
       "source_location": "L205"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -53770,7 +53860,7 @@
       "source_location": "L806"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -53779,7 +53869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -53788,7 +53878,7 @@
       "source_location": "L41"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -53797,7 +53887,7 @@
       "source_location": "L45"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -53806,7 +53896,7 @@
       "source_location": "L65"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -53815,7 +53905,7 @@
       "source_location": "L75"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -53824,7 +53914,7 @@
       "source_location": "L82"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -53833,49 +53923,13 @@
       "source_location": "L93"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
       "norm_label": "engagementmetrics.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "label": "RiskIndicators.tsx",
-      "norm_label": "riskindicators.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "riskindicators_getriskicon",
-      "label": "getRiskIcon()",
-      "norm_label": "getriskicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "riskindicators_getriskstyles",
-      "label": "getRiskStyles()",
-      "norm_label": "getriskstyles()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "riskindicators_riskindicators",
-      "label": "RiskIndicators()",
-      "norm_label": "riskindicators()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L54"
     },
     {
       "community": 23,
@@ -54024,6 +54078,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
+      "label": "RiskIndicators.tsx",
+      "norm_label": "riskindicators.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "riskindicators_getriskicon",
+      "label": "getRiskIcon()",
+      "norm_label": "getriskicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "riskindicators_getriskstyles",
+      "label": "getRiskStyles()",
+      "norm_label": "getriskstyles()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "riskindicators_riskindicators",
+      "label": "RiskIndicators()",
+      "norm_label": "riskindicators()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
       "norm_label": "formatobservabilitylabel()",
@@ -54031,7 +54121,7 @@
       "source_location": "L66"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -54040,7 +54130,7 @@
       "source_location": "L121"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -54049,7 +54139,7 @@
       "source_location": "L74"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -54058,7 +54148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -54067,7 +54157,7 @@
       "source_location": "L51"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -54076,7 +54166,7 @@
       "source_location": "L92"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -54085,7 +54175,7 @@
       "source_location": "L16"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -54094,7 +54184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -54103,7 +54193,7 @@
       "source_location": "L20"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -54112,7 +54202,7 @@
       "source_location": "L10"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -54121,7 +54211,7 @@
       "source_location": "L46"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -54130,7 +54220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -54139,7 +54229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -54148,7 +54238,7 @@
       "source_location": "L83"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -54157,7 +54247,7 @@
       "source_location": "L100"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -54166,7 +54256,7 @@
       "source_location": "L79"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -54175,7 +54265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -54184,7 +54274,7 @@
       "source_location": "L38"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -54193,7 +54283,7 @@
       "source_location": "L65"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -54202,7 +54292,7 @@
       "source_location": "L91"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -54211,7 +54301,7 @@
       "source_location": "L4"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -54220,7 +54310,7 @@
       "source_location": "L20"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -54229,7 +54319,7 @@
       "source_location": "L42"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -54238,7 +54328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -54247,7 +54337,7 @@
       "source_location": "L102"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -54256,7 +54346,7 @@
       "source_location": "L69"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -54265,7 +54355,7 @@
       "source_location": "L43"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -54274,7 +54364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -54283,7 +54373,7 @@
       "source_location": "L13"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -54292,7 +54382,7 @@
       "source_location": "L46"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -54301,7 +54391,7 @@
       "source_location": "L21"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -54310,7 +54400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -54319,7 +54409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -54328,7 +54418,7 @@
       "source_location": "L8"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -54337,49 +54427,13 @@
       "source_location": "L5"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "subcategory_getallsubcategories",
-      "label": "getAllSubcategories()",
-      "norm_label": "getallsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "subcategory_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "subcategory_getsubategory",
-      "label": "getSubategory()",
-      "norm_label": "getsubategory()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L25"
     },
     {
       "community": 24,
@@ -54528,6 +54582,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "subcategory_getallsubcategories",
+      "label": "getAllSubcategories()",
+      "norm_label": "getallsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "subcategory_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "subcategory_getsubategory",
+      "label": "getSubategory()",
+      "norm_label": "getsubategory()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
       "norm_label": "productactionbar.tsx",
@@ -54535,7 +54625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -54544,7 +54634,7 @@
       "source_location": "L50"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -54553,7 +54643,7 @@
       "source_location": "L92"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -54562,7 +54652,7 @@
       "source_location": "L74"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -54571,7 +54661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -54580,7 +54670,7 @@
       "source_location": "L62"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -54589,7 +54679,7 @@
       "source_location": "L109"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -54598,7 +54688,7 @@
       "source_location": "L177"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -54607,7 +54697,7 @@
       "source_location": "L18"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -54616,7 +54706,7 @@
       "source_location": "L52"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -54625,7 +54715,7 @@
       "source_location": "L68"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -54634,7 +54724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -54643,7 +54733,7 @@
       "source_location": "L68"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -54652,7 +54742,7 @@
       "source_location": "L26"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -54661,7 +54751,7 @@
       "source_location": "L7"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -54670,7 +54760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -54679,7 +54769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -54688,7 +54778,7 @@
       "source_location": "L81"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -54697,7 +54787,7 @@
       "source_location": "L85"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -54706,7 +54796,7 @@
       "source_location": "L27"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -54715,7 +54805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -54724,7 +54814,7 @@
       "source_location": "L43"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -54733,7 +54823,7 @@
       "source_location": "L13"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -54742,7 +54832,7 @@
       "source_location": "L88"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -54751,7 +54841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -54760,7 +54850,7 @@
       "source_location": "L111"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -54769,49 +54859,13 @@
       "source_location": "L66"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
     },
     {
       "community": 248,
@@ -57795,6 +57849,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
+      "label": "ProductStatus.test.tsx",
+      "norm_label": "productstatus.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "productstatus_test_makeproduct",
+      "label": "makeProduct()",
+      "norm_label": "makeproduct()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "productstatus_test_makevariant",
+      "label": "makeVariant()",
+      "norm_label": "makevariant()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
       "norm_label": "productslistview.tsx",
@@ -57802,7 +57883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -57811,7 +57892,7 @@
       "source_location": "L65"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -57820,7 +57901,7 @@
       "source_location": "L20"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -57829,7 +57910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -57838,7 +57919,7 @@
       "source_location": "L16"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -57847,7 +57928,7 @@
       "source_location": "L60"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -57856,7 +57937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -57865,7 +57946,7 @@
       "source_location": "L45"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -57874,7 +57955,7 @@
       "source_location": "L19"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -57883,7 +57964,7 @@
       "source_location": "L128"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -57892,7 +57973,7 @@
       "source_location": "L40"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -57901,7 +57982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -57910,7 +57991,7 @@
       "source_location": "L24"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -57919,7 +58000,7 @@
       "source_location": "L20"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -57928,7 +58009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -57937,7 +58018,7 @@
       "source_location": "L25"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -57946,7 +58027,7 @@
       "source_location": "L17"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -57955,7 +58036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -57964,7 +58045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -57973,7 +58054,7 @@
       "source_location": "L59"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -57982,7 +58063,7 @@
       "source_location": "L50"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -57991,7 +58072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -58000,7 +58081,7 @@
       "source_location": "L225"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -58009,7 +58090,7 @@
       "source_location": "L80"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -58018,7 +58099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -58027,40 +58108,13 @@
       "source_location": "L127"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
       "norm_label": "mockconvex()",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
       "source_location": "L71"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
-      "label": "SingleLineError.tsx",
-      "norm_label": "singlelineerror.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
-      "label": "SingleLineError.tsx",
-      "norm_label": "singlelineerror.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "singlelineerror_singlelineerror",
-      "label": "SingleLineError()",
-      "norm_label": "singlelineerror()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L3"
     },
     {
       "community": 32,
@@ -58191,6 +58245,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
+      "label": "SingleLineError.tsx",
+      "norm_label": "singlelineerror.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
+      "label": "SingleLineError.tsx",
+      "norm_label": "singlelineerror.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "singlelineerror_singlelineerror",
+      "label": "SingleLineError()",
+      "norm_label": "singlelineerror()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
       "norm_label": "errorpage()",
@@ -58198,7 +58279,7 @@
       "source_location": "L9"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -58207,7 +58288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -58216,7 +58297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -58225,7 +58306,7 @@
       "source_location": "L3"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -58234,7 +58315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -58243,7 +58324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -58252,7 +58333,7 @@
       "source_location": "L3"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -58261,7 +58342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -58270,7 +58351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -58279,7 +58360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -58288,7 +58369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -58297,7 +58378,7 @@
       "source_location": "L3"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -58306,7 +58387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -58315,7 +58396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -58324,7 +58405,7 @@
       "source_location": "L3"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -58333,7 +58414,7 @@
       "source_location": "L4"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -58342,7 +58423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -58351,7 +58432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -58360,7 +58441,7 @@
       "source_location": "L120"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -58369,7 +58450,7 @@
       "source_location": "L36"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -58378,7 +58459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -58387,7 +58468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -58396,7 +58477,7 @@
       "source_location": "L23"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -58405,7 +58486,7 @@
       "source_location": "L41"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -58414,7 +58495,7 @@
       "source_location": "L20"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -58423,39 +58504,12 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
       "norm_label": "app-context-menu.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "badge_badge",
-      "label": "Badge()",
-      "norm_label": "badge()",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1"
     },
     {
@@ -58578,6 +58632,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "badge_badge",
+      "label": "Badge()",
+      "norm_label": "badge()",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
       "norm_label": "loadingbutton()",
@@ -58585,7 +58666,7 @@
       "source_location": "L9"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -58594,7 +58675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -58603,7 +58684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -58612,7 +58693,7 @@
       "source_location": "L38"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -58621,7 +58702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -58630,7 +58711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -58639,7 +58720,7 @@
       "source_location": "L20"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -58648,7 +58729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -58657,7 +58738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -58666,7 +58747,7 @@
       "source_location": "L12"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -58675,7 +58756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -58684,7 +58765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -58693,7 +58774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -58702,7 +58783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -58711,7 +58792,7 @@
       "source_location": "L3"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -58720,7 +58801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -58729,7 +58810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -58738,7 +58819,7 @@
       "source_location": "L6"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -58747,7 +58828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -58756,7 +58837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -58765,7 +58846,7 @@
       "source_location": "L3"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -58774,7 +58855,7 @@
       "source_location": "L44"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -58783,7 +58864,7 @@
       "source_location": "L19"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -58792,7 +58873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -58801,7 +58882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -58810,40 +58891,13 @@
       "source_location": "L159"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
       "norm_label": "loadmore()",
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L195"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "label": "UserActivity.tsx",
-      "norm_label": "useractivity.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "useractivity_activityheader",
-      "label": "ActivityHeader()",
-      "norm_label": "activityheader()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "useractivity_useractivity",
-      "label": "UserActivity()",
-      "norm_label": "useractivity()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L45"
     },
     {
       "community": 34,
@@ -58965,6 +59019,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
+      "label": "UserActivity.tsx",
+      "norm_label": "useractivity.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "useractivity_activityheader",
+      "label": "ActivityHeader()",
+      "norm_label": "activityheader()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "useractivity_useractivity",
+      "label": "UserActivity()",
+      "norm_label": "useractivity()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
       "norm_label": "onlineorderprovider()",
@@ -58972,7 +59053,7 @@
       "source_location": "L24"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -58981,7 +59062,7 @@
       "source_location": "L38"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -58990,7 +59071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -58999,7 +59080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -59008,7 +59089,7 @@
       "source_location": "L23"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -59017,7 +59098,7 @@
       "source_location": "L51"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -59026,7 +59107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -59035,7 +59116,7 @@
       "source_location": "L54"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -59044,7 +59125,7 @@
       "source_location": "L282"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -59053,7 +59134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -59062,7 +59143,7 @@
       "source_location": "L12"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -59071,7 +59152,7 @@
       "source_location": "L37"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -59080,7 +59161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -59089,7 +59170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -59098,7 +59179,7 @@
       "source_location": "L4"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -59107,7 +59188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -59116,7 +59197,7 @@
       "source_location": "L9"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -59125,7 +59206,7 @@
       "source_location": "L50"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -59134,7 +59215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -59143,7 +59224,7 @@
       "source_location": "L6"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -59152,7 +59233,7 @@
       "source_location": "L31"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -59161,7 +59242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -59170,7 +59251,7 @@
       "source_location": "L5"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -59179,7 +59260,7 @@
       "source_location": "L31"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -59188,7 +59269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -59197,40 +59278,13 @@
       "source_location": "L19"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
       "norm_label": "usesessionmanagementexpense()",
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L33"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
-      "label": "runCommand.ts",
-      "norm_label": "runcommand.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "runcommand_extracttraceid",
-      "label": "extractTraceId()",
-      "norm_label": "extracttraceid()",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "runcommand_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L26"
     },
     {
       "community": 35,
@@ -59352,6 +59406,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
+      "label": "runCommand.ts",
+      "norm_label": "runcommand.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "runcommand_extracttraceid",
+      "label": "extractTraceId()",
+      "norm_label": "extracttraceid()",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "runcommand_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
       "norm_label": "isinmaintenancemode()",
@@ -59359,7 +59440,7 @@
       "source_location": "L7"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -59368,7 +59449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -59377,7 +59458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -59386,7 +59467,7 @@
       "source_location": "L3"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -59395,7 +59476,7 @@
       "source_location": "L10"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -59404,7 +59485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -59413,7 +59494,7 @@
       "source_location": "L18"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -59422,7 +59503,7 @@
       "source_location": "L59"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -59431,7 +59512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -59440,7 +59521,7 @@
       "source_location": "L31"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -59449,7 +59530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -59458,7 +59539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -59467,7 +59548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -59476,7 +59557,7 @@
       "source_location": "L28"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -59485,7 +59566,7 @@
       "source_location": "L46"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -59494,7 +59575,7 @@
       "source_location": "L18"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -59503,7 +59584,7 @@
       "source_location": "L28"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -59512,7 +59593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -59521,7 +59602,7 @@
       "source_location": "L127"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -59530,7 +59611,7 @@
       "source_location": "L106"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -59539,7 +59620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -59548,7 +59629,7 @@
       "source_location": "L66"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -59557,7 +59638,7 @@
       "source_location": "L20"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -59566,7 +59647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -59575,7 +59656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -59584,40 +59665,13 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
     },
     {
       "community": 36,
@@ -59739,6 +59793,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
       "norm_label": "vite.config.ts",
@@ -59746,7 +59827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -59755,7 +59836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -59764,7 +59845,7 @@
       "source_location": "L19"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -59773,7 +59854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -59782,7 +59863,7 @@
       "source_location": "L23"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -59791,7 +59872,7 @@
       "source_location": "L24"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -59800,7 +59881,7 @@
       "source_location": "L32"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -59809,7 +59890,7 @@
       "source_location": "L3"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -59818,7 +59899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -59827,7 +59908,7 @@
       "source_location": "L7"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -59836,7 +59917,7 @@
       "source_location": "L5"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -59845,7 +59926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -59854,7 +59935,7 @@
       "source_location": "L6"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -59863,7 +59944,7 @@
       "source_location": "L18"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -59872,7 +59953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -59881,7 +59962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -59890,7 +59971,7 @@
       "source_location": "L3"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -59899,7 +59980,7 @@
       "source_location": "L5"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -59908,7 +59989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -59917,7 +59998,7 @@
       "source_location": "L18"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -59926,7 +60007,7 @@
       "source_location": "L23"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -59935,7 +60016,7 @@
       "source_location": "L22"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -59944,7 +60025,7 @@
       "source_location": "L55"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -59953,7 +60034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -59962,7 +60043,7 @@
       "source_location": "L77"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -59971,39 +60052,12 @@
       "source_location": "L11"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
       "norm_label": "deliveryoptionsselector.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "deliverysection_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "deliverysection_deliveryoptions",
-      "label": "DeliveryOptions()",
-      "norm_label": "deliveryoptions()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "label": "DeliverySection.tsx",
-      "norm_label": "deliverysection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1"
     },
     {
@@ -60126,6 +60180,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "deliverysection_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "deliverysection_deliveryoptions",
+      "label": "DeliveryOptions()",
+      "norm_label": "deliveryoptions()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
+      "label": "DeliverySection.tsx",
+      "norm_label": "deliverysection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
@@ -60133,7 +60214,7 @@
       "source_location": "L110"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -60142,7 +60223,7 @@
       "source_location": "L89"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -60151,7 +60232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -60160,7 +60241,7 @@
       "source_location": "L4"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -60169,7 +60250,7 @@
       "source_location": "L24"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -60178,7 +60259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -60187,7 +60268,7 @@
       "source_location": "L131"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -60196,7 +60277,7 @@
       "source_location": "L12"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -60205,7 +60286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -60214,7 +60295,7 @@
       "source_location": "L20"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -60223,7 +60304,7 @@
       "source_location": "L46"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -60232,7 +60313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -60241,7 +60322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -60250,7 +60331,7 @@
       "source_location": "L20"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -60259,7 +60340,7 @@
       "source_location": "L59"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -60268,7 +60349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -60277,7 +60358,7 @@
       "source_location": "L25"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -60286,7 +60367,7 @@
       "source_location": "L20"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -60295,7 +60376,7 @@
       "source_location": "L30"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -60304,7 +60385,7 @@
       "source_location": "L95"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -60313,7 +60394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -60322,7 +60403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -60331,7 +60412,7 @@
       "source_location": "L150"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -60340,7 +60421,7 @@
       "source_location": "L157"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -60349,7 +60430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -60358,40 +60439,13 @@
       "source_location": "L63"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
     },
     {
       "community": 38,
@@ -60513,6 +60567,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
       "norm_label": "welcomebackmodalform.tsx",
@@ -60520,7 +60601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -60529,7 +60610,7 @@
       "source_location": "L51"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -60538,7 +60619,7 @@
       "source_location": "L36"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -60547,7 +60628,7 @@
       "source_location": "L16"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -60556,7 +60637,7 @@
       "source_location": "L39"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -60565,7 +60646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -60574,7 +60655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -60583,7 +60664,7 @@
       "source_location": "L25"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -60592,7 +60673,7 @@
       "source_location": "L82"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -60601,7 +60682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -60610,7 +60691,7 @@
       "source_location": "L20"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -60619,7 +60700,7 @@
       "source_location": "L55"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -60628,7 +60709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -60637,7 +60718,7 @@
       "source_location": "L107"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -60646,7 +60727,7 @@
       "source_location": "L25"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -60655,7 +60736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -60664,7 +60745,7 @@
       "source_location": "L556"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -60673,7 +60754,7 @@
       "source_location": "L52"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -60682,7 +60763,7 @@
       "source_location": "L429"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -60691,7 +60772,7 @@
       "source_location": "L102"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -60700,7 +60781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -60709,7 +60790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -60718,7 +60799,7 @@
       "source_location": "L250"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -60727,7 +60808,7 @@
       "source_location": "L46"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -60736,7 +60817,7 @@
       "source_location": "L17"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -60745,39 +60826,12 @@
       "source_location": "L63"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
       "norm_label": "account.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
     },
     {
@@ -60891,6 +60945,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
       "norm_label": "verify.index.tsx",
@@ -60898,7 +60979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -60907,7 +60988,7 @@
       "source_location": "L21"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -60916,7 +60997,7 @@
       "source_location": "L107"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -60925,7 +61006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -60934,7 +61015,7 @@
       "source_location": "L161"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -60943,7 +61024,7 @@
       "source_location": "L66"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -60952,7 +61033,7 @@
       "source_location": "L11"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -60961,7 +61042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -60970,7 +61051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -60979,7 +61060,7 @@
       "source_location": "L16"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -60988,7 +61069,7 @@
       "source_location": "L10"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -60997,7 +61078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61006,7 +61087,7 @@
       "source_location": "L17"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -61015,7 +61096,7 @@
       "source_location": "L11"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -61024,7 +61105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -61033,7 +61114,7 @@
       "source_location": "L21"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -61042,7 +61123,7 @@
       "source_location": "L15"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -61051,7 +61132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61060,7 +61141,7 @@
       "source_location": "L48"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -61069,7 +61150,7 @@
       "source_location": "L42"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -61078,7 +61159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61087,7 +61168,7 @@
       "source_location": "L16"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -61096,7 +61177,7 @@
       "source_location": "L10"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -61105,7 +61186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61114,7 +61195,7 @@
       "source_location": "L19"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -61123,39 +61204,12 @@
       "source_location": "L13"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
       "norm_label": "harness-inferential-review.test.ts",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "harness_self_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "harness_self_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "scripts_harness_self_review_test_ts",
-      "label": "harness-self-review.test.ts",
-      "norm_label": "harness-self-review.test.ts",
-      "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -61512,6 +61566,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "harness_self_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "harness_self_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "scripts_harness_self_review_test_ts",
+      "label": "harness-self-review.test.ts",
+      "norm_label": "harness-self-review.test.ts",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -61519,7 +61600,7 @@
       "source_location": "L20"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -61528,7 +61609,7 @@
       "source_location": "L14"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -61537,7 +61618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -61546,7 +61627,7 @@
       "source_location": "L26"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -61555,7 +61636,7 @@
       "source_location": "L18"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -61564,7 +61645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -61573,7 +61654,7 @@
       "source_location": "L45"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -61582,7 +61663,7 @@
       "source_location": "L20"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -61591,7 +61672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -61600,7 +61681,7 @@
       "source_location": "L8"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -61609,7 +61690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -61618,7 +61699,7 @@
       "source_location": "L9"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -61627,7 +61708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -61636,7 +61717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61645,7 +61726,7 @@
       "source_location": "L12"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -61654,7 +61735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -61663,7 +61744,7 @@
       "source_location": "L8"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -61672,7 +61753,7 @@
       "source_location": "L10"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -61681,7 +61762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -61690,31 +61771,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
       "norm_label": "verificationcode()",
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "subcategories_removestorefronthiddensubcategorylist",
-      "label": "removeStorefrontHiddenSubcategoryList()",
-      "norm_label": "removestorefronthiddensubcategorylist()",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
-      "source_location": "L10"
     },
     {
       "community": 41,
@@ -61818,6 +61881,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "subcategories_removestorefronthiddensubcategorylist",
+      "label": "removeStorefrontHiddenSubcategoryList()",
+      "norm_label": "removestorefronthiddensubcategorylist()",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
       "norm_label": "handlecollectionnotification()",
@@ -61825,7 +61906,7 @@
       "source_location": "L10"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -61834,7 +61915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -61843,7 +61924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61852,7 +61933,7 @@
       "source_location": "L6"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -61861,7 +61942,7 @@
       "source_location": "L110"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -61870,7 +61951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -61879,7 +61960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -61888,7 +61969,7 @@
       "source_location": "L8"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -61897,7 +61978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -61906,7 +61987,7 @@
       "source_location": "L22"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -61915,7 +61996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -61924,7 +62005,7 @@
       "source_location": "L8"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -61933,7 +62014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -61942,7 +62023,7 @@
       "source_location": "L29"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -61951,7 +62032,7 @@
       "source_location": "L22"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -61960,7 +62041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -61969,30 +62050,12 @@
       "source_location": "L4"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
       "norm_label": "callllmprovider.ts",
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "anthropic_callanthropic",
-      "label": "callAnthropic()",
-      "norm_label": "callanthropic()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
-      "label": "anthropic.ts",
-      "norm_label": "anthropic.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L1"
     },
     {
@@ -62097,6 +62160,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "anthropic_callanthropic",
+      "label": "callAnthropic()",
+      "norm_label": "callanthropic()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
+      "label": "anthropic.ts",
+      "norm_label": "anthropic.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
       "norm_label": "callopenai()",
@@ -62104,7 +62185,7 @@
       "source_location": "L3"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -62113,7 +62194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -62122,7 +62203,7 @@
       "source_location": "L6"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -62131,7 +62212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -62140,7 +62221,7 @@
       "source_location": "L3"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -62149,7 +62230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -62158,7 +62239,7 @@
       "source_location": "L19"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -62167,7 +62248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -62176,7 +62257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -62185,7 +62266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -62194,7 +62275,7 @@
       "source_location": "L9"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -62203,7 +62284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -62212,7 +62293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -62221,7 +62302,7 @@
       "source_location": "L17"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -62230,7 +62311,7 @@
       "source_location": "L31"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -62239,7 +62320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -62248,31 +62329,13 @@
       "source_location": "L6"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
       "norm_label": "cashierrepository.ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
-      "label": "sessionRepository.test.ts",
-      "norm_label": "sessionrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "sessionrepository_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
-      "source_location": "L88"
     },
     {
       "community": 43,
@@ -62376,6 +62439,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
+      "label": "sessionRepository.test.ts",
+      "norm_label": "sessionrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "sessionrepository_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
       "norm_label": "buildservicecatalogitem()",
@@ -62383,7 +62464,7 @@
       "source_location": "L9"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -62392,7 +62473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -62401,7 +62482,7 @@
       "source_location": "L4"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -62410,7 +62491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -62419,7 +62500,7 @@
       "source_location": "L15"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -62428,7 +62509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -62437,7 +62518,7 @@
       "source_location": "L7"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -62446,7 +62527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -62455,7 +62536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -62464,7 +62545,7 @@
       "source_location": "L8"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -62473,7 +62554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -62482,7 +62563,7 @@
       "source_location": "L5"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -62491,7 +62572,7 @@
       "source_location": "L15"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -62500,7 +62581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -62509,7 +62590,7 @@
       "source_location": "L8"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -62518,7 +62599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -62527,30 +62608,12 @@
       "source_location": "L17"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
       "norm_label": "customerobservabilitytimeline.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "helperorchestration_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
-      "label": "helperOrchestration.test.ts",
-      "norm_label": "helperorchestration.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L1"
     },
     {
@@ -62655,6 +62718,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "helperorchestration_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
+      "label": "helperOrchestration.test.ts",
+      "norm_label": "helperorchestration.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
@@ -62662,7 +62743,7 @@
       "source_location": "L5"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -62671,7 +62752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -62680,7 +62761,7 @@
       "source_location": "L25"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -62689,7 +62770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -62698,7 +62779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -62707,7 +62788,7 @@
       "source_location": "L19"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -62716,7 +62797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -62725,7 +62806,7 @@
       "source_location": "L7"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -62734,7 +62815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -62743,7 +62824,7 @@
       "source_location": "L14"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -62752,7 +62833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -62761,7 +62842,7 @@
       "source_location": "L8"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -62770,7 +62851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -62779,7 +62860,7 @@
       "source_location": "L3"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -62788,7 +62869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -62797,7 +62878,7 @@
       "source_location": "L5"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -62806,31 +62887,13 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "useroffers_determineoffereligibility",
-      "label": "determineOfferEligibility()",
-      "norm_label": "determineoffereligibility()",
-      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
-      "source_location": "L30"
     },
     {
       "community": 45,
@@ -62934,6 +62997,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "useroffers_determineoffereligibility",
+      "label": "determineOfferEligibility()",
+      "norm_label": "determineoffereligibility()",
+      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
       "norm_label": "possession.ts",
@@ -62941,7 +63022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -62950,7 +63031,7 @@
       "source_location": "L43"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -62959,7 +63040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -62968,7 +63049,7 @@
       "source_location": "L31"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -62977,7 +63058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -62986,7 +63067,7 @@
       "source_location": "L5"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -62995,7 +63076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -63004,7 +63085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -63013,7 +63094,7 @@
       "source_location": "L7"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -63022,7 +63103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -63031,7 +63112,7 @@
       "source_location": "L12"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -63040,7 +63121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -63049,7 +63130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -63058,7 +63139,7 @@
       "source_location": "L11"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -63067,7 +63148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -63076,7 +63157,7 @@
       "source_location": "L11"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -63085,31 +63166,13 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
       "norm_label": "settingsview()",
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeactions_tsx",
-      "label": "StoreActions.tsx",
-      "norm_label": "storeactions.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "storeactions_storeactions",
-      "label": "StoreActions()",
-      "norm_label": "storeactions()",
-      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
-      "source_location": "L12"
     },
     {
       "community": 46,
@@ -63204,6 +63267,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeactions_tsx",
+      "label": "StoreActions.tsx",
+      "norm_label": "storeactions.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "storeactions_storeactions",
+      "label": "StoreActions()",
+      "norm_label": "storeactions()",
+      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
       "norm_label": "storedropdown.tsx",
@@ -63211,7 +63292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -63220,7 +63301,7 @@
       "source_location": "L42"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -63229,7 +63310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -63238,7 +63319,7 @@
       "source_location": "L13"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -63247,7 +63328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -63256,7 +63337,7 @@
       "source_location": "L42"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -63265,7 +63346,7 @@
       "source_location": "L31"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -63274,7 +63355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -63283,7 +63364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -63292,7 +63373,7 @@
       "source_location": "L10"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -63301,7 +63382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -63310,7 +63391,7 @@
       "source_location": "L14"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -63319,7 +63400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -63328,7 +63409,7 @@
       "source_location": "L5"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -63337,7 +63418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -63346,7 +63427,7 @@
       "source_location": "L10"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -63355,31 +63436,13 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
       "norm_label": "header()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
-      "label": "ProductPage.tsx",
-      "norm_label": "productpage.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "productpage_productpage",
-      "label": "ProductPage()",
-      "norm_label": "productpage()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
-      "source_location": "L13"
     },
     {
       "community": 47,
@@ -63474,6 +63537,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
+      "label": "ProductPage.tsx",
+      "norm_label": "productpage.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "productpage_productpage",
+      "label": "ProductPage()",
+      "norm_label": "productpage()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
       "norm_label": "setisupdatingsku()",
@@ -63481,7 +63562,7 @@
       "source_location": "L116"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -63490,7 +63571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -63499,7 +63580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -63508,7 +63589,7 @@
       "source_location": "L47"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -63517,7 +63598,7 @@
       "source_location": "L151"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -63526,7 +63607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -63535,7 +63616,7 @@
       "source_location": "L6"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -63544,7 +63625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -63553,7 +63634,7 @@
       "source_location": "L19"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -63562,7 +63643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -63571,7 +63652,7 @@
       "source_location": "L7"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -63580,7 +63661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -63589,7 +63670,7 @@
       "source_location": "L42"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -63598,7 +63679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -63607,7 +63688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -63616,7 +63697,7 @@
       "source_location": "L66"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -63625,31 +63706,13 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
       "norm_label": "formathour()",
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "logitems_logitems",
-      "label": "LogItems()",
-      "norm_label": "logitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
-      "label": "LogItems.tsx",
-      "norm_label": "logitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
-      "source_location": "L1"
     },
     {
       "community": 48,
@@ -63744,6 +63807,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "logitems_logitems",
+      "label": "LogItems()",
+      "norm_label": "logitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
+      "label": "LogItems.tsx",
+      "norm_label": "logitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
       "norm_label": "header()",
@@ -63751,7 +63832,7 @@
       "source_location": "L10"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -63760,7 +63841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -63769,7 +63850,7 @@
       "source_location": "L27"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -63778,7 +63859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -63787,7 +63868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -63796,7 +63877,7 @@
       "source_location": "L12"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -63805,7 +63886,7 @@
       "source_location": "L3"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -63814,7 +63895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -63823,7 +63904,7 @@
       "source_location": "L5"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -63832,7 +63913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -63841,7 +63922,7 @@
       "source_location": "L49"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -63850,7 +63931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -63859,7 +63940,7 @@
       "source_location": "L23"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -63868,7 +63949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -63877,7 +63958,7 @@
       "source_location": "L50"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -63886,7 +63967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -63895,30 +63976,12 @@
       "source_location": "L13"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
       "norm_label": "checkoutsessionstable.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "checkoutsesssionsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
-      "label": "CheckoutSesssionsView.tsx",
-      "norm_label": "checkoutsesssionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L1"
     },
     {
@@ -64014,6 +64077,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "checkoutsesssionsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
+      "label": "CheckoutSesssionsView.tsx",
+      "norm_label": "checkoutsesssionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
       "norm_label": "expensecompletion()",
@@ -64021,7 +64102,7 @@
       "source_location": "L31"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -64030,7 +64111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -64039,7 +64120,7 @@
       "source_location": "L29"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -64048,7 +64129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -64057,7 +64138,7 @@
       "source_location": "L37"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -64066,7 +64147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -64075,7 +64156,7 @@
       "source_location": "L25"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -64084,7 +64165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -64093,7 +64174,7 @@
       "source_location": "L83"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -64102,7 +64183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -64111,7 +64192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -64120,7 +64201,7 @@
       "source_location": "L35"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -64129,7 +64210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -64138,7 +64219,7 @@
       "source_location": "L28"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -64147,7 +64228,7 @@
       "source_location": "L12"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -64156,7 +64237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -64165,30 +64246,12 @@
       "source_location": "L13"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
       "norm_label": "customerdetailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "emailstatusview_handlesendorderemail",
-      "label": "handleSendOrderEmail()",
-      "norm_label": "handlesendorderemail()",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "label": "EmailStatusView.tsx",
-      "norm_label": "emailstatusview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1"
     },
     {
@@ -64536,6 +64599,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "emailstatusview_handlesendorderemail",
+      "label": "handleSendOrderEmail()",
+      "norm_label": "handlesendorderemail()",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
+      "label": "EmailStatusView.tsx",
+      "norm_label": "emailstatusview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
       "norm_label": "handletimerangechange()",
@@ -64543,7 +64624,7 @@
       "source_location": "L33"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -64552,7 +64633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -64561,7 +64642,7 @@
       "source_location": "L35"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -64570,7 +64651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -64579,7 +64660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -64588,7 +64669,7 @@
       "source_location": "L81"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -64597,7 +64678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -64606,7 +64687,7 @@
       "source_location": "L6"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -64615,7 +64696,7 @@
       "source_location": "L34"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64624,7 +64705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -64633,7 +64714,7 @@
       "source_location": "L89"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -64642,7 +64723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -64651,7 +64732,7 @@
       "source_location": "L8"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -64660,7 +64741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -64669,7 +64750,7 @@
       "source_location": "L5"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -64678,7 +64759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -64687,31 +64768,13 @@
       "source_location": "L7"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
       "norm_label": "noresultsmessage.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L13"
     },
     {
       "community": 51,
@@ -64806,6 +64869,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
       "norm_label": "pointofsaleview.tsx",
@@ -64813,7 +64894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -64822,7 +64903,7 @@
       "source_location": "L35"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -64831,7 +64912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -64840,7 +64921,7 @@
       "source_location": "L3"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -64849,7 +64930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -64858,7 +64939,7 @@
       "source_location": "L14"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -64867,7 +64948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -64876,7 +64957,7 @@
       "source_location": "L15"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -64885,7 +64966,7 @@
       "source_location": "L18"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -64894,7 +64975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -64903,7 +64984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -64912,7 +64993,7 @@
       "source_location": "L8"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -64921,7 +65002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -64930,7 +65011,7 @@
       "source_location": "L9"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -64939,7 +65020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
@@ -64948,7 +65029,7 @@
       "source_location": "L31"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -64957,31 +65038,13 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
       "norm_label": "getpaymentmethodicon()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L25"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "barcodeview_barcodeview",
-      "label": "BarcodeView()",
-      "norm_label": "barcodeview()",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "label": "BarcodeView.tsx",
-      "norm_label": "barcodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 52,
@@ -65076,6 +65139,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "barcodeview_barcodeview",
+      "label": "BarcodeView()",
+      "norm_label": "barcodeview()",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
+      "label": "BarcodeView.tsx",
+      "norm_label": "barcodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
       "norm_label": "categorizationview()",
@@ -65083,7 +65164,7 @@
       "source_location": "L6"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -65092,7 +65173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -65101,7 +65182,7 @@
       "source_location": "L37"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -65110,7 +65191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -65119,7 +65200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -65128,7 +65209,7 @@
       "source_location": "L11"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -65137,7 +65218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -65146,7 +65227,7 @@
       "source_location": "L10"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -65155,7 +65236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -65164,7 +65245,7 @@
       "source_location": "L6"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -65173,7 +65254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -65182,7 +65263,7 @@
       "source_location": "L5"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -65191,7 +65272,7 @@
       "source_location": "L17"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -65200,7 +65281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -65209,7 +65290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -65218,7 +65299,7 @@
       "source_location": "L4"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -65227,31 +65308,13 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
       "norm_label": "togglediscounttype()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L23"
     },
     {
       "community": 53,
@@ -65346,6 +65409,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
       "norm_label": "promocodepreview.tsx",
@@ -65353,7 +65434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -65362,7 +65443,7 @@
       "source_location": "L37"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -65371,7 +65452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -65380,7 +65461,7 @@
       "source_location": "L9"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -65389,7 +65470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -65398,7 +65479,7 @@
       "source_location": "L23"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -65407,7 +65488,7 @@
       "source_location": "L5"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -65416,7 +65497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -65425,7 +65506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -65434,7 +65515,7 @@
       "source_location": "L4"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -65443,7 +65524,7 @@
       "source_location": "L13"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -65452,7 +65533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -65461,7 +65542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -65470,7 +65551,7 @@
       "source_location": "L29"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -65479,7 +65560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -65488,7 +65569,7 @@
       "source_location": "L20"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -65497,31 +65578,13 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
       "source_location": "L63"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
-      "label": "ServiceCatalogView.test.tsx",
-      "norm_label": "servicecatalogview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "servicecatalogview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L30"
     },
     {
       "community": 54,
@@ -65616,6 +65679,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "label": "ServiceCatalogView.test.tsx",
+      "norm_label": "servicecatalogview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "servicecatalogview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
       "norm_label": "serviceintakeform.tsx",
@@ -65623,7 +65704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -65632,7 +65713,7 @@
       "source_location": "L59"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -65641,7 +65722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -65650,7 +65731,7 @@
       "source_location": "L45"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -65659,7 +65740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -65668,7 +65749,7 @@
       "source_location": "L47"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -65677,7 +65758,7 @@
       "source_location": "L29"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -65686,7 +65767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -65695,7 +65776,7 @@
       "source_location": "L3"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -65704,7 +65785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -65713,7 +65794,7 @@
       "source_location": "L4"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -65722,7 +65803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -65731,7 +65812,7 @@
       "source_location": "L4"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -65740,7 +65821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -65749,7 +65830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -65758,7 +65839,7 @@
       "source_location": "L9"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -65767,30 +65848,12 @@
       "source_location": "L9"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
       "norm_label": "contactview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1"
     },
     {
@@ -65877,6 +65940,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
       "norm_label": "maintenanceview()",
@@ -65884,7 +65965,7 @@
       "source_location": "L11"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -65893,7 +65974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -65902,7 +65983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -65911,7 +65992,7 @@
       "source_location": "L25"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -65920,7 +66001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -65929,7 +66010,7 @@
       "source_location": "L21"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -65938,7 +66019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -65947,7 +66028,7 @@
       "source_location": "L63"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -65956,7 +66037,7 @@
       "source_location": "L7"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -65965,7 +66046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -65974,7 +66055,7 @@
       "source_location": "L25"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -65983,7 +66064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -65992,7 +66073,7 @@
       "source_location": "L15"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -66001,7 +66082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -66010,7 +66091,7 @@
       "source_location": "L21"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -66019,7 +66100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -66028,30 +66109,12 @@
       "source_location": "L6"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
       "norm_label": "label.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -66138,6 +66201,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
@@ -66145,7 +66226,7 @@
       "source_location": "L49"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -66154,7 +66235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -66163,7 +66244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -66172,7 +66253,7 @@
       "source_location": "L63"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -66181,7 +66262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -66190,7 +66271,7 @@
       "source_location": "L5"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -66199,7 +66280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -66208,7 +66289,7 @@
       "source_location": "L12"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -66217,7 +66298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -66226,7 +66307,7 @@
       "source_location": "L15"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -66235,7 +66316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -66244,7 +66325,7 @@
       "source_location": "L3"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -66253,7 +66334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -66262,7 +66343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -66271,7 +66352,7 @@
       "source_location": "L5"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -66280,7 +66361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -66289,30 +66370,12 @@
       "source_location": "L11"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
       "norm_label": "bagitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1"
     },
     {
@@ -66399,6 +66462,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
       "norm_label": "string()",
@@ -66406,7 +66487,7 @@
       "source_location": "L110"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -66415,7 +66496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -66424,7 +66505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -66433,7 +66514,7 @@
       "source_location": "L13"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -66442,7 +66523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -66451,7 +66532,7 @@
       "source_location": "L7"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -66460,7 +66541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -66469,7 +66550,7 @@
       "source_location": "L11"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -66478,7 +66559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -66487,7 +66568,7 @@
       "source_location": "L7"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -66496,7 +66577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -66505,7 +66586,7 @@
       "source_location": "L45"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -66514,7 +66595,7 @@
       "source_location": "L13"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -66523,7 +66604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -66532,7 +66613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -66541,7 +66622,7 @@
       "source_location": "L7"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -66550,30 +66631,12 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
       "norm_label": "useismobile()",
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5"
     },
     {
@@ -66660,6 +66723,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
       "norm_label": "use-navigation-keyboard-shortcuts.ts",
@@ -66667,7 +66748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -66676,7 +66757,7 @@
       "source_location": "L7"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -66685,7 +66766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -66694,7 +66775,7 @@
       "source_location": "L9"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -66703,7 +66784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -66712,7 +66793,7 @@
       "source_location": "L6"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -66721,7 +66802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -66730,7 +66811,7 @@
       "source_location": "L168"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -66739,7 +66820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -66748,7 +66829,7 @@
       "source_location": "L5"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -66757,7 +66838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -66766,7 +66847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -66775,7 +66856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -66784,7 +66865,7 @@
       "source_location": "L6"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -66793,7 +66874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -66802,7 +66883,7 @@
       "source_location": "L12"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -66811,31 +66892,13 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
       "norm_label": "useexpenseoperations()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L24"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 59,
@@ -66921,6 +66984,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
       "norm_label": "usegetautheduser.ts",
@@ -66928,7 +67009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -66937,7 +67018,7 @@
       "source_location": "L4"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -66946,7 +67027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -66955,7 +67036,7 @@
       "source_location": "L5"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -66964,7 +67045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -66973,7 +67054,7 @@
       "source_location": "L5"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -66982,7 +67063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -66991,7 +67072,7 @@
       "source_location": "L4"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -67000,7 +67081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -67009,7 +67090,7 @@
       "source_location": "L5"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -67018,7 +67099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -67027,7 +67108,7 @@
       "source_location": "L5"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -67036,7 +67117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -67045,7 +67126,7 @@
       "source_location": "L8"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -67054,7 +67135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -67063,7 +67144,7 @@
       "source_location": "L13"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -67072,31 +67153,13 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
       "norm_label": "useprint()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L27"
     },
     {
       "community": 6,
@@ -67416,6 +67479,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
       "norm_label": "useproductwithnoimagesnotification.tsx",
@@ -67423,7 +67504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -67432,7 +67513,7 @@
       "source_location": "L7"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -67441,7 +67522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -67450,7 +67531,7 @@
       "source_location": "L5"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -67459,7 +67540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -67468,7 +67549,7 @@
       "source_location": "L12"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -67477,7 +67558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -67486,7 +67567,7 @@
       "source_location": "L12"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -67495,7 +67576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -67504,7 +67585,7 @@
       "source_location": "L5"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -67513,7 +67594,7 @@
       "source_location": "L44"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -67522,7 +67603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -67531,7 +67612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -67540,7 +67621,7 @@
       "source_location": "L6"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -67549,7 +67630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -67558,7 +67639,7 @@
       "source_location": "L7"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -67567,30 +67648,12 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
       "norm_label": "navigationutils.ts",
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "additem_additem",
-      "label": "addItem()",
-      "norm_label": "additem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
-      "label": "addItem.ts",
-      "norm_label": "additem.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
       "source_location": "L1"
     },
     {
@@ -67677,6 +67740,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "additem_additem",
+      "label": "addItem()",
+      "norm_label": "additem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
+      "label": "addItem.ts",
+      "norm_label": "additem.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
       "norm_label": "bootstrapregister()",
@@ -67684,7 +67765,7 @@
       "source_location": "L6"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -67693,7 +67774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -67702,7 +67783,7 @@
       "source_location": "L5"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -67711,7 +67792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -67720,7 +67801,7 @@
       "source_location": "L5"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -67729,7 +67810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -67738,7 +67819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -67747,7 +67828,7 @@
       "source_location": "L5"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -67756,7 +67837,7 @@
       "source_location": "L10"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -67765,7 +67846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -67774,7 +67855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -67783,7 +67864,7 @@
       "source_location": "L12"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -67792,7 +67873,7 @@
       "source_location": "L9"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -67801,7 +67882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -67810,7 +67891,7 @@
       "source_location": "L6"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -67819,7 +67900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -67828,31 +67909,13 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
       "norm_label": "hasorgnotfoundpayload()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 62,
@@ -67938,6 +68001,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
       "norm_label": "published.index.tsx",
@@ -67945,7 +68026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -67954,7 +68035,7 @@
       "source_location": "L9"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -67963,7 +68044,7 @@
       "source_location": "L13"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -67972,7 +68053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -67981,7 +68062,7 @@
       "source_location": "L4"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -67990,7 +68071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -67999,7 +68080,7 @@
       "source_location": "L13"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -68008,7 +68089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -68017,7 +68098,7 @@
       "source_location": "L5"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -68026,7 +68107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -68035,7 +68116,7 @@
       "source_location": "L17"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -68044,7 +68125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -68053,7 +68134,7 @@
       "source_location": "L15"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -68062,7 +68143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -68071,7 +68152,7 @@
       "source_location": "L12"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -68080,7 +68161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -68089,31 +68170,13 @@
       "source_location": "L5"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
-      "label": "Popover.stories.tsx",
-      "norm_label": "popover.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "popover_stories_popovershowcase",
-      "label": "PopoverShowcase()",
-      "norm_label": "popovershowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L13"
     },
     {
       "community": 63,
@@ -68199,6 +68262,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
+      "label": "Popover.stories.tsx",
+      "norm_label": "popover.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "popover_stories_popovershowcase",
+      "label": "PopoverShowcase()",
+      "norm_label": "popovershowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
       "norm_label": "sheet.stories.tsx",
@@ -68206,7 +68287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -68215,7 +68296,7 @@
       "source_location": "L14"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -68224,7 +68305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -68233,7 +68314,7 @@
       "source_location": "L13"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -68242,7 +68323,7 @@
       "source_location": "L5"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -68251,7 +68332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -68260,7 +68341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -68269,7 +68350,7 @@
       "source_location": "L17"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -68278,7 +68359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -68287,7 +68368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -68296,7 +68377,7 @@
       "source_location": "L4"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -68305,7 +68386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -68314,7 +68395,7 @@
       "source_location": "L27"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -68323,7 +68404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -68332,7 +68413,7 @@
       "source_location": "L4"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -68341,7 +68422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -68350,31 +68431,13 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "entitypage_entitypage",
-      "label": "EntityPage()",
-      "norm_label": "entitypage()",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "label": "EntityPage.tsx",
-      "norm_label": "entitypage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
     },
     {
       "community": 64,
@@ -68451,6 +68514,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "entitypage_entitypage",
+      "label": "EntityPage()",
+      "norm_label": "entitypage()",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
+      "label": "EntityPage.tsx",
+      "norm_label": "entitypage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
       "norm_label": "productspage.tsx",
@@ -68458,7 +68539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -68467,7 +68548,7 @@
       "source_location": "L10"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -68476,7 +68557,7 @@
       "source_location": "L4"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -68485,7 +68566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -68494,7 +68575,7 @@
       "source_location": "L39"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -68503,7 +68584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -68512,7 +68593,7 @@
       "source_location": "L18"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -68521,7 +68602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -68530,7 +68611,7 @@
       "source_location": "L71"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -68539,7 +68620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -68548,7 +68629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -68557,7 +68638,7 @@
       "source_location": "L12"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -68566,7 +68647,7 @@
       "source_location": "L6"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -68575,7 +68656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -68584,7 +68665,7 @@
       "source_location": "L18"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -68593,7 +68674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -68602,31 +68683,13 @@
       "source_location": "L10"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "label": "PaymentMethodSection.tsx",
-      "norm_label": "paymentmethodsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "paymentmethodsection_paymentmethodsection",
-      "label": "PaymentMethodSection()",
-      "norm_label": "paymentmethodsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L8"
     },
     {
       "community": 65,
@@ -68703,6 +68766,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
+      "label": "PaymentMethodSection.tsx",
+      "norm_label": "paymentmethodsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "paymentmethodsection_paymentmethodsection",
+      "label": "PaymentMethodSection()",
+      "norm_label": "paymentmethodsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
       "norm_label": "paymentsection.tsx",
@@ -68710,7 +68791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -68719,7 +68800,7 @@
       "source_location": "L27"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -68728,7 +68809,7 @@
       "source_location": "L40"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -68737,7 +68818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -68746,7 +68827,7 @@
       "source_location": "L3"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -68755,7 +68836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -68764,7 +68845,7 @@
       "source_location": "L8"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -68773,7 +68854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -68782,7 +68863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -68791,7 +68872,7 @@
       "source_location": "L12"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -68800,7 +68881,7 @@
       "source_location": "L77"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -68809,7 +68890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -68818,7 +68899,7 @@
       "source_location": "L161"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -68827,7 +68908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -68836,7 +68917,7 @@
       "source_location": "L3"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -68845,7 +68926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -68854,31 +68935,13 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
       "norm_label": "trustsignals()",
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "label": "ProductFilter.tsx",
-      "norm_label": "productfilter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "productfilter_productfilter",
-      "label": "ProductFilter()",
-      "norm_label": "productfilter()",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L14"
     },
     {
       "community": 66,
@@ -68955,6 +69018,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
+      "label": "ProductFilter.tsx",
+      "norm_label": "productfilter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "productfilter_productfilter",
+      "label": "ProductFilter()",
+      "norm_label": "productfilter()",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
       "norm_label": "handlecheckboxchange()",
@@ -68962,7 +69043,7 @@
       "source_location": "L27"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -68971,7 +69052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -68980,7 +69061,7 @@
       "source_location": "L17"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -68989,7 +69070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -68998,7 +69079,7 @@
       "source_location": "L13"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -69007,7 +69088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -69016,7 +69097,7 @@
       "source_location": "L47"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -69025,7 +69106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -69034,7 +69115,7 @@
       "source_location": "L7"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -69043,7 +69124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -69052,7 +69133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -69061,7 +69142,7 @@
       "source_location": "L17"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -69070,7 +69151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -69079,7 +69160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -69088,7 +69169,7 @@
       "source_location": "L12"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -69097,7 +69178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -69106,30 +69187,12 @@
       "source_location": "L7"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
       "norm_label": "discountbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "galleryviewer_handleclickonpreview",
-      "label": "handleClickOnPreview()",
-      "norm_label": "handleclickonpreview()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "label": "GalleryViewer.tsx",
-      "norm_label": "galleryviewer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L1"
     },
     {
@@ -69207,6 +69270,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "galleryviewer_handleclickonpreview",
+      "label": "handleClickOnPreview()",
+      "norm_label": "handleclickonpreview()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
+      "label": "GalleryViewer.tsx",
+      "norm_label": "galleryviewer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
       "norm_label": "onsaleproduct()",
@@ -69214,7 +69295,7 @@
       "source_location": "L5"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -69223,7 +69304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -69232,7 +69313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -69241,7 +69322,7 @@
       "source_location": "L17"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -69250,7 +69331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -69259,7 +69340,25 @@
       "source_location": "L3"
     },
     {
-      "community": 673,
+      "community": 674,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
+      "label": "ProductPage.test.tsx",
+      "norm_label": "productpage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 674,
+      "file_type": "code",
+      "id": "productpage_test_makepagestate",
+      "label": "makePageState()",
+      "norm_label": "makepagestate()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -69268,7 +69367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -69277,7 +69376,7 @@
       "source_location": "L79"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -69286,7 +69385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -69295,7 +69394,7 @@
       "source_location": "L87"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -69304,7 +69403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -69313,7 +69412,7 @@
       "source_location": "L8"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -69322,7 +69421,7 @@
       "source_location": "L12"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -69331,7 +69430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -69340,49 +69439,13 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
       "norm_label": "ratingselector()",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "guestrewardsprompt_guestrewardsprompt",
-      "label": "GuestRewardsPrompt()",
-      "norm_label": "guestrewardsprompt()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "label": "GuestRewardsPrompt.tsx",
-      "norm_label": "guestrewardsprompt.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "orderpointsdisplay_orderpointsdisplay",
-      "label": "OrderPointsDisplay()",
-      "norm_label": "orderpointsdisplay()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "label": "OrderPointsDisplay.tsx",
-      "norm_label": "orderpointsdisplay.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L1"
     },
     {
       "community": 68,
@@ -69459,6 +69522,42 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "guestrewardsprompt_guestrewardsprompt",
+      "label": "GuestRewardsPrompt()",
+      "norm_label": "guestrewardsprompt()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
+      "label": "GuestRewardsPrompt.tsx",
+      "norm_label": "guestrewardsprompt.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "orderpointsdisplay_orderpointsdisplay",
+      "label": "OrderPointsDisplay()",
+      "norm_label": "orderpointsdisplay()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
+      "label": "OrderPointsDisplay.tsx",
+      "norm_label": "orderpointsdisplay.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
       "norm_label": "pastordersrewards.tsx",
@@ -69466,7 +69565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 682,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -69475,7 +69574,7 @@
       "source_location": "L59"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -69484,7 +69583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -69493,7 +69592,7 @@
       "source_location": "L33"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -69502,7 +69601,7 @@
       "source_location": "L19"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -69511,7 +69610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -69520,7 +69619,7 @@
       "source_location": "L4"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -69529,7 +69628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -69538,7 +69637,7 @@
       "source_location": "L22"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -69547,7 +69646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -69556,7 +69655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -69565,7 +69664,7 @@
       "source_location": "L11"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -69574,7 +69673,7 @@
       "source_location": "L3"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -69583,7 +69682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -69592,48 +69691,12 @@
       "source_location": "L3"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
       "norm_label": "ghana-region-select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "ghost_button_ghostbutton",
-      "label": "GhostButton()",
-      "norm_label": "ghostbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
-      "label": "ghost-button.tsx",
-      "norm_label": "ghost-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "leaveareviewmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "label": "LeaveAReviewModal.tsx",
-      "norm_label": "leaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1"
     },
     {
@@ -69711,6 +69774,42 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "ghost_button_ghostbutton",
+      "label": "GhostButton()",
+      "norm_label": "ghostbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
+      "label": "ghost-button.tsx",
+      "norm_label": "ghost-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "leaveareviewmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
+      "label": "LeaveAReviewModal.tsx",
+      "norm_label": "leaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
       "norm_label": "upsellmodalsuccess.tsx",
@@ -69718,7 +69817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 690,
+      "community": 692,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -69727,7 +69826,7 @@
       "source_location": "L19"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -69736,7 +69835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -69745,7 +69844,7 @@
       "source_location": "L13"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -69754,7 +69853,7 @@
       "source_location": "L46"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -69763,7 +69862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -69772,7 +69871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -69781,7 +69880,7 @@
       "source_location": "L46"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -69790,7 +69889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -69799,7 +69898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -69808,7 +69907,7 @@
       "source_location": "L15"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -69817,7 +69916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -69826,7 +69925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -69835,7 +69934,7 @@
       "source_location": "L5"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -69844,49 +69943,13 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
       "norm_label": "usediscountcodealert()",
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
-      "label": "useEnhancedTracking.ts",
-      "norm_label": "useenhancedtracking.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "useenhancedtracking_useenhancedtracking",
-      "label": "useEnhancedTracking()",
-      "norm_label": "useenhancedtracking()",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "label": "useGetActiveCheckoutSession.tsx",
-      "norm_label": "usegetactivecheckoutsession.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "label": "useGetActiveCheckoutSession()",
-      "norm_label": "usegetactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
     },
     {
       "community": 7,
@@ -70188,6 +70251,42 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
+      "label": "useEnhancedTracking.ts",
+      "norm_label": "useenhancedtracking.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "useenhancedtracking_useenhancedtracking",
+      "label": "useEnhancedTracking()",
+      "norm_label": "useenhancedtracking()",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
+      "label": "useGetActiveCheckoutSession.tsx",
+      "norm_label": "usegetactivecheckoutsession.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
+      "label": "useGetActiveCheckoutSession()",
+      "norm_label": "usegetactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
       "norm_label": "usegetproduct.tsx",
@@ -70195,7 +70294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 702,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -70204,7 +70303,7 @@
       "source_location": "L5"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -70213,7 +70312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -70222,7 +70321,7 @@
       "source_location": "L3"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -70231,7 +70330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -70240,7 +70339,7 @@
       "source_location": "L4"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -70249,7 +70348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -70258,7 +70357,7 @@
       "source_location": "L4"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -70267,7 +70366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -70276,7 +70375,7 @@
       "source_location": "L9"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -70285,7 +70384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -70294,7 +70393,7 @@
       "source_location": "L17"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -70303,7 +70402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -70312,7 +70411,7 @@
       "source_location": "L5"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -70321,49 +70420,13 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
       "norm_label": "usemodalstate()",
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
-      "label": "useProductPageLogic.ts",
-      "norm_label": "useproductpagelogic.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "useproductpagelogic_useproductpagelogic",
-      "label": "useProductPageLogic()",
-      "norm_label": "useproductpagelogic()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "label": "useProductReminder.tsx",
-      "norm_label": "useproductreminder.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "useproductreminder_useproductreminder",
-      "label": "useProductReminder()",
-      "norm_label": "useproductreminder()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L9"
     },
     {
       "community": 71,
@@ -70440,6 +70503,42 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
+      "label": "useProductPageLogic.ts",
+      "norm_label": "useproductpagelogic.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "useproductpagelogic_useproductpagelogic",
+      "label": "useProductPageLogic()",
+      "norm_label": "useproductpagelogic()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
+      "label": "useProductReminder.tsx",
+      "norm_label": "useproductreminder.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "useproductreminder_useproductreminder",
+      "label": "useProductReminder()",
+      "norm_label": "useproductreminder()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
       "norm_label": "usepromoalert.tsx",
@@ -70447,7 +70546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 712,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -70456,7 +70555,7 @@
       "source_location": "L16"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -70465,7 +70564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -70474,7 +70573,7 @@
       "source_location": "L4"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -70483,7 +70582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -70492,7 +70591,7 @@
       "source_location": "L11"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -70501,7 +70600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -70510,7 +70609,7 @@
       "source_location": "L3"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -70519,7 +70618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -70528,7 +70627,7 @@
       "source_location": "L7"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -70537,7 +70636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -70546,7 +70645,7 @@
       "source_location": "L4"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -70555,7 +70654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -70564,7 +70663,7 @@
       "source_location": "L14"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -70573,48 +70672,12 @@
       "source_location": "L4"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "bag_usebagqueries",
-      "label": "useBagQueries()",
-      "norm_label": "usebagqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "bannermessage_usebannermessagequeries",
-      "label": "useBannerMessageQueries()",
-      "norm_label": "usebannermessagequeries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -70692,6 +70755,42 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "bag_usebagqueries",
+      "label": "useBagQueries()",
+      "norm_label": "usebagqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "bannermessage_usebannermessagequeries",
+      "label": "useBannerMessageQueries()",
+      "norm_label": "usebannermessagequeries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
       "norm_label": "usecheckoutsessionqueries()",
@@ -70699,7 +70798,7 @@
       "source_location": "L10"
     },
     {
-      "community": 720,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -70708,7 +70807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -70717,7 +70816,7 @@
       "source_location": "L6"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -70726,7 +70825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -70735,7 +70834,7 @@
       "source_location": "L5"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -70744,7 +70843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -70753,7 +70852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -70762,7 +70861,7 @@
       "source_location": "L14"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -70771,7 +70870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -70780,7 +70879,7 @@
       "source_location": "L9"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -70789,7 +70888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -70798,7 +70897,7 @@
       "source_location": "L10"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -70807,7 +70906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -70816,7 +70915,7 @@
       "source_location": "L11"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -70825,48 +70924,12 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
       "norm_label": "useupsellsqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "user_useuserqueries",
-      "label": "useUserQueries()",
-      "norm_label": "useuserqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "useroffers_useuseroffersqueries",
-      "label": "useUserOffersQueries()",
-      "norm_label": "useuseroffersqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6"
     },
     {
@@ -70944,6 +71007,42 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "user_useuserqueries",
+      "label": "useUserQueries()",
+      "norm_label": "useuserqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "useroffers_useuseroffersqueries",
+      "label": "useUserOffersQueries()",
+      "norm_label": "useuseroffersqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
       "norm_label": "storeconfig.test.ts",
@@ -70951,7 +71050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 730,
+      "community": 732,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -70960,7 +71059,7 @@
       "source_location": "L10"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -70969,7 +71068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -70978,7 +71077,7 @@
       "source_location": "L15"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -70987,7 +71086,7 @@
       "source_location": "L14"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -70996,7 +71095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -71005,7 +71104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -71014,7 +71113,7 @@
       "source_location": "L6"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -71023,7 +71122,7 @@
       "source_location": "L13"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -71032,7 +71131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -71041,7 +71140,7 @@
       "source_location": "L8"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -71050,7 +71149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -71059,7 +71158,7 @@
       "source_location": "L14"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -71068,7 +71167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -71077,49 +71176,13 @@
       "source_location": "L13"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
       "norm_label": "delivery-returns-exchanges.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
-      "label": "privacy.index.tsx",
-      "norm_label": "privacy.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "privacy_index_privacypolicy",
-      "label": "PrivacyPolicy()",
-      "norm_label": "privacypolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "label": "tos.index.tsx",
-      "norm_label": "tos.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "tos_index_tossection",
-      "label": "TosSection()",
-      "norm_label": "tossection()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L15"
     },
     {
       "community": 74,
@@ -71196,6 +71259,42 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
+      "label": "privacy.index.tsx",
+      "norm_label": "privacy.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "privacy_index_privacypolicy",
+      "label": "PrivacyPolicy()",
+      "norm_label": "privacypolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
+      "label": "tos.index.tsx",
+      "norm_label": "tos.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "tos_index_tossection",
+      "label": "TosSection()",
+      "norm_label": "tossection()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
       "norm_label": "shop.product.$productslug.tsx",
@@ -71203,7 +71302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 742,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -71212,7 +71311,7 @@
       "source_location": "L16"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -71221,7 +71320,7 @@
       "source_location": "L6"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -71230,7 +71329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -71239,7 +71338,7 @@
       "source_location": "L10"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -71248,7 +71347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -71257,7 +71356,7 @@
       "source_location": "L21"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -71266,7 +71365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -71275,7 +71374,7 @@
       "source_location": "L33"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -71284,7 +71383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -71293,7 +71392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -71302,7 +71401,7 @@
       "source_location": "L193"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -71311,7 +71410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -71320,7 +71419,7 @@
       "source_location": "L7"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -71329,48 +71428,12 @@
       "source_location": "L10"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
       "norm_label": "architecture-boundaries.test.ts",
       "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "architecture_boundary_check_run",
-      "label": "run()",
-      "norm_label": "run()",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "scripts_architecture_boundary_check_ts",
-      "label": "architecture-boundary-check.ts",
-      "norm_label": "architecture-boundary-check.ts",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "athena_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "label": "athena-runtime-app.ts",
-      "norm_label": "athena-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
       "source_location": "L1"
     },
     {
@@ -71448,6 +71511,42 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "architecture_boundary_check_run",
+      "label": "run()",
+      "norm_label": "run()",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "scripts_architecture_boundary_check_ts",
+      "label": "architecture-boundary-check.ts",
+      "norm_label": "architecture-boundary-check.ts",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "athena_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
+      "label": "athena-runtime-app.ts",
+      "norm_label": "athena-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
       "norm_label": "shutdown()",
@@ -71455,7 +71554,7 @@
       "source_location": "L85"
     },
     {
-      "community": 750,
+      "community": 752,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -71464,7 +71563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -71473,7 +71572,7 @@
       "source_location": "L15"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -71482,7 +71581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -71491,7 +71590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -71500,7 +71599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -71509,7 +71608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -71518,7 +71617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -71527,30 +71626,12 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
       "norm_label": "app.ts",
       "source_file": "packages/athena-webapp/convex/app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_config_js",
-      "label": "auth.config.js",
-      "norm_label": "auth.config.js",
-      "source_file": "packages/athena-webapp/convex/auth.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/auth.ts",
       "source_location": "L1"
     },
     {
@@ -71628,6 +71709,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_config_js",
+      "label": "auth.config.js",
+      "norm_label": "auth.config.js",
+      "source_file": "packages/athena-webapp/convex/auth.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 762,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
       "norm_label": "registersessions.test.ts",
@@ -71635,7 +71734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -71644,7 +71743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -71653,7 +71752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -71662,7 +71761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -71671,7 +71770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -71680,7 +71779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -71689,30 +71788,12 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
       "norm_label": "neworderadmin.tsx",
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
-      "label": "OrderEmail.tsx",
-      "norm_label": "orderemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "label": "PosReceiptEmail.tsx",
-      "norm_label": "posreceiptemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1"
     },
     {
@@ -71790,6 +71871,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
+      "label": "OrderEmail.tsx",
+      "norm_label": "orderemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
+      "label": "PosReceiptEmail.tsx",
+      "norm_label": "posreceiptemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 772,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
       "norm_label": "env.ts",
@@ -71797,7 +71896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -71806,7 +71905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -71815,7 +71914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71824,7 +71923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -71833,7 +71932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -71842,7 +71941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -71851,30 +71950,12 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
       "norm_label": "products.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_storefronthidden_test_ts",
-      "label": "storefrontHidden.test.ts",
-      "norm_label": "storefronthidden.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/storefrontHidden.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
       "source_location": "L1"
     },
     {
@@ -71952,6 +72033,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_storefronthidden_test_ts",
+      "label": "storefrontHidden.test.ts",
+      "norm_label": "storefronthidden.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/storefrontHidden.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -71959,7 +72058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -71968,7 +72067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -71977,7 +72076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -71986,7 +72085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -71995,7 +72094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -72004,7 +72103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -72013,30 +72112,12 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
       "norm_label": "paystack.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
       "source_location": "L1"
     },
     {
@@ -72114,6 +72195,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 792,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
@@ -72121,7 +72220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -72130,7 +72229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -72139,7 +72238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -72148,7 +72247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -72157,7 +72256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -72166,7 +72265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -72175,30 +72274,12 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
       "norm_label": "http.ts",
       "source_file": "packages/athena-webapp/convex/http.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -72474,6 +72555,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
       "norm_label": "bestseller.ts",
@@ -72481,7 +72580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -72490,7 +72589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -72499,7 +72598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -72508,7 +72607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -72517,7 +72616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -72526,7 +72625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -72535,30 +72634,12 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_pos_ts",
-      "label": "pos.ts",
-      "norm_label": "pos.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
-      "label": "posCustomers.ts",
-      "norm_label": "poscustomers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1"
     },
     {
@@ -72636,6 +72717,24 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_pos_ts",
+      "label": "pos.ts",
+      "norm_label": "pos.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
+      "label": "posCustomers.ts",
+      "norm_label": "poscustomers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 812,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
@@ -72643,7 +72742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -72652,7 +72751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
@@ -72661,7 +72760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -72670,7 +72769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -72679,7 +72778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -72688,7 +72787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -72697,30 +72796,12 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
       "norm_label": "currency.test.ts",
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
-      "label": "storeInsights.ts",
-      "norm_label": "storeinsights.ts",
-      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_userinsights_ts",
-      "label": "userInsights.ts",
-      "norm_label": "userinsights.ts",
-      "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
       "source_location": "L1"
     },
     {
@@ -72789,6 +72870,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
+      "label": "storeInsights.ts",
+      "norm_label": "storeinsights.ts",
+      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_userinsights_ts",
+      "label": "userInsights.ts",
+      "norm_label": "userinsights.ts",
+      "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
       "norm_label": "migrateamountstopesewas.ts",
@@ -72796,7 +72895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -72805,7 +72904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -72814,7 +72913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -72823,7 +72922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -72832,7 +72931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -72841,7 +72940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -72850,30 +72949,12 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
       "norm_label": "paymentallocations.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
-      "label": "EmailOTP.test.ts",
-      "norm_label": "emailotp.test.ts",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
-      "label": "completeTransaction.test.ts",
-      "norm_label": "completetransaction.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
       "source_location": "L1"
     },
     {
@@ -72942,6 +73023,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
+      "label": "EmailOTP.test.ts",
+      "norm_label": "emailotp.test.ts",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
+      "label": "completeTransaction.test.ts",
+      "norm_label": "completetransaction.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
@@ -72949,7 +73048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -72958,7 +73057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -72967,7 +73066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -72976,7 +73075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -72985,7 +73084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -72994,7 +73093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -73003,30 +73102,12 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
       "norm_label": "registersessionrepository.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
-      "label": "sessionCommandRepository.test.ts",
-      "norm_label": "sessioncommandrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
       "source_location": "L1"
     },
     {
@@ -73095,6 +73176,24 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
+      "label": "sessionCommandRepository.test.ts",
+      "norm_label": "sessioncommandrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
       "norm_label": "customers.ts",
@@ -73102,7 +73201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -73111,7 +73210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -73120,7 +73219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -73129,7 +73228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -73138,7 +73237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -73147,7 +73246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -73156,30 +73255,12 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
       "source_location": "L1"
     },
     {
@@ -73248,6 +73329,24 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
@@ -73255,7 +73354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -73264,7 +73363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -73273,7 +73372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -73282,7 +73381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -73291,7 +73390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -73300,7 +73399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -73309,30 +73408,12 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
-      "label": "redeemedPromoCode.ts",
-      "norm_label": "redeemedpromocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1"
     },
     {
@@ -73401,6 +73482,24 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
+      "label": "redeemedPromoCode.ts",
+      "norm_label": "redeemedpromocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -73408,7 +73507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -73417,7 +73516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -73426,7 +73525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -73435,7 +73534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -73444,7 +73543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -73453,7 +73552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -73462,30 +73561,12 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
       "norm_label": "customerprofile.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/customerProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
-      "label": "inventoryMovement.ts",
-      "norm_label": "inventorymovement.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
       "source_location": "L1"
     },
     {
@@ -73554,6 +73635,24 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
+      "label": "inventoryMovement.ts",
+      "norm_label": "inventorymovement.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
       "norm_label": "operationalevent.ts",
@@ -73561,7 +73660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -73570,7 +73669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -73579,7 +73678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -73588,7 +73687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -73597,7 +73696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -73606,7 +73705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -73615,30 +73714,12 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
       "norm_label": "mtncollections.ts",
       "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
-      "label": "expenseSession.ts",
-      "norm_label": "expensesession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1"
     },
     {
@@ -73707,6 +73788,24 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
+      "label": "expenseSession.ts",
+      "norm_label": "expensesession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
       "norm_label": "expensesessionitem.ts",
@@ -73714,7 +73813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -73723,7 +73822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -73732,7 +73831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -73741,7 +73840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -73750,7 +73849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -73759,7 +73858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -73768,30 +73867,12 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
-      "label": "posTransactionItem.ts",
-      "norm_label": "postransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
       "source_location": "L1"
     },
     {
@@ -73860,6 +73941,24 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
+      "label": "posTransactionItem.ts",
+      "norm_label": "postransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
       "norm_label": "serviceappointment.ts",
@@ -73867,7 +73966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -73876,7 +73975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -73885,7 +73984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -73894,7 +73993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -73903,7 +74002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -73912,7 +74011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -73921,30 +74020,12 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
       "norm_label": "purchaseorderlineitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
-      "label": "receivingBatch.ts",
-      "norm_label": "receivingbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
-      "label": "stockAdjustmentBatch.ts",
-      "norm_label": "stockadjustmentbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
       "source_location": "L1"
     },
     {
@@ -74202,6 +74283,24 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
+      "label": "receivingBatch.ts",
+      "norm_label": "receivingbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
+      "label": "stockAdjustmentBatch.ts",
+      "norm_label": "stockadjustmentbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
       "norm_label": "vendor.ts",
@@ -74209,7 +74308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -74218,7 +74317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -74227,7 +74326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -74236,7 +74335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -74245,7 +74344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -74254,7 +74353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -74263,30 +74362,12 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "label": "offer.ts",
-      "norm_label": "offer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1"
     },
     {
@@ -74355,6 +74436,24 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
+      "label": "offer.ts",
+      "norm_label": "offer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
@@ -74362,7 +74461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -74371,7 +74470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -74380,7 +74479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -74389,7 +74488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -74398,7 +74497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -74407,7 +74506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -74416,30 +74515,12 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "label": "storeFrontVerificationCode.ts",
-      "norm_label": "storefrontverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
       "source_location": "L1"
     },
     {
@@ -74508,6 +74589,24 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
+      "label": "storeFrontVerificationCode.ts",
+      "norm_label": "storefrontverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
       "norm_label": "catalogappointments.test.ts",
@@ -74515,7 +74614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -74524,7 +74623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -74533,7 +74632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -74542,7 +74641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -74551,7 +74650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -74560,7 +74659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -74569,30 +74668,12 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
-      "label": "paystackActions.ts",
-      "norm_label": "paystackactions.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
       "source_location": "L1"
     },
     {
@@ -74661,6 +74742,24 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
+      "label": "paystackActions.ts",
+      "norm_label": "paystackactions.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
@@ -74668,7 +74767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -74677,7 +74776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -74686,7 +74785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -74695,7 +74794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -74704,7 +74803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -74713,7 +74812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -74722,30 +74821,12 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/shared/auth.ts",
       "source_location": "L1"
     },
     {
@@ -74814,6 +74895,24 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/shared/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
       "norm_label": "commandresult.test.ts",
@@ -74821,7 +74920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -74830,7 +74929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -74839,7 +74938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -74848,7 +74947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -74857,7 +74956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -74866,7 +74965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -74875,30 +74974,12 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
       "norm_label": "productattributesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -74967,6 +75048,24 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -74974,7 +75073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -74983,7 +75082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -74992,7 +75091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -75001,7 +75100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -75010,7 +75109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -75019,7 +75118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -75028,30 +75127,12 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -75120,6 +75201,24 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -75127,7 +75226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -75136,7 +75235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75145,7 +75244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75154,7 +75253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -75163,7 +75262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75172,7 +75271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -75181,30 +75280,12 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
       "source_location": "L1"
     },
     {
@@ -75273,6 +75354,24 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -75280,7 +75379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75289,7 +75388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75298,7 +75397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -75307,7 +75406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -75316,7 +75415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75325,7 +75424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75334,30 +75433,12 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -75426,6 +75507,24 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -75433,7 +75532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75442,7 +75541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -75451,7 +75550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -75460,7 +75559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75469,7 +75568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75478,7 +75577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -75487,30 +75586,12 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "label": "app-sidebar.tsx",
-      "norm_label": "app-sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
-      "label": "assetsColumns.tsx",
-      "norm_label": "assetscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -75579,6 +75660,24 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
+      "label": "app-sidebar.tsx",
+      "norm_label": "app-sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
+      "label": "assetsColumns.tsx",
+      "norm_label": "assetscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -75586,7 +75685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75595,7 +75694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75604,7 +75703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75613,7 +75712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -75622,7 +75721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -75631,7 +75730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -75640,30 +75739,12 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
       "norm_label": "inputotp.test.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
-      "label": "LoginForm.test.tsx",
-      "norm_label": "loginform.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "label": "LoginForm.tsx",
-      "norm_label": "loginform.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19667,7 +19667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
-      "source_location": "L38",
+      "source_location": "L37",
       "target": "imagesview_handlekeydown",
       "weight": 1
     },
@@ -19679,7 +19679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
-      "source_location": "L5",
+      "source_location": "L11",
       "target": "productstatus_productstatus",
       "weight": 1
     },
@@ -65098,7 +65098,7 @@
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
-      "source_location": "L38"
+      "source_location": "L37"
     },
     {
       "community": 521,
@@ -65125,7 +65125,7 @@
       "label": "ProductStatus()",
       "norm_label": "productstatus()",
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
-      "source_location": "L5"
+      "source_location": "L11"
     },
     {
       "community": 523,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1510
-- Graph nodes: 3860
-- Graph edges: 3410
-- Communities: 1425
+- Code files discovered: 1512
+- Graph nodes: 3865
+- Graph edges: 3413
+- Communities: 1427
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 69 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 523 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 524 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 5 file(s); key children: OperationsQueueView.auth.test.tsx, OperationsQueueView.test.tsx, OperationsQueueView.tsx, StockAdjustmentWorkspace.test.tsx, StockAdjustmentWorkspace.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -122,6 +122,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/pos/transactions/transactionColumns.test.tsx`](../../src/components/pos/transactions/transactionColumns.test.tsx)
 - [`src/components/procurement/ProcurementView.test.tsx`](../../src/components/procurement/ProcurementView.test.tsx)
 - [`src/components/procurement/ReceivingView.test.tsx`](../../src/components/procurement/ReceivingView.test.tsx)
+- [`src/components/product/ProductStatus.test.tsx`](../../src/components/product/ProductStatus.test.tsx)
 - [`src/components/promo-codes/PromoCodeHeader.test.tsx`](../../src/components/promo-codes/PromoCodeHeader.test.tsx)
 - [`src/components/promo-codes/promoCodeMoney.test.ts`](../../src/components/promo-codes/promoCodeMoney.test.ts)
 - [`src/components/services/ServiceAppointmentsView.test.tsx`](../../src/components/services/ServiceAppointmentsView.test.tsx)

--- a/packages/athena-webapp/src/components/add-product/ProductStock.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductStock.tsx
@@ -835,39 +835,38 @@ function Stock({
 
                 <TableCell>
                   <div className="flex items-center gap-2">
-                    {productVariants.length > 1 && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              onClick={() => setVisibility(variant.id)}
-                              disabled={
-                                isLastActiveVariant(index) ||
-                                isLastVisibleVariant(index) ||
-                                isSkuReserved(variant.sku)
-                              }
-                            >
-                              {(variant.isVisible == undefined ||
-                                variant.isVisible) && (
-                                <EyeOff className="w-4 h-4" />
-                              )}
-
-                              {variant.isVisible == false && (
-                                <Eye className="w-4 h-4 text-muted-foreground" />
-                              )}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setVisibility(variant.id)}
+                            disabled={
+                              (productVariants.length > 1 &&
+                                (isLastActiveVariant(index) ||
+                                  isLastVisibleVariant(index))) ||
+                              isSkuReserved(variant.sku)
+                            }
+                          >
                             {(variant.isVisible == undefined ||
-                              variant.isVisible) && <p>Hide</p>}
+                              variant.isVisible) && (
+                              <EyeOff className="w-4 h-4" />
+                            )}
 
-                            {variant.isVisible == false && <p>Make visible</p>}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    )}
+                            {variant.isVisible == false && (
+                              <Eye className="w-4 h-4 text-muted-foreground" />
+                            )}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {(variant.isVisible == undefined ||
+                            variant.isVisible) && <p>Hide</p>}
+
+                          {variant.isVisible == false && <p>Make visible</p>}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
 
                     <TooltipProvider>
                       <Tooltip>

--- a/packages/athena-webapp/src/components/product/ImagesView.tsx
+++ b/packages/athena-webapp/src/components/product/ImagesView.tsx
@@ -23,7 +23,6 @@ import { usePermissions } from "~/src/hooks/usePermissions";
 import { FadeIn } from "../common/FadeIn";
 import { Skeleton } from "../ui/skeleton";
 import { useEffect } from "react";
-import { ProductStockStatus } from "./ProductStock";
 import { ProductStatus } from "./ProductStatus";
 
 export function ImagesView() {
@@ -83,13 +82,10 @@ export function ImagesView() {
               <div className="relative">
                 {i == 0 && (
                   <div className="font-medium text-xs absolute top-0 left-0 m-2">
-                    {activeProduct.isVisible ? (
-                      <ProductStockStatus
-                        productVariant={activeProductVariant}
-                      />
-                    ) : (
-                      <ProductStatus product={activeProduct} />
-                    )}
+                    <ProductStatus
+                      product={activeProduct}
+                      productVariant={activeProductVariant}
+                    />
                   </div>
                 )}
                 <img

--- a/packages/athena-webapp/src/components/product/ProductStatus.test.tsx
+++ b/packages/athena-webapp/src/components/product/ProductStatus.test.tsx
@@ -1,54 +1,58 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { Product } from "~/types";
+import { ProductVariant } from "../add-product/ProductStock";
 import { ProductStatus } from "./ProductStatus";
 
-const visibleProduct = {
-  _id: "product-1",
-  _creationTime: 0,
-  inventoryCount: 12,
-  isVisible: true,
-  skus: [],
-} as const;
+const makeProduct = (overrides: Partial<Product> = {}) =>
+  ({
+    _id: "product-id",
+    name: "Product",
+    sku: "PROD-1",
+    isVisible: true,
+    inventoryCount: 12,
+    ...overrides,
+  }) as unknown as Product;
+
+const makeVariant = (overrides: Partial<ProductVariant> = {}) =>
+  ({
+    id: "variant-id",
+    images: [],
+    isVisible: true,
+    stock: 12,
+    quantityAvailable: 12,
+    ...overrides,
+  }) as unknown as ProductVariant;
 
 describe("ProductStatus", () => {
-  it("shows hidden when the product is hidden", () => {
+  it("shows product as hidden when product is hidden regardless of variant visibility", () => {
     render(
       <ProductStatus
-        product={{ ...visibleProduct, isVisible: false }}
-        productVariant={{ id: "variant-1", isVisible: true } as any}
+        product={makeProduct({ isVisible: false })}
+        productVariant={makeVariant({ isVisible: true })}
       />,
     );
 
     expect(screen.getByText("Hidden")).toBeInTheDocument();
   });
 
-  it("shows hidden when the variant is hidden", () => {
+  it("shows variant visibility when product is visible", () => {
     render(
       <ProductStatus
-        product={visibleProduct as any}
-        productVariant={{
-          id: "variant-2",
-          isVisible: false,
-          stock: 12,
-          quantityAvailable: 12,
-        } as any}
+        product={makeProduct({ isVisible: true })}
+        productVariant={makeVariant({ isVisible: false })}
       />,
     );
 
     expect(screen.getByText("Hidden")).toBeInTheDocument();
   });
 
-  it("shows live when both product and variant are visible", () => {
+  it("shows live status when product and variant are visible", () => {
     render(
       <ProductStatus
-        product={visibleProduct as any}
-        productVariant={{
-          id: "variant-3",
-          isVisible: true,
-          stock: 12,
-          quantityAvailable: 12,
-        } as any}
+        product={makeProduct({ isVisible: true })}
+        productVariant={makeVariant({ isVisible: true, stock: 10, quantityAvailable: 10 })}
       />,
     );
 

--- a/packages/athena-webapp/src/components/product/ProductStatus.test.tsx
+++ b/packages/athena-webapp/src/components/product/ProductStatus.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProductStatus } from "./ProductStatus";
+
+const visibleProduct = {
+  _id: "product-1",
+  _creationTime: 0,
+  inventoryCount: 12,
+  isVisible: true,
+  skus: [],
+} as const;
+
+describe("ProductStatus", () => {
+  it("shows hidden when the product is hidden", () => {
+    render(
+      <ProductStatus
+        product={{ ...visibleProduct, isVisible: false }}
+        productVariant={{ id: "variant-1", isVisible: true } as any}
+      />,
+    );
+
+    expect(screen.getByText("Hidden")).toBeInTheDocument();
+  });
+
+  it("shows hidden when the variant is hidden", () => {
+    render(
+      <ProductStatus
+        product={visibleProduct as any}
+        productVariant={{
+          id: "variant-2",
+          isVisible: false,
+          stock: 12,
+          quantityAvailable: 12,
+        } as any}
+      />,
+    );
+
+    expect(screen.getByText("Hidden")).toBeInTheDocument();
+  });
+
+  it("shows live when both product and variant are visible", () => {
+    render(
+      <ProductStatus
+        product={visibleProduct as any}
+        productVariant={{
+          id: "variant-3",
+          isVisible: true,
+          stock: 12,
+          quantityAvailable: 12,
+        } as any}
+      />,
+    );
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+});

--- a/packages/athena-webapp/src/components/product/ProductStatus.tsx
+++ b/packages/athena-webapp/src/components/product/ProductStatus.tsx
@@ -1,27 +1,45 @@
 import { AlertOctagonIcon, AlertTriangle, EyeOff } from "lucide-react";
 import { Product } from "~/types";
+import { ProductVariant } from "../add-product/ProductStock";
 import { Badge } from "../ui/badge";
 
-export const ProductStatus = ({ product }: { product: Product }) => {
+type ProductStatusProps = {
+  product: Product;
+  productVariant?: ProductVariant;
+};
+
+export const ProductStatus = ({
+  product,
+  productVariant,
+}: ProductStatusProps) => {
+  const isVisible = productVariant?.isVisible ?? product.isVisible;
+  const inventoryCount = productVariant?.stock ?? product.inventoryCount;
+  const quantityAvailable = productVariant?.quantityAvailable ?? inventoryCount;
+
   const getBadgeStyles = () => {
-    if (!product.isVisible) {
+    if (!isVisible) {
       return {
         bg: "bg-zinc-100 text-zinc-700",
         text: "text-zinc-700",
       };
     }
 
-    if (product.inventoryCount === 0)
+    if (inventoryCount === 0 || quantityAvailable === 0) {
       return {
         bg: "bg-red-100 text-red-700",
         text: "text-red-700",
       };
+    }
 
-    if (product.inventoryCount <= 2)
+    if (
+      (inventoryCount !== undefined && inventoryCount <= 2) ||
+      (quantityAvailable !== undefined && quantityAvailable <= 2)
+    ) {
       return {
         bg: "bg-amber-100 text-amber-700",
         text: "text-amber-700",
       };
+    }
 
     return {
       bg: "bg-green-100 text-green-700",
@@ -31,9 +49,9 @@ export const ProductStatus = ({ product }: { product: Product }) => {
 
   const { bg, text } = getBadgeStyles();
 
-  const visibility = product.isVisible ? "Live" : "Hidden";
+  const visibility = isVisible ? "Live" : "Hidden";
 
-  if (!product.isVisible) {
+  if (!isVisible) {
     return (
       <Badge variant="outline" className={`${bg}`}>
         <div className="flex items-center text-xs">
@@ -47,12 +65,12 @@ export const ProductStatus = ({ product }: { product: Product }) => {
   return (
     <Badge variant="outline" className={`${bg}`}>
       <div className="flex items-center text-xs">
-        {product.inventoryCount === 0 ? (
+        {inventoryCount === 0 || quantityAvailable === 0 ? (
           <>
             <AlertTriangle className="w-3.5 h-3.5 mr-2 text-red-700" />
             <p className={text}>Out of stock</p>
           </>
-        ) : product.inventoryCount <= 2 ? (
+        ) : inventoryCount <= 2 || quantityAvailable <= 2 ? (
           <>
             <AlertOctagonIcon className="w-3.5 h-3.5 mr-2 text-amber-700" />
             <p className={text}>Low stock</p>

--- a/packages/athena-webapp/src/components/product/ProductStatus.tsx
+++ b/packages/athena-webapp/src/components/product/ProductStatus.tsx
@@ -12,7 +12,8 @@ export const ProductStatus = ({
   product,
   productVariant,
 }: ProductStatusProps) => {
-  const isVisible = productVariant?.isVisible ?? product.isVisible;
+  const isVisible =
+    product.isVisible !== false && productVariant?.isVisible !== false;
   const inventoryCount = productVariant?.stock ?? product.inventoryCount;
   const quantityAvailable = productVariant?.quantityAvailable ?? inventoryCount;
 

--- a/packages/storefront-webapp/docs/agent/key-folder-index.md
+++ b/packages/storefront-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack Router routes, layouts, and browser journey entrypoints. Currently 34 file(s); key children: -homePageLoader.test.ts, -homePageLoader.ts, __root.tsx, _layout, _layout.tsx.
-- [`src/components`](../../src/components) — Reusable storefront UI and feature-specific checkout/catalog components. Currently 188 file(s); key children: DefaultCatchBoundary.tsx, EntityPage.tsx, HomePage.test.tsx, HomePage.tsx, ProductActionBar.tsx.
+- [`src/components`](../../src/components) — Reusable storefront UI and feature-specific checkout/catalog components. Currently 189 file(s); key children: DefaultCatchBoundary.tsx, EntityPage.tsx, HomePage.test.tsx, HomePage.tsx, ProductActionBar.tsx.
 - [`src/hooks`](../../src/hooks) — Client hooks for bag, routing, observability, and auth interactions. Currently 28 file(s); key children: TRACKING_SCALABILITY.md, use-store-modal.tsx, useAuth.ts, useCheckout.ts, useDiscountCodeAlert.tsx.
 - [`src/contexts`](../../src/contexts) — Shared client providers for store, navigation, and observability state. Currently 4 file(s); key children: FormSubmissionProvider.tsx, NavigationBarProvider.tsx, StoreContext.tsx, StorefrontObservabilityProvider.tsx.
 - [`src/lib`](../../src/lib) — Shared utilities, query helpers, schemas, and domain logic. Currently 46 file(s); key children: STOREFRONT_OBSERVABILITY.md, constants.ts, countries.ts, currency.ts, feeUtils.test.ts.

--- a/packages/storefront-webapp/docs/agent/test-index.md
+++ b/packages/storefront-webapp/docs/agent/test-index.md
@@ -31,6 +31,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/home/homePageContent.test.ts`](../../src/components/home/homePageContent.test.ts)
 - [`src/components/product-page/MobileProductActions.test.tsx`](../../src/components/product-page/MobileProductActions.test.tsx)
 - [`src/components/product-page/ProductActions.test.tsx`](../../src/components/product-page/ProductActions.test.tsx)
+- [`src/components/product-page/ProductPage.test.tsx`](../../src/components/product-page/ProductPage.test.tsx)
 - [`src/components/shopping-bag/ShoppingBag.test.tsx`](../../src/components/shopping-bag/ShoppingBag.test.tsx)
 - [`src/lib/feeUtils.test.ts`](../../src/lib/feeUtils.test.ts)
 - [`src/lib/maintenanceUtils.test.ts`](../../src/lib/maintenanceUtils.test.ts)

--- a/packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx
+++ b/packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx
@@ -1,0 +1,69 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ProductPage from "./ProductPage";
+import { useProductPageLogic } from "@/hooks/useProductPageLogic";
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => children,
+  motion: {
+    main: ({ children, ...props }: HTMLAttributes<HTMLElement>) => (
+      <main {...props}>{children}</main>
+    ),
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock("@/contexts/StoreContext", () => ({
+  useStoreContext: () => ({ store: {} }),
+}));
+
+vi.mock("@/hooks/useTrackAction", () => ({
+  useTrackAction: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useProductPageLogic", () => ({
+  useProductPageLogic: vi.fn(),
+}));
+
+vi.mock("@/lib/storeConfig", () => ({
+  getStoreFallbackImageUrl: () => "https://example.com/fallback.jpg",
+}));
+
+describe("ProductPage", () => {
+  it("renders not found when a product has no visible skus", () => {
+    vi.mocked(useProductPageLogic).mockReturnValue({
+      productSlug: "sample-product",
+      product: {
+        _id: "product-1",
+        skus: [],
+      },
+      error: null,
+      selectedSku: null,
+      setSelectedSku: vi.fn(),
+      isSheetOpen: false,
+      setIsSheetOpen: vi.fn(),
+      sheetContent: { current: null },
+      handleUpdateBag: vi.fn(),
+      handleUpdateSavedBag: vi.fn(),
+      savedBagItem: null,
+      formatter: (value: number) => `${value}`,
+      isSoldOut: false,
+      isLowStock: false,
+      isPromoCodeItem: false,
+      addedItemSuccessfully: false,
+      isUpdatingBag: false,
+      bagAction: "add",
+      productDiscount: null,
+    } as any);
+
+    render(<ProductPage />);
+
+    expect(
+      screen.getByText("The page you're looking for does not exist"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx
+++ b/packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx
@@ -1,64 +1,134 @@
-import type { HTMLAttributes, ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { type HTMLAttributes, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ProductPage from "./ProductPage";
-import { useProductPageLogic } from "@/hooks/useProductPageLogic";
+
+const useProductPageLogicMock = vi.fn();
 
 vi.mock("framer-motion", () => ({
   AnimatePresence: ({ children }: { children: ReactNode }) => children,
   motion: {
-    main: ({ children, ...props }: HTMLAttributes<HTMLElement>) => (
-      <main {...props}>{children}</main>
-    ),
     div: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
       <div {...props}>{children}</div>
     ),
+    main: ({ children, ...props }: HTMLAttributes<HTMLElement>) => (
+      <main {...props}>{children}</main>
+    ),
   },
+}));
+
+vi.mock("@/hooks/useProductPageLogic", () => ({
+  useProductPageLogic: () => useProductPageLogicMock(),
+}));
+
+vi.mock("@/hooks/useTrackAction", () => ({
+  useTrackAction: vi.fn(),
 }));
 
 vi.mock("@/contexts/StoreContext", () => ({
   useStoreContext: () => ({ store: {} }),
 }));
 
-vi.mock("@/hooks/useTrackAction", () => ({
-  useTrackAction: () => ({ track: vi.fn() }),
+vi.mock("../states/not-found/NotFound", () => ({
+  default: () => <div>The page you're looking for does not exist</div>,
 }));
 
-vi.mock("@/hooks/useProductPageLogic", () => ({
-  useProductPageLogic: vi.fn(),
-}));
+const makePageState = (overrides = {}) =>
+  ({
+    productSlug: "product-id",
+    product: { _id: "product-id", skus: [] },
+    error: false,
+    selectedSku: null,
+    setSelectedSku: vi.fn(),
+    isSheetOpen: false,
+    setIsSheetOpen: vi.fn(),
+    sheetContent: { current: null },
+    handleUpdateBag: vi.fn(),
+    handleUpdateSavedBag: vi.fn(),
+    savedBagItem: null,
+    formatter: new Intl.NumberFormat("en-US"),
+    isSoldOut: false,
+    isLowStock: false,
+    isPromoCodeItem: false,
+    addedItemSuccessfully: null,
+    isUpdatingBag: false,
+    bagAction: "add" as const,
+    productDiscount: null,
+    ...overrides,
+  }) as any;
 
-vi.mock("@/lib/storeConfig", () => ({
-  getStoreFallbackImageUrl: () => "https://example.com/fallback.jpg",
-}));
+beforeEach(() => {
+  window.scrollTo = vi.fn();
+  cleanup();
+  useProductPageLogicMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("ProductPage", () => {
-  it("renders not found when a product has no visible skus", () => {
-    vi.mocked(useProductPageLogic).mockReturnValue({
-      productSlug: "sample-product",
-      product: {
-        _id: "product-1",
-        skus: [],
-      },
-      error: null,
-      selectedSku: null,
-      setSelectedSku: vi.fn(),
-      isSheetOpen: false,
-      setIsSheetOpen: vi.fn(),
-      sheetContent: { current: null },
-      handleUpdateBag: vi.fn(),
-      handleUpdateSavedBag: vi.fn(),
-      savedBagItem: null,
-      formatter: (value: number) => `${value}`,
-      isSoldOut: false,
-      isLowStock: false,
-      isPromoCodeItem: false,
-      addedItemSuccessfully: false,
-      isUpdatingBag: false,
-      bagAction: "add",
-      productDiscount: null,
-    } as any);
+  it("shows not found for a hidden product", () => {
+    useProductPageLogicMock.mockReturnValue(
+      makePageState({
+        product: {
+          _id: "product-id",
+          isVisible: false,
+          skus: [{ _id: "sku-id", images: [], price: 1000, isVisible: true }],
+        },
+        selectedSku: {
+          _id: "sku-id",
+          sku: "SKU-ID",
+          images: [],
+          price: 1000,
+          isVisible: true,
+        },
+      }),
+    );
+
+    render(<ProductPage />);
+
+    expect(
+      screen.getByText("The page you're looking for does not exist"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows not found when the single visible product SKU is hidden", () => {
+    useProductPageLogicMock.mockReturnValue(
+      makePageState({
+        product: {
+          _id: "product-id",
+          skus: [{ _id: "sku-id", images: [], price: 1000, isVisible: false }],
+        },
+        selectedSku: {
+          _id: "sku-id",
+          sku: "SKU-ID",
+          images: [],
+          price: 1000,
+          isVisible: false,
+        },
+      }),
+    );
+
+    render(<ProductPage />);
+
+    expect(
+      screen.getByText("The page you're looking for does not exist"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows not found when backend returns no visible single SKU", () => {
+    useProductPageLogicMock.mockReturnValue(
+      makePageState({
+        product: {
+          _id: "product-id",
+          isVisible: true,
+          skus: [],
+        },
+        selectedSku: null,
+      }),
+    );
 
     render(<ProductPage />);
 

--- a/packages/storefront-webapp/src/components/product-page/ProductPage.tsx
+++ b/packages/storefront-webapp/src/components/product-page/ProductPage.tsx
@@ -81,10 +81,18 @@ export default function ProductPage() {
     setIsSheetOpen(true);
   };
 
+  const isSingleSkuHidden =
+    product?.skus?.length === 1 &&
+    (selectedSku as (typeof selectedSku & { isVisible?: boolean }))?.isVisible ===
+      false;
+
   if (error) return <NotFound />;
-  if (!selectedSku || !product) return <div className="h-screen" />;
+  if (!product) return <div className="h-screen" />;
+  if (product.skus.length === 0) return <NotFound />;
+  if (!selectedSku) return <div className="h-screen" />;
   if (
     product?.isVisible === false ||
+    isSingleSkuHidden ||
     isPromoCodeItem ||
     selectedSku.price === 0 ||
     selectedSku.price === undefined

--- a/packages/storefront-webapp/src/routeTree.gen.ts
+++ b/packages/storefront-webapp/src/routeTree.gen.ts
@@ -8,636 +8,466 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as SignupRouteImport } from './routes/signup'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as LayoutRouteImport } from './routes/_layout'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as AuthVerifyRouteImport } from './routes/auth.verify'
-import { Route as LayoutContactUsRouteImport } from './routes/_layout/contact-us'
-import { Route as LayoutAccountRouteImport } from './routes/_layout/account'
-import { Route as LayoutShopLayoutRouteImport } from './routes/_layout/_shopLayout'
-import { Route as LayoutOrdersLayoutRouteImport } from './routes/_layout/_ordersLayout'
-import { Route as ShopCheckoutIndexRouteImport } from './routes/shop/checkout/index'
-import { Route as ShopBagIndexRouteImport } from './routes/shop/bag.index'
-import { Route as LayoutRewardsIndexRouteImport } from './routes/_layout/rewards.index'
-import { Route as ShopCheckoutPodConfirmationRouteImport } from './routes/shop/checkout/pod-confirmation'
-import { Route as ShopCheckoutPendingRouteImport } from './routes/shop/checkout/pending'
-import { Route as ShopCheckoutVerifyIndexRouteImport } from './routes/shop/checkout/verify.index'
-import { Route as ShopCheckoutCompleteIndexRouteImport } from './routes/shop/checkout/complete.index'
-import { Route as ShopCheckoutSessionIdSlugIndexRouteImport } from './routes/shop/checkout/$sessionIdSlug/index'
-import { Route as LayoutShopSavedIndexRouteImport } from './routes/_layout/shop.saved.index'
-import { Route as LayoutPoliciesTosIndexRouteImport } from './routes/_layout/policies/tos.index'
-import { Route as LayoutPoliciesPrivacyIndexRouteImport } from './routes/_layout/policies/privacy.index'
-import { Route as LayoutPoliciesDeliveryReturnsExchangesIndexRouteImport } from './routes/_layout/policies/delivery-returns-exchanges.index'
-import { Route as ShopCheckoutSessionIdSlugIncompleteRouteImport } from './routes/shop/checkout/$sessionIdSlug/incomplete'
-import { Route as ShopCheckoutSessionIdSlugCompleteRouteImport } from './routes/shop/checkout/$sessionIdSlug/complete'
-import { Route as ShopCheckoutSessionIdSlugCanceledRouteImport } from './routes/shop/checkout/$sessionIdSlug/canceled'
-import { Route as LayoutShopProductProductSlugRouteImport } from './routes/_layout/shop.product.$productSlug'
-import { Route as LayoutShopLayoutShopCategorySlugIndexRouteImport } from './routes/_layout/_shopLayout/shop/$categorySlug/index'
-import { Route as LayoutOrdersLayoutShopOrdersIndexRouteImport } from './routes/_layout/_ordersLayout/shop/orders/index'
-import { Route as LayoutShopLayoutShopCategorySlugSubcategorySlugRouteImport } from './routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug'
-import { Route as LayoutOrdersLayoutShopOrdersOrderIdIndexRouteImport } from './routes/_layout/_ordersLayout/shop/orders/$orderId/index'
-import { Route as LayoutOrdersLayoutShopOrdersOrderIdReviewRouteImport } from './routes/_layout/_ordersLayout/shop/orders/$orderId/review'
-import { Route as LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRouteImport } from './routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review'
+// Import Routes
 
-const SignupRoute = SignupRouteImport.update({
+import { Route as rootRoute } from './routes/__root'
+import { Route as SignupImport } from './routes/signup'
+import { Route as LoginImport } from './routes/login'
+import { Route as LayoutImport } from './routes/_layout'
+import { Route as IndexImport } from './routes/index'
+import { Route as AuthVerifyImport } from './routes/auth.verify'
+import { Route as LayoutContactUsImport } from './routes/_layout/contact-us'
+import { Route as LayoutAccountImport } from './routes/_layout/account'
+import { Route as LayoutShopLayoutImport } from './routes/_layout/_shopLayout'
+import { Route as LayoutOrdersLayoutImport } from './routes/_layout/_ordersLayout'
+import { Route as ShopCheckoutIndexImport } from './routes/shop/checkout/index'
+import { Route as ShopBagIndexImport } from './routes/shop/bag.index'
+import { Route as LayoutRewardsIndexImport } from './routes/_layout/rewards.index'
+import { Route as ShopCheckoutPodConfirmationImport } from './routes/shop/checkout/pod-confirmation'
+import { Route as ShopCheckoutPendingImport } from './routes/shop/checkout/pending'
+import { Route as ShopCheckoutVerifyIndexImport } from './routes/shop/checkout/verify.index'
+import { Route as ShopCheckoutCompleteIndexImport } from './routes/shop/checkout/complete.index'
+import { Route as ShopCheckoutSessionIdSlugIndexImport } from './routes/shop/checkout/$sessionIdSlug/index'
+import { Route as LayoutShopSavedIndexImport } from './routes/_layout/shop.saved.index'
+import { Route as LayoutPoliciesTosIndexImport } from './routes/_layout/policies/tos.index'
+import { Route as LayoutPoliciesPrivacyIndexImport } from './routes/_layout/policies/privacy.index'
+import { Route as LayoutPoliciesDeliveryReturnsExchangesIndexImport } from './routes/_layout/policies/delivery-returns-exchanges.index'
+import { Route as ShopCheckoutSessionIdSlugIncompleteImport } from './routes/shop/checkout/$sessionIdSlug/incomplete'
+import { Route as ShopCheckoutSessionIdSlugCompleteImport } from './routes/shop/checkout/$sessionIdSlug/complete'
+import { Route as ShopCheckoutSessionIdSlugCanceledImport } from './routes/shop/checkout/$sessionIdSlug/canceled'
+import { Route as LayoutShopProductProductSlugImport } from './routes/_layout/shop.product.$productSlug'
+import { Route as LayoutShopLayoutShopCategorySlugIndexImport } from './routes/_layout/_shopLayout/shop/$categorySlug/index'
+import { Route as LayoutOrdersLayoutShopOrdersIndexImport } from './routes/_layout/_ordersLayout/shop/orders/index'
+import { Route as LayoutShopLayoutShopCategorySlugSubcategorySlugImport } from './routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug'
+import { Route as LayoutOrdersLayoutShopOrdersOrderIdIndexImport } from './routes/_layout/_ordersLayout/shop/orders/$orderId/index'
+import { Route as LayoutOrdersLayoutShopOrdersOrderIdReviewImport } from './routes/_layout/_ordersLayout/shop/orders/$orderId/review'
+import { Route as LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewImport } from './routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review'
+
+// Create/Update Routes
+
+const SignupRoute = SignupImport.update({
   id: '/signup',
   path: '/signup',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const LoginRoute = LoginRouteImport.update({
+
+const LoginRoute = LoginImport.update({
   id: '/login',
   path: '/login',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const LayoutRoute = LayoutRouteImport.update({
+
+const LayoutRoute = LayoutImport.update({
   id: '/_layout',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const IndexRoute = IndexRouteImport.update({
+
+const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const AuthVerifyRoute = AuthVerifyRouteImport.update({
+
+const AuthVerifyRoute = AuthVerifyImport.update({
   id: '/auth/verify',
   path: '/auth/verify',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const LayoutContactUsRoute = LayoutContactUsRouteImport.update({
+
+const LayoutContactUsRoute = LayoutContactUsImport.update({
   id: '/contact-us',
   path: '/contact-us',
   getParentRoute: () => LayoutRoute,
 } as any)
-const LayoutAccountRoute = LayoutAccountRouteImport.update({
+
+const LayoutAccountRoute = LayoutAccountImport.update({
   id: '/account',
   path: '/account',
   getParentRoute: () => LayoutRoute,
 } as any)
-const LayoutShopLayoutRoute = LayoutShopLayoutRouteImport.update({
+
+const LayoutShopLayoutRoute = LayoutShopLayoutImport.update({
   id: '/_shopLayout',
   getParentRoute: () => LayoutRoute,
 } as any)
-const LayoutOrdersLayoutRoute = LayoutOrdersLayoutRouteImport.update({
+
+const LayoutOrdersLayoutRoute = LayoutOrdersLayoutImport.update({
   id: '/_ordersLayout',
   getParentRoute: () => LayoutRoute,
 } as any)
-const ShopCheckoutIndexRoute = ShopCheckoutIndexRouteImport.update({
+
+const ShopCheckoutIndexRoute = ShopCheckoutIndexImport.update({
   id: '/shop/checkout/',
   path: '/shop/checkout/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const ShopBagIndexRoute = ShopBagIndexRouteImport.update({
+
+const ShopBagIndexRoute = ShopBagIndexImport.update({
   id: '/shop/bag/',
   path: '/shop/bag/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const LayoutRewardsIndexRoute = LayoutRewardsIndexRouteImport.update({
+
+const LayoutRewardsIndexRoute = LayoutRewardsIndexImport.update({
   id: '/rewards/',
   path: '/rewards/',
   getParentRoute: () => LayoutRoute,
 } as any)
+
 const ShopCheckoutPodConfirmationRoute =
-  ShopCheckoutPodConfirmationRouteImport.update({
+  ShopCheckoutPodConfirmationImport.update({
     id: '/shop/checkout/pod-confirmation',
     path: '/shop/checkout/pod-confirmation',
-    getParentRoute: () => rootRouteImport,
+    getParentRoute: () => rootRoute,
   } as any)
-const ShopCheckoutPendingRoute = ShopCheckoutPendingRouteImport.update({
+
+const ShopCheckoutPendingRoute = ShopCheckoutPendingImport.update({
   id: '/shop/checkout/pending',
   path: '/shop/checkout/pending',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const ShopCheckoutVerifyIndexRoute = ShopCheckoutVerifyIndexRouteImport.update({
+
+const ShopCheckoutVerifyIndexRoute = ShopCheckoutVerifyIndexImport.update({
   id: '/shop/checkout/verify/',
   path: '/shop/checkout/verify/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const ShopCheckoutCompleteIndexRoute =
-  ShopCheckoutCompleteIndexRouteImport.update({
-    id: '/shop/checkout/complete/',
-    path: '/shop/checkout/complete/',
-    getParentRoute: () => rootRouteImport,
-  } as any)
+
+const ShopCheckoutCompleteIndexRoute = ShopCheckoutCompleteIndexImport.update({
+  id: '/shop/checkout/complete/',
+  path: '/shop/checkout/complete/',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const ShopCheckoutSessionIdSlugIndexRoute =
-  ShopCheckoutSessionIdSlugIndexRouteImport.update({
+  ShopCheckoutSessionIdSlugIndexImport.update({
     id: '/shop/checkout/$sessionIdSlug/',
     path: '/shop/checkout/$sessionIdSlug/',
-    getParentRoute: () => rootRouteImport,
+    getParentRoute: () => rootRoute,
   } as any)
-const LayoutShopSavedIndexRoute = LayoutShopSavedIndexRouteImport.update({
+
+const LayoutShopSavedIndexRoute = LayoutShopSavedIndexImport.update({
   id: '/shop/saved/',
   path: '/shop/saved/',
   getParentRoute: () => LayoutRoute,
 } as any)
-const LayoutPoliciesTosIndexRoute = LayoutPoliciesTosIndexRouteImport.update({
+
+const LayoutPoliciesTosIndexRoute = LayoutPoliciesTosIndexImport.update({
   id: '/policies/tos/',
   path: '/policies/tos/',
   getParentRoute: () => LayoutRoute,
 } as any)
-const LayoutPoliciesPrivacyIndexRoute =
-  LayoutPoliciesPrivacyIndexRouteImport.update({
+
+const LayoutPoliciesPrivacyIndexRoute = LayoutPoliciesPrivacyIndexImport.update(
+  {
     id: '/policies/privacy/',
     path: '/policies/privacy/',
     getParentRoute: () => LayoutRoute,
-  } as any)
+  } as any,
+)
+
 const LayoutPoliciesDeliveryReturnsExchangesIndexRoute =
-  LayoutPoliciesDeliveryReturnsExchangesIndexRouteImport.update({
+  LayoutPoliciesDeliveryReturnsExchangesIndexImport.update({
     id: '/policies/delivery-returns-exchanges/',
     path: '/policies/delivery-returns-exchanges/',
     getParentRoute: () => LayoutRoute,
   } as any)
+
 const ShopCheckoutSessionIdSlugIncompleteRoute =
-  ShopCheckoutSessionIdSlugIncompleteRouteImport.update({
+  ShopCheckoutSessionIdSlugIncompleteImport.update({
     id: '/shop/checkout/$sessionIdSlug/incomplete',
     path: '/shop/checkout/$sessionIdSlug/incomplete',
-    getParentRoute: () => rootRouteImport,
+    getParentRoute: () => rootRoute,
   } as any)
+
 const ShopCheckoutSessionIdSlugCompleteRoute =
-  ShopCheckoutSessionIdSlugCompleteRouteImport.update({
+  ShopCheckoutSessionIdSlugCompleteImport.update({
     id: '/shop/checkout/$sessionIdSlug/complete',
     path: '/shop/checkout/$sessionIdSlug/complete',
-    getParentRoute: () => rootRouteImport,
+    getParentRoute: () => rootRoute,
   } as any)
+
 const ShopCheckoutSessionIdSlugCanceledRoute =
-  ShopCheckoutSessionIdSlugCanceledRouteImport.update({
+  ShopCheckoutSessionIdSlugCanceledImport.update({
     id: '/shop/checkout/$sessionIdSlug/canceled',
     path: '/shop/checkout/$sessionIdSlug/canceled',
-    getParentRoute: () => rootRouteImport,
+    getParentRoute: () => rootRoute,
   } as any)
+
 const LayoutShopProductProductSlugRoute =
-  LayoutShopProductProductSlugRouteImport.update({
+  LayoutShopProductProductSlugImport.update({
     id: '/shop/product/$productSlug',
     path: '/shop/product/$productSlug',
     getParentRoute: () => LayoutRoute,
   } as any)
+
 const LayoutShopLayoutShopCategorySlugIndexRoute =
-  LayoutShopLayoutShopCategorySlugIndexRouteImport.update({
+  LayoutShopLayoutShopCategorySlugIndexImport.update({
     id: '/shop/$categorySlug/',
     path: '/shop/$categorySlug/',
     getParentRoute: () => LayoutShopLayoutRoute,
   } as any)
+
 const LayoutOrdersLayoutShopOrdersIndexRoute =
-  LayoutOrdersLayoutShopOrdersIndexRouteImport.update({
+  LayoutOrdersLayoutShopOrdersIndexImport.update({
     id: '/shop/orders/',
     path: '/shop/orders/',
     getParentRoute: () => LayoutOrdersLayoutRoute,
   } as any)
+
 const LayoutShopLayoutShopCategorySlugSubcategorySlugRoute =
-  LayoutShopLayoutShopCategorySlugSubcategorySlugRouteImport.update({
+  LayoutShopLayoutShopCategorySlugSubcategorySlugImport.update({
     id: '/shop/$categorySlug/$subcategorySlug',
     path: '/shop/$categorySlug/$subcategorySlug',
     getParentRoute: () => LayoutShopLayoutRoute,
   } as any)
+
 const LayoutOrdersLayoutShopOrdersOrderIdIndexRoute =
-  LayoutOrdersLayoutShopOrdersOrderIdIndexRouteImport.update({
+  LayoutOrdersLayoutShopOrdersOrderIdIndexImport.update({
     id: '/shop/orders/$orderId/',
     path: '/shop/orders/$orderId/',
     getParentRoute: () => LayoutOrdersLayoutRoute,
   } as any)
+
 const LayoutOrdersLayoutShopOrdersOrderIdReviewRoute =
-  LayoutOrdersLayoutShopOrdersOrderIdReviewRouteImport.update({
+  LayoutOrdersLayoutShopOrdersOrderIdReviewImport.update({
     id: '/shop/orders/$orderId/review',
     path: '/shop/orders/$orderId/review',
     getParentRoute: () => LayoutOrdersLayoutRoute,
   } as any)
+
 const LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRoute =
-  LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRouteImport.update({
+  LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewImport.update({
     id: '/shop/orders/$orderId/$orderItemId/review',
     path: '/shop/orders/$orderId/$orderItemId/review',
     getParentRoute: () => LayoutOrdersLayoutRoute,
   } as any)
 
-export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/login': typeof LoginRoute
-  '/signup': typeof SignupRoute
-  '/account': typeof LayoutAccountRoute
-  '/contact-us': typeof LayoutContactUsRoute
-  '/auth/verify': typeof AuthVerifyRoute
-  '/shop/checkout/pending': typeof ShopCheckoutPendingRoute
-  '/shop/checkout/pod-confirmation': typeof ShopCheckoutPodConfirmationRoute
-  '/rewards/': typeof LayoutRewardsIndexRoute
-  '/shop/bag/': typeof ShopBagIndexRoute
-  '/shop/checkout/': typeof ShopCheckoutIndexRoute
-  '/shop/product/$productSlug': typeof LayoutShopProductProductSlugRoute
-  '/shop/checkout/$sessionIdSlug/canceled': typeof ShopCheckoutSessionIdSlugCanceledRoute
-  '/shop/checkout/$sessionIdSlug/complete': typeof ShopCheckoutSessionIdSlugCompleteRoute
-  '/shop/checkout/$sessionIdSlug/incomplete': typeof ShopCheckoutSessionIdSlugIncompleteRoute
-  '/policies/delivery-returns-exchanges/': typeof LayoutPoliciesDeliveryReturnsExchangesIndexRoute
-  '/policies/privacy/': typeof LayoutPoliciesPrivacyIndexRoute
-  '/policies/tos/': typeof LayoutPoliciesTosIndexRoute
-  '/shop/saved/': typeof LayoutShopSavedIndexRoute
-  '/shop/checkout/$sessionIdSlug/': typeof ShopCheckoutSessionIdSlugIndexRoute
-  '/shop/checkout/complete/': typeof ShopCheckoutCompleteIndexRoute
-  '/shop/checkout/verify/': typeof ShopCheckoutVerifyIndexRoute
-  '/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
-  '/shop/orders/': typeof LayoutOrdersLayoutShopOrdersIndexRoute
-  '/shop/$categorySlug/': typeof LayoutShopLayoutShopCategorySlugIndexRoute
-  '/shop/orders/$orderId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdReviewRoute
-  '/shop/orders/$orderId/': typeof LayoutOrdersLayoutShopOrdersOrderIdIndexRoute
-  '/shop/orders/$orderId/$orderItemId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRoute
-}
-export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/login': typeof LoginRoute
-  '/signup': typeof SignupRoute
-  '/account': typeof LayoutAccountRoute
-  '/contact-us': typeof LayoutContactUsRoute
-  '/auth/verify': typeof AuthVerifyRoute
-  '/shop/checkout/pending': typeof ShopCheckoutPendingRoute
-  '/shop/checkout/pod-confirmation': typeof ShopCheckoutPodConfirmationRoute
-  '/rewards': typeof LayoutRewardsIndexRoute
-  '/shop/bag': typeof ShopBagIndexRoute
-  '/shop/checkout': typeof ShopCheckoutIndexRoute
-  '/shop/product/$productSlug': typeof LayoutShopProductProductSlugRoute
-  '/shop/checkout/$sessionIdSlug/canceled': typeof ShopCheckoutSessionIdSlugCanceledRoute
-  '/shop/checkout/$sessionIdSlug/complete': typeof ShopCheckoutSessionIdSlugCompleteRoute
-  '/shop/checkout/$sessionIdSlug/incomplete': typeof ShopCheckoutSessionIdSlugIncompleteRoute
-  '/policies/delivery-returns-exchanges': typeof LayoutPoliciesDeliveryReturnsExchangesIndexRoute
-  '/policies/privacy': typeof LayoutPoliciesPrivacyIndexRoute
-  '/policies/tos': typeof LayoutPoliciesTosIndexRoute
-  '/shop/saved': typeof LayoutShopSavedIndexRoute
-  '/shop/checkout/$sessionIdSlug': typeof ShopCheckoutSessionIdSlugIndexRoute
-  '/shop/checkout/complete': typeof ShopCheckoutCompleteIndexRoute
-  '/shop/checkout/verify': typeof ShopCheckoutVerifyIndexRoute
-  '/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
-  '/shop/orders': typeof LayoutOrdersLayoutShopOrdersIndexRoute
-  '/shop/$categorySlug': typeof LayoutShopLayoutShopCategorySlugIndexRoute
-  '/shop/orders/$orderId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdReviewRoute
-  '/shop/orders/$orderId': typeof LayoutOrdersLayoutShopOrdersOrderIdIndexRoute
-  '/shop/orders/$orderId/$orderItemId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRoute
-}
-export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/_layout': typeof LayoutRouteWithChildren
-  '/login': typeof LoginRoute
-  '/signup': typeof SignupRoute
-  '/_layout/_ordersLayout': typeof LayoutOrdersLayoutRouteWithChildren
-  '/_layout/_shopLayout': typeof LayoutShopLayoutRouteWithChildren
-  '/_layout/account': typeof LayoutAccountRoute
-  '/_layout/contact-us': typeof LayoutContactUsRoute
-  '/auth/verify': typeof AuthVerifyRoute
-  '/shop/checkout/pending': typeof ShopCheckoutPendingRoute
-  '/shop/checkout/pod-confirmation': typeof ShopCheckoutPodConfirmationRoute
-  '/_layout/rewards/': typeof LayoutRewardsIndexRoute
-  '/shop/bag/': typeof ShopBagIndexRoute
-  '/shop/checkout/': typeof ShopCheckoutIndexRoute
-  '/_layout/shop/product/$productSlug': typeof LayoutShopProductProductSlugRoute
-  '/shop/checkout/$sessionIdSlug/canceled': typeof ShopCheckoutSessionIdSlugCanceledRoute
-  '/shop/checkout/$sessionIdSlug/complete': typeof ShopCheckoutSessionIdSlugCompleteRoute
-  '/shop/checkout/$sessionIdSlug/incomplete': typeof ShopCheckoutSessionIdSlugIncompleteRoute
-  '/_layout/policies/delivery-returns-exchanges/': typeof LayoutPoliciesDeliveryReturnsExchangesIndexRoute
-  '/_layout/policies/privacy/': typeof LayoutPoliciesPrivacyIndexRoute
-  '/_layout/policies/tos/': typeof LayoutPoliciesTosIndexRoute
-  '/_layout/shop/saved/': typeof LayoutShopSavedIndexRoute
-  '/shop/checkout/$sessionIdSlug/': typeof ShopCheckoutSessionIdSlugIndexRoute
-  '/shop/checkout/complete/': typeof ShopCheckoutCompleteIndexRoute
-  '/shop/checkout/verify/': typeof ShopCheckoutVerifyIndexRoute
-  '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
-  '/_layout/_ordersLayout/shop/orders/': typeof LayoutOrdersLayoutShopOrdersIndexRoute
-  '/_layout/_shopLayout/shop/$categorySlug/': typeof LayoutShopLayoutShopCategorySlugIndexRoute
-  '/_layout/_ordersLayout/shop/orders/$orderId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdReviewRoute
-  '/_layout/_ordersLayout/shop/orders/$orderId/': typeof LayoutOrdersLayoutShopOrdersOrderIdIndexRoute
-  '/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRoute
-}
-export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/login'
-    | '/signup'
-    | '/account'
-    | '/contact-us'
-    | '/auth/verify'
-    | '/shop/checkout/pending'
-    | '/shop/checkout/pod-confirmation'
-    | '/rewards/'
-    | '/shop/bag/'
-    | '/shop/checkout/'
-    | '/shop/product/$productSlug'
-    | '/shop/checkout/$sessionIdSlug/canceled'
-    | '/shop/checkout/$sessionIdSlug/complete'
-    | '/shop/checkout/$sessionIdSlug/incomplete'
-    | '/policies/delivery-returns-exchanges/'
-    | '/policies/privacy/'
-    | '/policies/tos/'
-    | '/shop/saved/'
-    | '/shop/checkout/$sessionIdSlug/'
-    | '/shop/checkout/complete/'
-    | '/shop/checkout/verify/'
-    | '/shop/$categorySlug/$subcategorySlug'
-    | '/shop/orders/'
-    | '/shop/$categorySlug/'
-    | '/shop/orders/$orderId/review'
-    | '/shop/orders/$orderId/'
-    | '/shop/orders/$orderId/$orderItemId/review'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/login'
-    | '/signup'
-    | '/account'
-    | '/contact-us'
-    | '/auth/verify'
-    | '/shop/checkout/pending'
-    | '/shop/checkout/pod-confirmation'
-    | '/rewards'
-    | '/shop/bag'
-    | '/shop/checkout'
-    | '/shop/product/$productSlug'
-    | '/shop/checkout/$sessionIdSlug/canceled'
-    | '/shop/checkout/$sessionIdSlug/complete'
-    | '/shop/checkout/$sessionIdSlug/incomplete'
-    | '/policies/delivery-returns-exchanges'
-    | '/policies/privacy'
-    | '/policies/tos'
-    | '/shop/saved'
-    | '/shop/checkout/$sessionIdSlug'
-    | '/shop/checkout/complete'
-    | '/shop/checkout/verify'
-    | '/shop/$categorySlug/$subcategorySlug'
-    | '/shop/orders'
-    | '/shop/$categorySlug'
-    | '/shop/orders/$orderId/review'
-    | '/shop/orders/$orderId'
-    | '/shop/orders/$orderId/$orderItemId/review'
-  id:
-    | '__root__'
-    | '/'
-    | '/_layout'
-    | '/login'
-    | '/signup'
-    | '/_layout/_ordersLayout'
-    | '/_layout/_shopLayout'
-    | '/_layout/account'
-    | '/_layout/contact-us'
-    | '/auth/verify'
-    | '/shop/checkout/pending'
-    | '/shop/checkout/pod-confirmation'
-    | '/_layout/rewards/'
-    | '/shop/bag/'
-    | '/shop/checkout/'
-    | '/_layout/shop/product/$productSlug'
-    | '/shop/checkout/$sessionIdSlug/canceled'
-    | '/shop/checkout/$sessionIdSlug/complete'
-    | '/shop/checkout/$sessionIdSlug/incomplete'
-    | '/_layout/policies/delivery-returns-exchanges/'
-    | '/_layout/policies/privacy/'
-    | '/_layout/policies/tos/'
-    | '/_layout/shop/saved/'
-    | '/shop/checkout/$sessionIdSlug/'
-    | '/shop/checkout/complete/'
-    | '/shop/checkout/verify/'
-    | '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug'
-    | '/_layout/_ordersLayout/shop/orders/'
-    | '/_layout/_shopLayout/shop/$categorySlug/'
-    | '/_layout/_ordersLayout/shop/orders/$orderId/review'
-    | '/_layout/_ordersLayout/shop/orders/$orderId/'
-    | '/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review'
-  fileRoutesById: FileRoutesById
-}
-export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  LayoutRoute: typeof LayoutRouteWithChildren
-  LoginRoute: typeof LoginRoute
-  SignupRoute: typeof SignupRoute
-  AuthVerifyRoute: typeof AuthVerifyRoute
-  ShopCheckoutPendingRoute: typeof ShopCheckoutPendingRoute
-  ShopCheckoutPodConfirmationRoute: typeof ShopCheckoutPodConfirmationRoute
-  ShopBagIndexRoute: typeof ShopBagIndexRoute
-  ShopCheckoutIndexRoute: typeof ShopCheckoutIndexRoute
-  ShopCheckoutSessionIdSlugCanceledRoute: typeof ShopCheckoutSessionIdSlugCanceledRoute
-  ShopCheckoutSessionIdSlugCompleteRoute: typeof ShopCheckoutSessionIdSlugCompleteRoute
-  ShopCheckoutSessionIdSlugIncompleteRoute: typeof ShopCheckoutSessionIdSlugIncompleteRoute
-  ShopCheckoutSessionIdSlugIndexRoute: typeof ShopCheckoutSessionIdSlugIndexRoute
-  ShopCheckoutCompleteIndexRoute: typeof ShopCheckoutCompleteIndexRoute
-  ShopCheckoutVerifyIndexRoute: typeof ShopCheckoutVerifyIndexRoute
-}
+// Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/signup': {
-      id: '/signup'
-      path: '/signup'
-      fullPath: '/signup'
-      preLoaderRoute: typeof SignupRouteImport
-      parentRoute: typeof rootRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/_layout': {
+      id: '/_layout'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof LayoutImport
+      parentRoute: typeof rootRoute
     }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
+      preLoaderRoute: typeof LoginImport
+      parentRoute: typeof rootRoute
     }
-    '/_layout': {
-      id: '/_layout'
+    '/signup': {
+      id: '/signup'
+      path: '/signup'
+      fullPath: '/signup'
+      preLoaderRoute: typeof SignupImport
+      parentRoute: typeof rootRoute
+    }
+    '/_layout/_ordersLayout': {
+      id: '/_layout/_ordersLayout'
       path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: ''
+      preLoaderRoute: typeof LayoutOrdersLayoutImport
+      parentRoute: typeof LayoutImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/auth/verify': {
-      id: '/auth/verify'
-      path: '/auth/verify'
-      fullPath: '/auth/verify'
-      preLoaderRoute: typeof AuthVerifyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout/contact-us': {
-      id: '/_layout/contact-us'
-      path: '/contact-us'
-      fullPath: '/contact-us'
-      preLoaderRoute: typeof LayoutContactUsRouteImport
-      parentRoute: typeof LayoutRoute
+    '/_layout/_shopLayout': {
+      id: '/_layout/_shopLayout'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof LayoutShopLayoutImport
+      parentRoute: typeof LayoutImport
     }
     '/_layout/account': {
       id: '/_layout/account'
       path: '/account'
       fullPath: '/account'
-      preLoaderRoute: typeof LayoutAccountRouteImport
-      parentRoute: typeof LayoutRoute
+      preLoaderRoute: typeof LayoutAccountImport
+      parentRoute: typeof LayoutImport
     }
-    '/_layout/_shopLayout': {
-      id: '/_layout/_shopLayout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutShopLayoutRouteImport
-      parentRoute: typeof LayoutRoute
+    '/_layout/contact-us': {
+      id: '/_layout/contact-us'
+      path: '/contact-us'
+      fullPath: '/contact-us'
+      preLoaderRoute: typeof LayoutContactUsImport
+      parentRoute: typeof LayoutImport
     }
-    '/_layout/_ordersLayout': {
-      id: '/_layout/_ordersLayout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutOrdersLayoutRouteImport
-      parentRoute: typeof LayoutRoute
-    }
-    '/shop/checkout/': {
-      id: '/shop/checkout/'
-      path: '/shop/checkout'
-      fullPath: '/shop/checkout/'
-      preLoaderRoute: typeof ShopCheckoutIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/shop/bag/': {
-      id: '/shop/bag/'
-      path: '/shop/bag'
-      fullPath: '/shop/bag/'
-      preLoaderRoute: typeof ShopBagIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout/rewards/': {
-      id: '/_layout/rewards/'
-      path: '/rewards'
-      fullPath: '/rewards/'
-      preLoaderRoute: typeof LayoutRewardsIndexRouteImport
-      parentRoute: typeof LayoutRoute
-    }
-    '/shop/checkout/pod-confirmation': {
-      id: '/shop/checkout/pod-confirmation'
-      path: '/shop/checkout/pod-confirmation'
-      fullPath: '/shop/checkout/pod-confirmation'
-      preLoaderRoute: typeof ShopCheckoutPodConfirmationRouteImport
-      parentRoute: typeof rootRouteImport
+    '/auth/verify': {
+      id: '/auth/verify'
+      path: '/auth/verify'
+      fullPath: '/auth/verify'
+      preLoaderRoute: typeof AuthVerifyImport
+      parentRoute: typeof rootRoute
     }
     '/shop/checkout/pending': {
       id: '/shop/checkout/pending'
       path: '/shop/checkout/pending'
       fullPath: '/shop/checkout/pending'
-      preLoaderRoute: typeof ShopCheckoutPendingRouteImport
-      parentRoute: typeof rootRouteImport
+      preLoaderRoute: typeof ShopCheckoutPendingImport
+      parentRoute: typeof rootRoute
     }
-    '/shop/checkout/verify/': {
-      id: '/shop/checkout/verify/'
-      path: '/shop/checkout/verify'
-      fullPath: '/shop/checkout/verify/'
-      preLoaderRoute: typeof ShopCheckoutVerifyIndexRouteImport
-      parentRoute: typeof rootRouteImport
+    '/shop/checkout/pod-confirmation': {
+      id: '/shop/checkout/pod-confirmation'
+      path: '/shop/checkout/pod-confirmation'
+      fullPath: '/shop/checkout/pod-confirmation'
+      preLoaderRoute: typeof ShopCheckoutPodConfirmationImport
+      parentRoute: typeof rootRoute
     }
-    '/shop/checkout/complete/': {
-      id: '/shop/checkout/complete/'
-      path: '/shop/checkout/complete'
-      fullPath: '/shop/checkout/complete/'
-      preLoaderRoute: typeof ShopCheckoutCompleteIndexRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_layout/rewards/': {
+      id: '/_layout/rewards/'
+      path: '/rewards'
+      fullPath: '/rewards'
+      preLoaderRoute: typeof LayoutRewardsIndexImport
+      parentRoute: typeof LayoutImport
     }
-    '/shop/checkout/$sessionIdSlug/': {
-      id: '/shop/checkout/$sessionIdSlug/'
-      path: '/shop/checkout/$sessionIdSlug'
-      fullPath: '/shop/checkout/$sessionIdSlug/'
-      preLoaderRoute: typeof ShopCheckoutSessionIdSlugIndexRouteImport
-      parentRoute: typeof rootRouteImport
+    '/shop/bag/': {
+      id: '/shop/bag/'
+      path: '/shop/bag'
+      fullPath: '/shop/bag'
+      preLoaderRoute: typeof ShopBagIndexImport
+      parentRoute: typeof rootRoute
     }
-    '/_layout/shop/saved/': {
-      id: '/_layout/shop/saved/'
-      path: '/shop/saved'
-      fullPath: '/shop/saved/'
-      preLoaderRoute: typeof LayoutShopSavedIndexRouteImport
-      parentRoute: typeof LayoutRoute
-    }
-    '/_layout/policies/tos/': {
-      id: '/_layout/policies/tos/'
-      path: '/policies/tos'
-      fullPath: '/policies/tos/'
-      preLoaderRoute: typeof LayoutPoliciesTosIndexRouteImport
-      parentRoute: typeof LayoutRoute
-    }
-    '/_layout/policies/privacy/': {
-      id: '/_layout/policies/privacy/'
-      path: '/policies/privacy'
-      fullPath: '/policies/privacy/'
-      preLoaderRoute: typeof LayoutPoliciesPrivacyIndexRouteImport
-      parentRoute: typeof LayoutRoute
-    }
-    '/_layout/policies/delivery-returns-exchanges/': {
-      id: '/_layout/policies/delivery-returns-exchanges/'
-      path: '/policies/delivery-returns-exchanges'
-      fullPath: '/policies/delivery-returns-exchanges/'
-      preLoaderRoute: typeof LayoutPoliciesDeliveryReturnsExchangesIndexRouteImport
-      parentRoute: typeof LayoutRoute
-    }
-    '/shop/checkout/$sessionIdSlug/incomplete': {
-      id: '/shop/checkout/$sessionIdSlug/incomplete'
-      path: '/shop/checkout/$sessionIdSlug/incomplete'
-      fullPath: '/shop/checkout/$sessionIdSlug/incomplete'
-      preLoaderRoute: typeof ShopCheckoutSessionIdSlugIncompleteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/shop/checkout/$sessionIdSlug/complete': {
-      id: '/shop/checkout/$sessionIdSlug/complete'
-      path: '/shop/checkout/$sessionIdSlug/complete'
-      fullPath: '/shop/checkout/$sessionIdSlug/complete'
-      preLoaderRoute: typeof ShopCheckoutSessionIdSlugCompleteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/shop/checkout/$sessionIdSlug/canceled': {
-      id: '/shop/checkout/$sessionIdSlug/canceled'
-      path: '/shop/checkout/$sessionIdSlug/canceled'
-      fullPath: '/shop/checkout/$sessionIdSlug/canceled'
-      preLoaderRoute: typeof ShopCheckoutSessionIdSlugCanceledRouteImport
-      parentRoute: typeof rootRouteImport
+    '/shop/checkout/': {
+      id: '/shop/checkout/'
+      path: '/shop/checkout'
+      fullPath: '/shop/checkout'
+      preLoaderRoute: typeof ShopCheckoutIndexImport
+      parentRoute: typeof rootRoute
     }
     '/_layout/shop/product/$productSlug': {
       id: '/_layout/shop/product/$productSlug'
       path: '/shop/product/$productSlug'
       fullPath: '/shop/product/$productSlug'
-      preLoaderRoute: typeof LayoutShopProductProductSlugRouteImport
-      parentRoute: typeof LayoutRoute
+      preLoaderRoute: typeof LayoutShopProductProductSlugImport
+      parentRoute: typeof LayoutImport
     }
-    '/_layout/_shopLayout/shop/$categorySlug/': {
-      id: '/_layout/_shopLayout/shop/$categorySlug/'
-      path: '/shop/$categorySlug'
-      fullPath: '/shop/$categorySlug/'
-      preLoaderRoute: typeof LayoutShopLayoutShopCategorySlugIndexRouteImport
-      parentRoute: typeof LayoutShopLayoutRoute
+    '/shop/checkout/$sessionIdSlug/canceled': {
+      id: '/shop/checkout/$sessionIdSlug/canceled'
+      path: '/shop/checkout/$sessionIdSlug/canceled'
+      fullPath: '/shop/checkout/$sessionIdSlug/canceled'
+      preLoaderRoute: typeof ShopCheckoutSessionIdSlugCanceledImport
+      parentRoute: typeof rootRoute
     }
-    '/_layout/_ordersLayout/shop/orders/': {
-      id: '/_layout/_ordersLayout/shop/orders/'
-      path: '/shop/orders'
-      fullPath: '/shop/orders/'
-      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersIndexRouteImport
-      parentRoute: typeof LayoutOrdersLayoutRoute
+    '/shop/checkout/$sessionIdSlug/complete': {
+      id: '/shop/checkout/$sessionIdSlug/complete'
+      path: '/shop/checkout/$sessionIdSlug/complete'
+      fullPath: '/shop/checkout/$sessionIdSlug/complete'
+      preLoaderRoute: typeof ShopCheckoutSessionIdSlugCompleteImport
+      parentRoute: typeof rootRoute
+    }
+    '/shop/checkout/$sessionIdSlug/incomplete': {
+      id: '/shop/checkout/$sessionIdSlug/incomplete'
+      path: '/shop/checkout/$sessionIdSlug/incomplete'
+      fullPath: '/shop/checkout/$sessionIdSlug/incomplete'
+      preLoaderRoute: typeof ShopCheckoutSessionIdSlugIncompleteImport
+      parentRoute: typeof rootRoute
+    }
+    '/_layout/policies/delivery-returns-exchanges/': {
+      id: '/_layout/policies/delivery-returns-exchanges/'
+      path: '/policies/delivery-returns-exchanges'
+      fullPath: '/policies/delivery-returns-exchanges'
+      preLoaderRoute: typeof LayoutPoliciesDeliveryReturnsExchangesIndexImport
+      parentRoute: typeof LayoutImport
+    }
+    '/_layout/policies/privacy/': {
+      id: '/_layout/policies/privacy/'
+      path: '/policies/privacy'
+      fullPath: '/policies/privacy'
+      preLoaderRoute: typeof LayoutPoliciesPrivacyIndexImport
+      parentRoute: typeof LayoutImport
+    }
+    '/_layout/policies/tos/': {
+      id: '/_layout/policies/tos/'
+      path: '/policies/tos'
+      fullPath: '/policies/tos'
+      preLoaderRoute: typeof LayoutPoliciesTosIndexImport
+      parentRoute: typeof LayoutImport
+    }
+    '/_layout/shop/saved/': {
+      id: '/_layout/shop/saved/'
+      path: '/shop/saved'
+      fullPath: '/shop/saved'
+      preLoaderRoute: typeof LayoutShopSavedIndexImport
+      parentRoute: typeof LayoutImport
+    }
+    '/shop/checkout/$sessionIdSlug/': {
+      id: '/shop/checkout/$sessionIdSlug/'
+      path: '/shop/checkout/$sessionIdSlug'
+      fullPath: '/shop/checkout/$sessionIdSlug'
+      preLoaderRoute: typeof ShopCheckoutSessionIdSlugIndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/shop/checkout/complete/': {
+      id: '/shop/checkout/complete/'
+      path: '/shop/checkout/complete'
+      fullPath: '/shop/checkout/complete'
+      preLoaderRoute: typeof ShopCheckoutCompleteIndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/shop/checkout/verify/': {
+      id: '/shop/checkout/verify/'
+      path: '/shop/checkout/verify'
+      fullPath: '/shop/checkout/verify'
+      preLoaderRoute: typeof ShopCheckoutVerifyIndexImport
+      parentRoute: typeof rootRoute
     }
     '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug': {
       id: '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug'
       path: '/shop/$categorySlug/$subcategorySlug'
       fullPath: '/shop/$categorySlug/$subcategorySlug'
-      preLoaderRoute: typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRouteImport
-      parentRoute: typeof LayoutShopLayoutRoute
+      preLoaderRoute: typeof LayoutShopLayoutShopCategorySlugSubcategorySlugImport
+      parentRoute: typeof LayoutShopLayoutImport
     }
-    '/_layout/_ordersLayout/shop/orders/$orderId/': {
-      id: '/_layout/_ordersLayout/shop/orders/$orderId/'
-      path: '/shop/orders/$orderId'
-      fullPath: '/shop/orders/$orderId/'
-      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersOrderIdIndexRouteImport
-      parentRoute: typeof LayoutOrdersLayoutRoute
+    '/_layout/_ordersLayout/shop/orders/': {
+      id: '/_layout/_ordersLayout/shop/orders/'
+      path: '/shop/orders'
+      fullPath: '/shop/orders'
+      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersIndexImport
+      parentRoute: typeof LayoutOrdersLayoutImport
+    }
+    '/_layout/_shopLayout/shop/$categorySlug/': {
+      id: '/_layout/_shopLayout/shop/$categorySlug/'
+      path: '/shop/$categorySlug'
+      fullPath: '/shop/$categorySlug'
+      preLoaderRoute: typeof LayoutShopLayoutShopCategorySlugIndexImport
+      parentRoute: typeof LayoutShopLayoutImport
     }
     '/_layout/_ordersLayout/shop/orders/$orderId/review': {
       id: '/_layout/_ordersLayout/shop/orders/$orderId/review'
       path: '/shop/orders/$orderId/review'
       fullPath: '/shop/orders/$orderId/review'
-      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersOrderIdReviewRouteImport
-      parentRoute: typeof LayoutOrdersLayoutRoute
+      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersOrderIdReviewImport
+      parentRoute: typeof LayoutOrdersLayoutImport
+    }
+    '/_layout/_ordersLayout/shop/orders/$orderId/': {
+      id: '/_layout/_ordersLayout/shop/orders/$orderId/'
+      path: '/shop/orders/$orderId'
+      fullPath: '/shop/orders/$orderId'
+      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersOrderIdIndexImport
+      parentRoute: typeof LayoutOrdersLayoutImport
     }
     '/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review': {
       id: '/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review'
       path: '/shop/orders/$orderId/$orderItemId/review'
       fullPath: '/shop/orders/$orderId/$orderItemId/review'
-      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRouteImport
-      parentRoute: typeof LayoutOrdersLayoutRoute
+      preLoaderRoute: typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewImport
+      parentRoute: typeof LayoutOrdersLayoutImport
     }
   }
 }
+
+// Create and export the route tree
 
 interface LayoutOrdersLayoutRouteChildren {
   LayoutOrdersLayoutShopOrdersIndexRoute: typeof LayoutOrdersLayoutShopOrdersIndexRoute
@@ -705,6 +535,222 @@ const LayoutRouteChildren: LayoutRouteChildren = {
 const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
 
+export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '': typeof LayoutShopLayoutRouteWithChildren
+  '/login': typeof LoginRoute
+  '/signup': typeof SignupRoute
+  '/account': typeof LayoutAccountRoute
+  '/contact-us': typeof LayoutContactUsRoute
+  '/auth/verify': typeof AuthVerifyRoute
+  '/shop/checkout/pending': typeof ShopCheckoutPendingRoute
+  '/shop/checkout/pod-confirmation': typeof ShopCheckoutPodConfirmationRoute
+  '/rewards': typeof LayoutRewardsIndexRoute
+  '/shop/bag': typeof ShopBagIndexRoute
+  '/shop/checkout': typeof ShopCheckoutIndexRoute
+  '/shop/product/$productSlug': typeof LayoutShopProductProductSlugRoute
+  '/shop/checkout/$sessionIdSlug/canceled': typeof ShopCheckoutSessionIdSlugCanceledRoute
+  '/shop/checkout/$sessionIdSlug/complete': typeof ShopCheckoutSessionIdSlugCompleteRoute
+  '/shop/checkout/$sessionIdSlug/incomplete': typeof ShopCheckoutSessionIdSlugIncompleteRoute
+  '/policies/delivery-returns-exchanges': typeof LayoutPoliciesDeliveryReturnsExchangesIndexRoute
+  '/policies/privacy': typeof LayoutPoliciesPrivacyIndexRoute
+  '/policies/tos': typeof LayoutPoliciesTosIndexRoute
+  '/shop/saved': typeof LayoutShopSavedIndexRoute
+  '/shop/checkout/$sessionIdSlug': typeof ShopCheckoutSessionIdSlugIndexRoute
+  '/shop/checkout/complete': typeof ShopCheckoutCompleteIndexRoute
+  '/shop/checkout/verify': typeof ShopCheckoutVerifyIndexRoute
+  '/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
+  '/shop/orders': typeof LayoutOrdersLayoutShopOrdersIndexRoute
+  '/shop/$categorySlug': typeof LayoutShopLayoutShopCategorySlugIndexRoute
+  '/shop/orders/$orderId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdReviewRoute
+  '/shop/orders/$orderId': typeof LayoutOrdersLayoutShopOrdersOrderIdIndexRoute
+  '/shop/orders/$orderId/$orderItemId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRoute
+}
+
+export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '': typeof LayoutShopLayoutRouteWithChildren
+  '/login': typeof LoginRoute
+  '/signup': typeof SignupRoute
+  '/account': typeof LayoutAccountRoute
+  '/contact-us': typeof LayoutContactUsRoute
+  '/auth/verify': typeof AuthVerifyRoute
+  '/shop/checkout/pending': typeof ShopCheckoutPendingRoute
+  '/shop/checkout/pod-confirmation': typeof ShopCheckoutPodConfirmationRoute
+  '/rewards': typeof LayoutRewardsIndexRoute
+  '/shop/bag': typeof ShopBagIndexRoute
+  '/shop/checkout': typeof ShopCheckoutIndexRoute
+  '/shop/product/$productSlug': typeof LayoutShopProductProductSlugRoute
+  '/shop/checkout/$sessionIdSlug/canceled': typeof ShopCheckoutSessionIdSlugCanceledRoute
+  '/shop/checkout/$sessionIdSlug/complete': typeof ShopCheckoutSessionIdSlugCompleteRoute
+  '/shop/checkout/$sessionIdSlug/incomplete': typeof ShopCheckoutSessionIdSlugIncompleteRoute
+  '/policies/delivery-returns-exchanges': typeof LayoutPoliciesDeliveryReturnsExchangesIndexRoute
+  '/policies/privacy': typeof LayoutPoliciesPrivacyIndexRoute
+  '/policies/tos': typeof LayoutPoliciesTosIndexRoute
+  '/shop/saved': typeof LayoutShopSavedIndexRoute
+  '/shop/checkout/$sessionIdSlug': typeof ShopCheckoutSessionIdSlugIndexRoute
+  '/shop/checkout/complete': typeof ShopCheckoutCompleteIndexRoute
+  '/shop/checkout/verify': typeof ShopCheckoutVerifyIndexRoute
+  '/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
+  '/shop/orders': typeof LayoutOrdersLayoutShopOrdersIndexRoute
+  '/shop/$categorySlug': typeof LayoutShopLayoutShopCategorySlugIndexRoute
+  '/shop/orders/$orderId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdReviewRoute
+  '/shop/orders/$orderId': typeof LayoutOrdersLayoutShopOrdersOrderIdIndexRoute
+  '/shop/orders/$orderId/$orderItemId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRoute
+}
+
+export interface FileRoutesById {
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/_layout': typeof LayoutRouteWithChildren
+  '/login': typeof LoginRoute
+  '/signup': typeof SignupRoute
+  '/_layout/_ordersLayout': typeof LayoutOrdersLayoutRouteWithChildren
+  '/_layout/_shopLayout': typeof LayoutShopLayoutRouteWithChildren
+  '/_layout/account': typeof LayoutAccountRoute
+  '/_layout/contact-us': typeof LayoutContactUsRoute
+  '/auth/verify': typeof AuthVerifyRoute
+  '/shop/checkout/pending': typeof ShopCheckoutPendingRoute
+  '/shop/checkout/pod-confirmation': typeof ShopCheckoutPodConfirmationRoute
+  '/_layout/rewards/': typeof LayoutRewardsIndexRoute
+  '/shop/bag/': typeof ShopBagIndexRoute
+  '/shop/checkout/': typeof ShopCheckoutIndexRoute
+  '/_layout/shop/product/$productSlug': typeof LayoutShopProductProductSlugRoute
+  '/shop/checkout/$sessionIdSlug/canceled': typeof ShopCheckoutSessionIdSlugCanceledRoute
+  '/shop/checkout/$sessionIdSlug/complete': typeof ShopCheckoutSessionIdSlugCompleteRoute
+  '/shop/checkout/$sessionIdSlug/incomplete': typeof ShopCheckoutSessionIdSlugIncompleteRoute
+  '/_layout/policies/delivery-returns-exchanges/': typeof LayoutPoliciesDeliveryReturnsExchangesIndexRoute
+  '/_layout/policies/privacy/': typeof LayoutPoliciesPrivacyIndexRoute
+  '/_layout/policies/tos/': typeof LayoutPoliciesTosIndexRoute
+  '/_layout/shop/saved/': typeof LayoutShopSavedIndexRoute
+  '/shop/checkout/$sessionIdSlug/': typeof ShopCheckoutSessionIdSlugIndexRoute
+  '/shop/checkout/complete/': typeof ShopCheckoutCompleteIndexRoute
+  '/shop/checkout/verify/': typeof ShopCheckoutVerifyIndexRoute
+  '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
+  '/_layout/_ordersLayout/shop/orders/': typeof LayoutOrdersLayoutShopOrdersIndexRoute
+  '/_layout/_shopLayout/shop/$categorySlug/': typeof LayoutShopLayoutShopCategorySlugIndexRoute
+  '/_layout/_ordersLayout/shop/orders/$orderId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdReviewRoute
+  '/_layout/_ordersLayout/shop/orders/$orderId/': typeof LayoutOrdersLayoutShopOrdersOrderIdIndexRoute
+  '/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review': typeof LayoutOrdersLayoutShopOrdersOrderIdOrderItemIdReviewRoute
+}
+
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | ''
+    | '/login'
+    | '/signup'
+    | '/account'
+    | '/contact-us'
+    | '/auth/verify'
+    | '/shop/checkout/pending'
+    | '/shop/checkout/pod-confirmation'
+    | '/rewards'
+    | '/shop/bag'
+    | '/shop/checkout'
+    | '/shop/product/$productSlug'
+    | '/shop/checkout/$sessionIdSlug/canceled'
+    | '/shop/checkout/$sessionIdSlug/complete'
+    | '/shop/checkout/$sessionIdSlug/incomplete'
+    | '/policies/delivery-returns-exchanges'
+    | '/policies/privacy'
+    | '/policies/tos'
+    | '/shop/saved'
+    | '/shop/checkout/$sessionIdSlug'
+    | '/shop/checkout/complete'
+    | '/shop/checkout/verify'
+    | '/shop/$categorySlug/$subcategorySlug'
+    | '/shop/orders'
+    | '/shop/$categorySlug'
+    | '/shop/orders/$orderId/review'
+    | '/shop/orders/$orderId'
+    | '/shop/orders/$orderId/$orderItemId/review'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | ''
+    | '/login'
+    | '/signup'
+    | '/account'
+    | '/contact-us'
+    | '/auth/verify'
+    | '/shop/checkout/pending'
+    | '/shop/checkout/pod-confirmation'
+    | '/rewards'
+    | '/shop/bag'
+    | '/shop/checkout'
+    | '/shop/product/$productSlug'
+    | '/shop/checkout/$sessionIdSlug/canceled'
+    | '/shop/checkout/$sessionIdSlug/complete'
+    | '/shop/checkout/$sessionIdSlug/incomplete'
+    | '/policies/delivery-returns-exchanges'
+    | '/policies/privacy'
+    | '/policies/tos'
+    | '/shop/saved'
+    | '/shop/checkout/$sessionIdSlug'
+    | '/shop/checkout/complete'
+    | '/shop/checkout/verify'
+    | '/shop/$categorySlug/$subcategorySlug'
+    | '/shop/orders'
+    | '/shop/$categorySlug'
+    | '/shop/orders/$orderId/review'
+    | '/shop/orders/$orderId'
+    | '/shop/orders/$orderId/$orderItemId/review'
+  id:
+    | '__root__'
+    | '/'
+    | '/_layout'
+    | '/login'
+    | '/signup'
+    | '/_layout/_ordersLayout'
+    | '/_layout/_shopLayout'
+    | '/_layout/account'
+    | '/_layout/contact-us'
+    | '/auth/verify'
+    | '/shop/checkout/pending'
+    | '/shop/checkout/pod-confirmation'
+    | '/_layout/rewards/'
+    | '/shop/bag/'
+    | '/shop/checkout/'
+    | '/_layout/shop/product/$productSlug'
+    | '/shop/checkout/$sessionIdSlug/canceled'
+    | '/shop/checkout/$sessionIdSlug/complete'
+    | '/shop/checkout/$sessionIdSlug/incomplete'
+    | '/_layout/policies/delivery-returns-exchanges/'
+    | '/_layout/policies/privacy/'
+    | '/_layout/policies/tos/'
+    | '/_layout/shop/saved/'
+    | '/shop/checkout/$sessionIdSlug/'
+    | '/shop/checkout/complete/'
+    | '/shop/checkout/verify/'
+    | '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug'
+    | '/_layout/_ordersLayout/shop/orders/'
+    | '/_layout/_shopLayout/shop/$categorySlug/'
+    | '/_layout/_ordersLayout/shop/orders/$orderId/review'
+    | '/_layout/_ordersLayout/shop/orders/$orderId/'
+    | '/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review'
+  fileRoutesById: FileRoutesById
+}
+
+export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
+  LayoutRoute: typeof LayoutRouteWithChildren
+  LoginRoute: typeof LoginRoute
+  SignupRoute: typeof SignupRoute
+  AuthVerifyRoute: typeof AuthVerifyRoute
+  ShopCheckoutPendingRoute: typeof ShopCheckoutPendingRoute
+  ShopCheckoutPodConfirmationRoute: typeof ShopCheckoutPodConfirmationRoute
+  ShopBagIndexRoute: typeof ShopBagIndexRoute
+  ShopCheckoutIndexRoute: typeof ShopCheckoutIndexRoute
+  ShopCheckoutSessionIdSlugCanceledRoute: typeof ShopCheckoutSessionIdSlugCanceledRoute
+  ShopCheckoutSessionIdSlugCompleteRoute: typeof ShopCheckoutSessionIdSlugCompleteRoute
+  ShopCheckoutSessionIdSlugIncompleteRoute: typeof ShopCheckoutSessionIdSlugIncompleteRoute
+  ShopCheckoutSessionIdSlugIndexRoute: typeof ShopCheckoutSessionIdSlugIndexRoute
+  ShopCheckoutCompleteIndexRoute: typeof ShopCheckoutCompleteIndexRoute
+  ShopCheckoutVerifyIndexRoute: typeof ShopCheckoutVerifyIndexRoute
+}
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LayoutRoute: LayoutRouteWithChildren,
@@ -725,6 +771,165 @@ const rootRouteChildren: RootRouteChildren = {
   ShopCheckoutCompleteIndexRoute: ShopCheckoutCompleteIndexRoute,
   ShopCheckoutVerifyIndexRoute: ShopCheckoutVerifyIndexRoute,
 }
-export const routeTree = rootRouteImport
+
+export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/",
+        "/_layout",
+        "/login",
+        "/signup",
+        "/auth/verify",
+        "/shop/checkout/pending",
+        "/shop/checkout/pod-confirmation",
+        "/shop/bag/",
+        "/shop/checkout/",
+        "/shop/checkout/$sessionIdSlug/canceled",
+        "/shop/checkout/$sessionIdSlug/complete",
+        "/shop/checkout/$sessionIdSlug/incomplete",
+        "/shop/checkout/$sessionIdSlug/",
+        "/shop/checkout/complete/",
+        "/shop/checkout/verify/"
+      ]
+    },
+    "/": {
+      "filePath": "index.tsx"
+    },
+    "/_layout": {
+      "filePath": "_layout.tsx",
+      "children": [
+        "/_layout/_ordersLayout",
+        "/_layout/_shopLayout",
+        "/_layout/account",
+        "/_layout/contact-us",
+        "/_layout/rewards/",
+        "/_layout/shop/product/$productSlug",
+        "/_layout/policies/delivery-returns-exchanges/",
+        "/_layout/policies/privacy/",
+        "/_layout/policies/tos/",
+        "/_layout/shop/saved/"
+      ]
+    },
+    "/login": {
+      "filePath": "login.tsx"
+    },
+    "/signup": {
+      "filePath": "signup.tsx"
+    },
+    "/_layout/_ordersLayout": {
+      "filePath": "_layout/_ordersLayout.tsx",
+      "parent": "/_layout",
+      "children": [
+        "/_layout/_ordersLayout/shop/orders/",
+        "/_layout/_ordersLayout/shop/orders/$orderId/review",
+        "/_layout/_ordersLayout/shop/orders/$orderId/",
+        "/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review"
+      ]
+    },
+    "/_layout/_shopLayout": {
+      "filePath": "_layout/_shopLayout.tsx",
+      "parent": "/_layout",
+      "children": [
+        "/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug",
+        "/_layout/_shopLayout/shop/$categorySlug/"
+      ]
+    },
+    "/_layout/account": {
+      "filePath": "_layout/account.tsx",
+      "parent": "/_layout"
+    },
+    "/_layout/contact-us": {
+      "filePath": "_layout/contact-us.tsx",
+      "parent": "/_layout"
+    },
+    "/auth/verify": {
+      "filePath": "auth.verify.tsx"
+    },
+    "/shop/checkout/pending": {
+      "filePath": "shop/checkout/pending.tsx"
+    },
+    "/shop/checkout/pod-confirmation": {
+      "filePath": "shop/checkout/pod-confirmation.tsx"
+    },
+    "/_layout/rewards/": {
+      "filePath": "_layout/rewards.index.tsx",
+      "parent": "/_layout"
+    },
+    "/shop/bag/": {
+      "filePath": "shop/bag.index.tsx"
+    },
+    "/shop/checkout/": {
+      "filePath": "shop/checkout/index.tsx"
+    },
+    "/_layout/shop/product/$productSlug": {
+      "filePath": "_layout/shop.product.$productSlug.tsx",
+      "parent": "/_layout"
+    },
+    "/shop/checkout/$sessionIdSlug/canceled": {
+      "filePath": "shop/checkout/$sessionIdSlug/canceled.tsx"
+    },
+    "/shop/checkout/$sessionIdSlug/complete": {
+      "filePath": "shop/checkout/$sessionIdSlug/complete.tsx"
+    },
+    "/shop/checkout/$sessionIdSlug/incomplete": {
+      "filePath": "shop/checkout/$sessionIdSlug/incomplete.tsx"
+    },
+    "/_layout/policies/delivery-returns-exchanges/": {
+      "filePath": "_layout/policies/delivery-returns-exchanges.index.tsx",
+      "parent": "/_layout"
+    },
+    "/_layout/policies/privacy/": {
+      "filePath": "_layout/policies/privacy.index.tsx",
+      "parent": "/_layout"
+    },
+    "/_layout/policies/tos/": {
+      "filePath": "_layout/policies/tos.index.tsx",
+      "parent": "/_layout"
+    },
+    "/_layout/shop/saved/": {
+      "filePath": "_layout/shop.saved.index.tsx",
+      "parent": "/_layout"
+    },
+    "/shop/checkout/$sessionIdSlug/": {
+      "filePath": "shop/checkout/$sessionIdSlug/index.tsx"
+    },
+    "/shop/checkout/complete/": {
+      "filePath": "shop/checkout/complete.index.tsx"
+    },
+    "/shop/checkout/verify/": {
+      "filePath": "shop/checkout/verify.index.tsx"
+    },
+    "/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug": {
+      "filePath": "_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
+      "parent": "/_layout/_shopLayout"
+    },
+    "/_layout/_ordersLayout/shop/orders/": {
+      "filePath": "_layout/_ordersLayout/shop/orders/index.tsx",
+      "parent": "/_layout/_ordersLayout"
+    },
+    "/_layout/_shopLayout/shop/$categorySlug/": {
+      "filePath": "_layout/_shopLayout/shop/$categorySlug/index.tsx",
+      "parent": "/_layout/_shopLayout"
+    },
+    "/_layout/_ordersLayout/shop/orders/$orderId/review": {
+      "filePath": "_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "parent": "/_layout/_ordersLayout"
+    },
+    "/_layout/_ordersLayout/shop/orders/$orderId/": {
+      "filePath": "_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "parent": "/_layout/_ordersLayout"
+    },
+    "/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId/review": {
+      "filePath": "_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
+      "parent": "/_layout/_ordersLayout"
+    }
+  }
+}
+ROUTE_MANIFEST_END */


### PR DESCRIPTION
## Summary
- show hidden variants in product status component (handles both product+variant visibility)
- storefront product page now renders Not Found when product skus are hidden/none
- add tests for Athena product status and storefront product page hidden/empty-sku flows

## Validation
- pre-push validation suite passed locally
- vitest targeted tests for product status and product page scenarios cover both changes