### PR TITLE
Remove unused customer table

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1512 files · ~0 words
+- 1511 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3865 nodes · 3413 edges · 1427 communities detected
+- 3864 nodes · 3413 edges · 1426 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1436,7 +1436,6 @@
 - [[_COMMUNITY_Community 1423|Community 1423]]
 - [[_COMMUNITY_Community 1424|Community 1424]]
 - [[_COMMUNITY_Community 1425|Community 1425]]
-- [[_COMMUNITY_Community 1426|Community 1426]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -7168,10 +7167,6 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
-### Community 1426 - "Community 1426"
-Cohesion: 1.0
-Nodes (0):
-
 ## Knowledge Gaps
 - **Thin community `Community 404`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -8181,1043 +8176,1041 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 907`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `customer.ts`
+- **Thin community `Community 908`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `guest.ts`
+- **Thin community `Community 909`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `index.ts`
+- **Thin community `Community 910`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `offer.ts`
+- **Thin community `Community 911`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 912`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 913`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `review.ts`
+- **Thin community `Community 914`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `rewards.ts`
+- **Thin community `Community 915`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 916`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 917`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 918`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 919`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 920`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 921`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 922`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `bag.ts`
+- **Thin community `Community 923`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 924`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `customer.ts`
+- **Thin community `Community 925`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `guest.ts`
+- **Thin community `Community 926`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 927`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 928`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `payment.ts`
+- **Thin community `Community 929`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 930`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 931`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 932`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `users.ts`
+- **Thin community `Community 933`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `payment.ts`
+- **Thin community `Community 934`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 935`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 936`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 937`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 938`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `index.ts`
+- **Thin community `Community 939`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 940`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `auth.ts`
+- **Thin community `Community 941`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 942`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 943`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 944`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 945`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 946`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 947`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 948`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 949`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `constants.ts`
+- **Thin community `Community 950`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 951`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 952`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 953`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `types.ts`
+- **Thin community `Community 954`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 955`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 956`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 957`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 958`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 959`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 960`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 961`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 962`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `columns.tsx`
+- **Thin community `Community 963`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 964`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 965`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 967`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `columns.tsx`
+- **Thin community `Community 968`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 969`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 970`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `chart.tsx`
+- **Thin community `Community 971`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `columns.tsx`
+- **Thin community `Community 972`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 973`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 974`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `columns.tsx`
+- **Thin community `Community 975`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `constants.ts`
+- **Thin community `Community 976`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 979`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `data.ts`
+- **Thin community `Community 980`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `columns.tsx`
+- **Thin community `Community 981`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 982`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 983`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `columns.tsx`
+- **Thin community `Community 984`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 985`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 986`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 987`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 988`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 989`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 990`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 991`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `constants.ts`
+- **Thin community `Community 992`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 994`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 995`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `data.ts`
+- **Thin community `Community 996`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 997`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 998`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 999`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1000`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1001`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1003`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1004`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1005`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1006`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1007`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1008`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `constants.ts`
+- **Thin community `Community 1009`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1011`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1012`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1013`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1014`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1015`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1016`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1017`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1018`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1019`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1020`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1021`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1022`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1023`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1024`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1025`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1026`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1027`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1028`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1029`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1030`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1031`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1032`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `constants.ts`
+- **Thin community `Community 1033`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1034`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1035`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1036`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `data.ts`
+- **Thin community `Community 1037`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1038`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `constants.ts`
+- **Thin community `Community 1039`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1040`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1041`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1042`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1043`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `data.ts`
+- **Thin community `Community 1044`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1045`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `constants.ts`
+- **Thin community `Community 1046`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1047`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1048`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1049`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1050`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `data.ts`
+- **Thin community `Community 1051`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1052`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1053`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1054`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1055`** (1 nodes): `OrderSummary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `OrderSummary.test.tsx`
+- **Thin community `Community 1056`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1057`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1058`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1059`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1060`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1061`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1062`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1063`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1064`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1065`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1066`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1067`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1068`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1069`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1070`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1071`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1072`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1073`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `types.ts`
+- **Thin community `Community 1074`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1075`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1076`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1077`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1078`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1079`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1080`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1081`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1082`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1083`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1084`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1085`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1086`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1087`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1089`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1090`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1091`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1092`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `data.ts`
+- **Thin community `Community 1093`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1094`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1095`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1096`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1097`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1098`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1099`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1100`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1101`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1102`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1103`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1104`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1105`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1106`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `constants.ts`
+- **Thin community `Community 1107`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1108`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1109`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1110`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `data.ts`
+- **Thin community `Community 1111`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `types.ts`
+- **Thin community `Community 1112`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1113`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1114`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1115`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1116`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `index.tsx`
+- **Thin community `Community 1117`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1118`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1119`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1120`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1121`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `index.tsx`
+- **Thin community `Community 1122`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1123`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1124`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1125`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `button.tsx`
+- **Thin community `Community 1126`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1127`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `card.tsx`
+- **Thin community `Community 1128`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1129`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1130`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `command.tsx`
+- **Thin community `Community 1131`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1132`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1133`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1134`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `form.tsx`
+- **Thin community `Community 1135`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1136`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1137`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `input.tsx`
+- **Thin community `Community 1138`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1139`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1140`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1141`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1142`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1143`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `select.tsx`
+- **Thin community `Community 1144`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1145`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1146`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1147`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `table.tsx`
+- **Thin community `Community 1148`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1149`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1150`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1151`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1152`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1153`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1154`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1155`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1156`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `constants.ts`
+- **Thin community `Community 1157`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1158`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1159`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1160`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `data.ts`
+- **Thin community `Community 1161`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1162`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1163`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1164`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1165`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1166`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1167`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1168`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1169`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1170`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1171`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1172`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1173`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1174`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `index.ts`
+- **Thin community `Community 1175`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `config.ts`
+- **Thin community `Community 1176`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1177`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1178`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1179`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1180`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1181`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `aws.ts`
+- **Thin community `Community 1182`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `constants.ts`
+- **Thin community `Community 1183`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `countries.ts`
+- **Thin community `Community 1184`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1185`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1188`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1189`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1190`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1191`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `dto.ts`
+- **Thin community `Community 1192`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `ports.ts`
+- **Thin community `Community 1193`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `constants.ts`
+- **Thin community `Community 1194`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1196`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `index.ts`
+- **Thin community `Community 1197`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `types.ts`
+- **Thin community `Community 1199`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1201`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1202`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1203`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1204`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `category.ts`
+- **Thin community `Community 1206`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `product.ts`
+- **Thin community `Community 1207`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `store.ts`
+- **Thin community `Community 1208`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1209`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `user.ts`
+- **Thin community `Community 1210`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1212`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1213`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1214`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1215`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1216`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1217`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `index.tsx`
+- **Thin community `Community 1218`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1219`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1220`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1221`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1222`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1223`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `index.tsx`
+- **Thin community `Community 1224`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1225`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1226`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1227`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `home.tsx`
+- **Thin community `Community 1228`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1229`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1230`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1231`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1232`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `index.tsx`
+- **Thin community `Community 1233`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1234`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1235`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1236`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `index.tsx`
+- **Thin community `Community 1237`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1238`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1239`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1240`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1241`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1242`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1243`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1244`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `index.tsx`
+- **Thin community `Community 1245`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1246`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1247`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1248`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1249`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1250`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1251`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1252`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `index.tsx`
+- **Thin community `Community 1253`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `new.tsx`
+- **Thin community `Community 1254`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `index.tsx`
+- **Thin community `Community 1255`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `new.tsx`
+- **Thin community `Community 1256`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1257`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1258`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `index.tsx`
+- **Thin community `Community 1259`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `new.tsx`
+- **Thin community `Community 1260`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `index.tsx`
+- **Thin community `Community 1261`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1262`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1263`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1264`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1265`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1266`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1267`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1268`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `index.tsx`
+- **Thin community `Community 1269`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1271`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1273`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1274`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1275`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1276`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1278`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1280`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1281`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1283`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1284`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1285`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1286`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `setup.ts`
+- **Thin community `Community 1288`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1290`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `types.ts`
+- **Thin community `Community 1291`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1292`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1293`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1294`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1295`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `types.ts`
+- **Thin community `Community 1297`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1298`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1299`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1300`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1302`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1303`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1304`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1305`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1306`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `schema.ts`
+- **Thin community `Community 1307`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1308`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1312`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1313`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1314`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1315`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1316`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `types.ts`
+- **Thin community `Community 1317`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1318`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1319`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1320`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1321`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1322`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1324`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `constants.ts`
+- **Thin community `Community 1325`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1326`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `About.tsx`
+- **Thin community `Community 1327`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1328`** (1 nodes): `MobileProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `MobileProductActions.test.tsx`
+- **Thin community `Community 1329`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1330`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1331`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1332`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1333`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1334`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1335`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1336`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1337`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `types.ts`
+- **Thin community `Community 1338`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1339`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1340`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1341`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1342`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1343`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1344`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1345`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1346`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1347`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1348`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `button.tsx`
+- **Thin community `Community 1349`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `card.tsx`
+- **Thin community `Community 1350`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1351`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `command.tsx`
+- **Thin community `Community 1352`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1353`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1354`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1355`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `form.tsx`
+- **Thin community `Community 1356`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1357`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1358`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1359`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1360`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `input.tsx`
+- **Thin community `Community 1361`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `label.tsx`
+- **Thin community `Community 1362`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1363`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1364`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1365`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `index.ts`
+- **Thin community `Community 1366`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `types.ts`
+- **Thin community `Community 1367`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1368`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1369`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1370`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1371`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `select.tsx`
+- **Thin community `Community 1372`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1373`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1374`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `table.tsx`
+- **Thin community `Community 1375`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1376`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1377`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1378`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1379`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1380`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `config.ts`
+- **Thin community `Community 1381`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1382`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1383`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1384`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `constants.ts`
+- **Thin community `Community 1385`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `countries.ts`
+- **Thin community `Community 1386`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1387`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1388`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1389`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1390`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `index.ts`
+- **Thin community `Community 1391`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `store.ts`
+- **Thin community `Community 1392`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `bag.ts`
+- **Thin community `Community 1393`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1394`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `category.ts`
+- **Thin community `Community 1395`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `organization.ts`
+- **Thin community `Community 1396`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `product.ts`
+- **Thin community `Community 1397`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `store.ts`
+- **Thin community `Community 1398`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1399`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `user.ts`
+- **Thin community `Community 1400`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `states.ts`
+- **Thin community `Community 1401`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1402`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1403`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1404`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1405`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1406`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1407`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1408`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `index.tsx`
+- **Thin community `Community 1409`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1410`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `index.tsx`
+- **Thin community `Community 1411`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1412`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1413`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1414`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1415`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1416`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `index.tsx`
+- **Thin community `Community 1417`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1418`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1419`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1420`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1421`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `index.js`
+- **Thin community `Community 1422`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1423`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1424`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `harness-behavior-scenarios.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1425`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -42054,15 +42054,6 @@
     {
       "community": 1000,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
-      "label": "LoginForm.test.tsx",
-      "norm_label": "loginform.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1001,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
       "norm_label": "loginform.tsx",
@@ -42070,7 +42061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1001,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -42079,7 +42070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -42088,7 +42079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42097,7 +42088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42106,7 +42097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42115,7 +42106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42124,7 +42115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -42133,12 +42124,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1009,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1009,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -42207,15 +42207,6 @@
     {
       "community": 1010,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1011,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -42223,7 +42214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1011,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42232,7 +42223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -42241,7 +42232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -42250,7 +42241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -42259,7 +42250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -42268,7 +42259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -42277,7 +42268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -42286,12 +42277,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1019,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
       "norm_label": "registersessionview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1019,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -42360,15 +42360,6 @@
     {
       "community": 1020,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1021,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -42376,7 +42367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1021,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42385,7 +42376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -42394,7 +42385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -42403,7 +42394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -42412,7 +42403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -42421,7 +42412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -42430,7 +42421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -42439,12 +42430,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1029,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
       "norm_label": "orderstatus.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1029,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -42513,15 +42513,6 @@
     {
       "community": 1030,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1031,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
       "norm_label": "orders.tsx",
@@ -42529,7 +42520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1031,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -42538,7 +42529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -42547,7 +42538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42556,7 +42547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42565,7 +42556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42574,7 +42565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -42583,7 +42574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -42592,12 +42583,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1039,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -42666,15 +42666,6 @@
     {
       "community": 1040,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1041,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -42682,7 +42673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1041,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42691,7 +42682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -42700,7 +42691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -42709,7 +42700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -42718,7 +42709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -42727,7 +42718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42736,7 +42727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42745,12 +42736,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1049,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -42810,15 +42810,6 @@
     {
       "community": 1050,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1051,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -42826,7 +42817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1051,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -42835,7 +42826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -42844,7 +42835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -42853,7 +42844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -42862,7 +42853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -42871,7 +42862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -42880,7 +42871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -42889,12 +42880,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1059,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
       "norm_label": "registeractions.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1059,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
+      "label": "SearchResultsSection.tsx",
+      "norm_label": "searchresultssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -42954,15 +42954,6 @@
     {
       "community": 1060,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "label": "SearchResultsSection.tsx",
-      "norm_label": "searchresultssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1061,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
       "norm_label": "sessionmanager.test.tsx",
@@ -42970,7 +42961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1061,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -42979,7 +42970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -42988,7 +42979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -42997,7 +42988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -43006,7 +42997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -43015,7 +43006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -43024,7 +43015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -43033,12 +43024,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
       "norm_label": "registercheckoutpanel.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1069,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
+      "label": "HeldSessionsList.test.tsx",
+      "norm_label": "heldsessionslist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43098,15 +43098,6 @@
     {
       "community": 1070,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
-      "label": "HeldSessionsList.test.tsx",
-      "norm_label": "heldsessionslist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1071,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
       "norm_label": "transactionview.test.tsx",
@@ -43114,7 +43105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1071,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -43123,7 +43114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -43132,7 +43123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -43141,7 +43132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -43150,7 +43141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -43159,7 +43150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -43168,7 +43159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -43177,12 +43168,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
       "norm_label": "detailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1079,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1"
     },
     {
@@ -43242,15 +43242,6 @@
     {
       "community": 1080,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1081,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
       "norm_label": "categorylistview.tsx",
@@ -43258,7 +43249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1081,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -43267,7 +43258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -43276,7 +43267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -43285,7 +43276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -43294,7 +43285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -43303,7 +43294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -43312,7 +43303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -43321,12 +43312,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1089,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -43386,15 +43386,6 @@
     {
       "community": 1090,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1091,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -43402,7 +43393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1091,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -43411,7 +43402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -43420,7 +43411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -43429,7 +43420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -43438,7 +43429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -43447,7 +43438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -43456,7 +43447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -43465,12 +43456,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1099,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
       "norm_label": "promocodemoney.test.ts",
       "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1099,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -43710,15 +43710,6 @@
     {
       "community": 1100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1101,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
@@ -43726,7 +43717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1101,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43735,7 +43726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43744,7 +43735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -43753,7 +43744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43762,7 +43753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -43771,7 +43762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -43780,7 +43771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43789,12 +43780,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1109,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -43854,15 +43854,6 @@
     {
       "community": 1110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1111,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -43870,7 +43861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1111,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -43879,7 +43870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -43888,7 +43879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -43897,7 +43888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -43906,7 +43897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -43915,7 +43906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -43924,7 +43915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -43933,12 +43924,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1119,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
       "norm_label": "maintenanceview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
+      "label": "MtnMomoView.test.tsx",
+      "norm_label": "mtnmomoview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43998,15 +43998,6 @@
     {
       "community": 1120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
-      "label": "MtnMomoView.test.tsx",
-      "norm_label": "mtnmomoview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1121,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
       "norm_label": "usestoreconfigupdate.test.tsx",
@@ -44014,7 +44005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1121,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -44023,7 +44014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -44032,7 +44023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -44041,7 +44032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -44050,7 +44041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -44059,7 +44050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -44068,7 +44059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -44077,12 +44068,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1129,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
+      "label": "collapsible.tsx",
+      "norm_label": "collapsible.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
       "source_location": "L1"
     },
     {
@@ -44142,15 +44142,6 @@
     {
       "community": 1130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
-      "label": "collapsible.tsx",
-      "norm_label": "collapsible.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1131,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
       "norm_label": "command.tsx",
@@ -44158,7 +44149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1131,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -44167,7 +44158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -44176,7 +44167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -44185,7 +44176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -44194,7 +44185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -44203,7 +44194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -44212,7 +44203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -44221,12 +44212,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1139,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1139,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
       "source_location": "L1"
     },
     {
@@ -44286,15 +44286,6 @@
     {
       "community": 1140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1141,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
       "norm_label": "primitives.test.tsx",
@@ -44302,7 +44293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -44311,7 +44302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -44320,7 +44311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -44329,7 +44320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -44338,7 +44329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -44347,7 +44338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -44356,7 +44347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -44365,12 +44356,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1149,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1"
     },
     {
@@ -44430,15 +44430,6 @@
     {
       "community": 1150,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1151,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
       "norm_label": "toggle-group.tsx",
@@ -44446,7 +44437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1151,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -44455,7 +44446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -44464,7 +44455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -44473,7 +44464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -44482,7 +44473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -44491,7 +44482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -44500,7 +44491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44509,12 +44500,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -44574,15 +44574,6 @@
     {
       "community": 1160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1161,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -44590,7 +44581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -44599,7 +44590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -44608,7 +44599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -44617,7 +44608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -44626,7 +44617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44635,7 +44626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44644,7 +44635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44653,12 +44644,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1169,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
+      "label": "LinkedAccounts.tsx",
+      "norm_label": "linkedaccounts.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1"
     },
     {
@@ -44718,15 +44718,6 @@
     {
       "community": 1170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "label": "LinkedAccounts.tsx",
-      "norm_label": "linkedaccounts.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1171,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
       "norm_label": "timelineeventcard.test.tsx",
@@ -44734,7 +44725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -44743,7 +44734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -44752,7 +44743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -44761,7 +44752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -44770,7 +44761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -44779,7 +44770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -44788,7 +44779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -44797,12 +44788,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
       "norm_label": "useauth.test.tsx",
       "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1179,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
+      "label": "useExpenseSessions.test.ts",
+      "norm_label": "useexpensesessions.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
       "source_location": "L1"
     },
     {
@@ -44862,15 +44862,6 @@
     {
       "community": 1180,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
-      "label": "useExpenseSessions.test.ts",
-      "norm_label": "useexpensesessions.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1181,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
@@ -44878,7 +44869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -44887,7 +44878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -44896,7 +44887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -44905,7 +44896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -44914,7 +44905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -44923,7 +44914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -44932,7 +44923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -44941,12 +44932,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
       "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
@@ -45006,15 +45006,6 @@
     {
       "community": 1190,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1191,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
       "norm_label": "bootstrapregister.test.ts",
@@ -45022,7 +45013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -45031,7 +45022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -45040,7 +45031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -45049,7 +45040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -45058,7 +45049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -45067,7 +45058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -45076,7 +45067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -45085,12 +45076,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1199,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1199,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
       "source_location": "L1"
     },
     {
@@ -45330,15 +45330,6 @@
     {
       "community": 1200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1201,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
       "norm_label": "sessiongateway.test.ts",
@@ -45346,7 +45337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -45355,7 +45346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -45364,7 +45355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -45373,7 +45364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -45382,7 +45373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -45391,7 +45382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -45400,7 +45391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -45409,12 +45400,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1209,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
@@ -45474,15 +45474,6 @@
     {
       "community": 1210,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1211,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
       "norm_label": "storeconfig.test.ts",
@@ -45490,7 +45481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -45499,7 +45490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -45508,7 +45499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -45517,7 +45508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -45526,7 +45517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -45535,7 +45526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -45544,7 +45535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -45553,12 +45544,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
       "norm_label": "$storeurlslug.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1219,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
       "source_location": "L1"
     },
     {
@@ -45618,15 +45618,6 @@
     {
       "community": 1220,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1221,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
       "norm_label": "assets.index.tsx",
@@ -45634,7 +45625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -45643,7 +45634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -45652,7 +45643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -45661,7 +45652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -45670,7 +45661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -45679,7 +45670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -45688,7 +45679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -45697,12 +45688,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1229,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
       "norm_label": "logs.$logid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1229,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1"
     },
     {
@@ -45762,15 +45762,6 @@
     {
       "community": 1230,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1231,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
       "norm_label": "members.index.tsx",
@@ -45778,7 +45769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -45787,7 +45778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -45796,7 +45787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -45805,7 +45796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -45814,7 +45805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -45823,7 +45814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -45832,7 +45823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -45841,12 +45832,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1239,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
       "norm_label": "out-for-delivery.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1239,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1"
     },
     {
@@ -45906,15 +45906,6 @@
     {
       "community": 1240,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1241,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
       "norm_label": "refunded.index.tsx",
@@ -45922,7 +45913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -45931,7 +45922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -45940,7 +45931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -45949,7 +45940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -45958,7 +45949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -45967,7 +45958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -45976,7 +45967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -45985,12 +45976,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1249,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
       "norm_label": "transactions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
       "source_location": "L1"
     },
     {
@@ -46050,15 +46050,6 @@
     {
       "community": 1250,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1251,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
       "norm_label": "edit.tsx",
@@ -46066,7 +46057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -46075,7 +46066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -46084,7 +46075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -46093,7 +46084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -46102,7 +46093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -46111,7 +46102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -46120,7 +46111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -46129,12 +46120,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1259,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1"
     },
     {
@@ -46194,15 +46194,6 @@
     {
       "community": 1260,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1261,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -46210,7 +46201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -46219,7 +46210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -46228,7 +46219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -46237,7 +46228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -46246,7 +46237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -46255,7 +46246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -46264,7 +46255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -46273,12 +46264,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1269,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
+      "label": "_authed.test.tsx",
+      "norm_label": "_authed.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
       "source_location": "L1"
     },
     {
@@ -46338,15 +46338,6 @@
     {
       "community": 1270,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
-      "label": "_authed.test.tsx",
-      "norm_label": "_authed.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1271,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
       "norm_label": "join-team.index.tsx",
@@ -46354,7 +46345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -46363,7 +46354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -46372,7 +46363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -46381,7 +46372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -46390,7 +46381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -46399,7 +46390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -46408,7 +46399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -46417,12 +46408,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1279,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
       "norm_label": "introduction-content.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1279,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
       "source_location": "L1"
     },
     {
@@ -46482,15 +46482,6 @@
     {
       "community": 1280,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1281,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
       "norm_label": "adminshell.stories.tsx",
@@ -46498,7 +46489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -46507,7 +46498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -46516,7 +46507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -46525,7 +46516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -46534,7 +46525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -46543,7 +46534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -46552,7 +46543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -46561,12 +46552,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1289,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
       "norm_label": "useprint.test.ts",
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1289,
+      "file_type": "code",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
       "source_location": "L1"
     },
     {
@@ -46626,15 +46626,6 @@
     {
       "community": 1290,
       "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1291,
-      "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -46642,7 +46633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1291,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -46651,7 +46642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -46660,7 +46651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -46669,7 +46660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -46678,7 +46669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -46687,7 +46678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -46696,7 +46687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -46705,12 +46696,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1299,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
       "norm_label": "defaultcatchboundary.tsx",
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1299,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
       "source_location": "L1"
     },
     {
@@ -46941,15 +46941,6 @@
     {
       "community": 1300,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1301,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
       "norm_label": "productcard.test.tsx",
@@ -46957,7 +46948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1301,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -46966,7 +46957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -46975,7 +46966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -46984,7 +46975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -46993,7 +46984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -47002,7 +46993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -47011,7 +47002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -47020,12 +47011,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1309,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
       "norm_label": "checkoutstorage.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1309,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
+      "label": "deliveryFees.test.ts",
+      "norm_label": "deliveryfees.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1"
     },
     {
@@ -47085,15 +47085,6 @@
     {
       "community": 1310,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "label": "deliveryFees.test.ts",
-      "norm_label": "deliveryfees.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1311,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
       "norm_label": "derivecheckoutstate.test.ts",
@@ -47101,7 +47092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -47110,7 +47101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -47119,7 +47110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -47128,7 +47119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -47137,7 +47128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -47146,7 +47137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -47155,7 +47146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -47164,12 +47155,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1319,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
       "norm_label": "productfilterbar.tsx",
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1319,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
+      "label": "BestSellersSection.test.tsx",
+      "norm_label": "bestsellerssection.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
       "source_location": "L1"
     },
     {
@@ -47229,15 +47229,6 @@
     {
       "community": 1320,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
-      "label": "BestSellersSection.test.tsx",
-      "norm_label": "bestsellerssection.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1321,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
       "norm_label": "homehero.tsx",
@@ -47245,7 +47236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -47254,7 +47245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -47263,7 +47254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -47272,7 +47263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -47281,7 +47272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -47290,7 +47281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -47299,7 +47290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -47308,12 +47299,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1329,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_test_tsx",
       "label": "MobileProductActions.test.tsx",
       "norm_label": "mobileproductactions.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1329,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
+      "label": "ProductActions.test.tsx",
+      "norm_label": "productactions.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
       "source_location": "L1"
     },
     {
@@ -47373,15 +47373,6 @@
     {
       "community": 1330,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
-      "label": "ProductActions.test.tsx",
-      "norm_label": "productactions.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1331,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
       "norm_label": "productinfo.tsx",
@@ -47389,7 +47380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -47398,7 +47389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -47407,7 +47398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -47416,7 +47407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -47425,7 +47416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -47434,7 +47425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -47443,7 +47434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -47452,12 +47443,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1339,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
       "norm_label": "savedbag.tsx",
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1339,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
+      "label": "SavedIcon.tsx",
+      "norm_label": "savedicon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1"
     },
     {
@@ -47517,15 +47517,6 @@
     {
       "community": 1340,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "label": "SavedIcon.tsx",
-      "norm_label": "savedicon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1341,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
       "norm_label": "carticon.tsx",
@@ -47533,7 +47524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1341,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -47542,7 +47533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -47551,7 +47542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -47560,7 +47551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -47569,7 +47560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -47578,7 +47569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -47587,7 +47578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -47596,12 +47587,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1349,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1349,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1"
     },
     {
@@ -47661,15 +47661,6 @@
     {
       "community": 1350,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1351,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
@@ -47677,7 +47668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -47686,7 +47677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -47695,7 +47686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -47704,7 +47695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -47713,7 +47704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -47722,7 +47713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -47731,7 +47722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -47740,12 +47731,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1359,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
       "norm_label": "input-otp.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1359,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
+      "label": "input-with-end-button.tsx",
+      "norm_label": "input-with-end-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
       "source_location": "L1"
     },
     {
@@ -47805,15 +47805,6 @@
     {
       "community": 1360,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
-      "label": "input-with-end-button.tsx",
-      "norm_label": "input-with-end-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1361,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
       "norm_label": "input.tsx",
@@ -47821,7 +47812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -47830,7 +47821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -47839,7 +47830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -47848,7 +47839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -47857,7 +47848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -47866,7 +47857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -47875,7 +47866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -47884,12 +47875,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1369,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
       "norm_label": "popover.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1369,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1"
     },
     {
@@ -47949,15 +47949,6 @@
     {
       "community": 1370,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1371,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
       "norm_label": "scroll-area.tsx",
@@ -47965,7 +47956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -47974,7 +47965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -47983,7 +47974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -47992,7 +47983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -48001,7 +47992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -48010,7 +48001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -48019,7 +48010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -48028,12 +48019,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1379,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1379,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1"
     },
     {
@@ -48093,15 +48093,6 @@
     {
       "community": 1380,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1381,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
@@ -48109,7 +48100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1381,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -48118,7 +48109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -48127,7 +48118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -48136,7 +48127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -48145,7 +48136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -48154,7 +48145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -48163,7 +48154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -48172,12 +48163,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1389,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
       "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1389,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
+      "label": "maintenanceUtils.test.ts",
+      "norm_label": "maintenanceutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1"
     },
     {
@@ -48237,15 +48237,6 @@
     {
       "community": 1390,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "label": "maintenanceUtils.test.ts",
-      "norm_label": "maintenanceutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1391,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -48253,7 +48244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1391,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -48262,7 +48253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -48271,7 +48262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -48280,7 +48271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -48289,7 +48280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -48298,7 +48289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -48307,7 +48298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -48316,12 +48307,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1399,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1399,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
@@ -48552,15 +48552,6 @@
     {
       "community": 1400,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1401,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
       "norm_label": "states.ts",
@@ -48568,7 +48559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1401,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -48577,7 +48568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -48586,7 +48577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -48595,7 +48586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -48604,7 +48595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -48613,7 +48604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -48622,7 +48613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -48631,12 +48622,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1409,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1409,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
+      "label": "$subcategorySlug.tsx",
+      "norm_label": "$subcategoryslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1"
     },
     {
@@ -48696,15 +48696,6 @@
     {
       "community": 1410,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "label": "$subcategorySlug.tsx",
-      "norm_label": "$subcategoryslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1411,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -48712,7 +48703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1411,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -48721,7 +48712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -48730,7 +48721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -48739,7 +48730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -48748,7 +48739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -48757,7 +48748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -48766,7 +48757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -48775,12 +48766,21 @@
       "source_location": "L1"
     },
     {
-      "community": 1419,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
       "norm_label": "tailwind.config.js",
       "source_file": "packages/storefront-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1419,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1"
     },
     {
@@ -48831,15 +48831,6 @@
     {
       "community": 1420,
       "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/storefront-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1421,
-      "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
       "norm_label": "vitest.setup.ts",
@@ -48847,7 +48838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1421,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -48856,7 +48847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1422,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -48865,7 +48856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1423,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -48874,7 +48865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1424,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -48883,7 +48874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1425,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -74355,19 +74346,19 @@
     {
       "community": 908,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
       "source_location": "L1"
     },
     {
       "community": 909,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
       "source_location": "L1"
     },
     {
@@ -74436,15 +74427,6 @@
     {
       "community": 910,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 911,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
       "norm_label": "offer.ts",
@@ -74452,7 +74434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 911,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -74461,7 +74443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -74470,7 +74452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -74479,7 +74461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -74488,7 +74470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -74497,7 +74479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -74506,7 +74488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -74515,12 +74497,21 @@
       "source_location": "L1"
     },
     {
-      "community": 919,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 919,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
+      "label": "storeFrontVerificationCode.ts",
+      "norm_label": "storefrontverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
       "source_location": "L1"
     },
     {
@@ -74589,15 +74580,6 @@
     {
       "community": 920,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "label": "storeFrontVerificationCode.ts",
-      "norm_label": "storefrontverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 921,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
@@ -74605,7 +74587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 921,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -74614,7 +74596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -74623,7 +74605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -74632,7 +74614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -74641,7 +74623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -74650,7 +74632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -74659,7 +74641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -74668,12 +74650,21 @@
       "source_location": "L1"
     },
     {
-      "community": 929,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 929,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
+      "label": "paystackActions.ts",
+      "norm_label": "paystackactions.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
       "source_location": "L1"
     },
     {
@@ -74742,15 +74733,6 @@
     {
       "community": 930,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
-      "label": "paystackActions.ts",
-      "norm_label": "paystackactions.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 931,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
       "norm_label": "savedbagitem.ts",
@@ -74758,7 +74740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 931,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -74767,7 +74749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -74776,7 +74758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -74785,7 +74767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -74794,7 +74776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -74803,7 +74785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -74812,7 +74794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -74821,12 +74803,21 @@
       "source_location": "L1"
     },
     {
-      "community": 939,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 939,
+      "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
@@ -74895,15 +74886,6 @@
     {
       "community": 940,
       "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 941,
-      "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -74911,7 +74893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 941,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -74920,7 +74902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -74929,7 +74911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -74938,7 +74920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -74947,7 +74929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -74956,7 +74938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -74965,7 +74947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -74974,12 +74956,21 @@
       "source_location": "L1"
     },
     {
-      "community": 949,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
       "norm_label": "productattributesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 949,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -75048,15 +75039,6 @@
     {
       "community": 950,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 951,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -75064,7 +75046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 951,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75073,7 +75055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75082,7 +75064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -75091,7 +75073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -75100,7 +75082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -75109,7 +75091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -75118,7 +75100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -75127,12 +75109,21 @@
       "source_location": "L1"
     },
     {
-      "community": 959,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 959,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -75201,15 +75192,6 @@
     {
       "community": 960,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 961,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -75217,7 +75199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 961,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75226,7 +75208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -75235,7 +75217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75244,7 +75226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75253,7 +75235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -75262,7 +75244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75271,7 +75253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -75280,12 +75262,21 @@
       "source_location": "L1"
     },
     {
-      "community": 969,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 969,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -75354,15 +75345,6 @@
     {
       "community": 970,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 971,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
       "norm_label": "chart.tsx",
@@ -75370,7 +75352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 971,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -75379,7 +75361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75388,7 +75370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75397,7 +75379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -75406,7 +75388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -75415,7 +75397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75424,7 +75406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75433,12 +75415,21 @@
       "source_location": "L1"
     },
     {
-      "community": 979,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 979,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
       "source_location": "L1"
     },
     {
@@ -75507,15 +75498,6 @@
     {
       "community": 980,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 981,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -75523,7 +75505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 981,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75532,7 +75514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75541,7 +75523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -75550,7 +75532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -75559,7 +75541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75568,7 +75550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75577,7 +75559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -75586,12 +75568,21 @@
       "source_location": "L1"
     },
     {
-      "community": 989,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 989,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
+      "label": "app-sidebar.tsx",
+      "norm_label": "app-sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
       "source_location": "L1"
     },
     {
@@ -75660,15 +75651,6 @@
     {
       "community": 990,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "label": "app-sidebar.tsx",
-      "norm_label": "app-sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 991,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
       "norm_label": "assetscolumns.tsx",
@@ -75676,7 +75658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 991,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -75685,7 +75667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75694,7 +75676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -75703,7 +75685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -75712,7 +75694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -75721,7 +75703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -75730,7 +75712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -75739,12 +75721,21 @@
       "source_location": "L1"
     },
     {
-      "community": 999,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
       "norm_label": "inputotp.test.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 999,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
+      "label": "LoginForm.test.tsx",
+      "norm_label": "loginform.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1512
-- Graph nodes: 3865
+- Code files discovered: 1511
+- Graph nodes: 3864
 - Graph edges: 3413
-- Communities: 1427
+- Communities: 1426
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -218,7 +218,6 @@ import type * as schemas_storeFront_bag from "../schemas/storeFront/bag.js";
 import type * as schemas_storeFront_bagItem from "../schemas/storeFront/bagItem.js";
 import type * as schemas_storeFront_checkoutSession from "../schemas/storeFront/checkoutSession.js";
 import type * as schemas_storeFront_checkoutSessionItem from "../schemas/storeFront/checkoutSessionItem.js";
-import type * as schemas_storeFront_customer from "../schemas/storeFront/customer.js";
 import type * as schemas_storeFront_guest from "../schemas/storeFront/guest.js";
 import type * as schemas_storeFront_index from "../schemas/storeFront/index.js";
 import type * as schemas_storeFront_offer from "../schemas/storeFront/offer.js";
@@ -500,7 +499,6 @@ declare const fullApi: ApiFromModules<{
   "schemas/storeFront/bagItem": typeof schemas_storeFront_bagItem;
   "schemas/storeFront/checkoutSession": typeof schemas_storeFront_checkoutSession;
   "schemas/storeFront/checkoutSessionItem": typeof schemas_storeFront_checkoutSessionItem;
-  "schemas/storeFront/customer": typeof schemas_storeFront_customer;
   "schemas/storeFront/guest": typeof schemas_storeFront_guest;
   "schemas/storeFront/index": typeof schemas_storeFront_index;
   "schemas/storeFront/offer": typeof schemas_storeFront_offer;

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -27,7 +27,6 @@ import {
   bagSchema,
   savedBagSchema,
   savedBagItemSchema,
-  customerSchema,
   guestSchema,
   checkoutSessionSchema,
   checkoutSessionItemSchema,
@@ -138,7 +137,6 @@ const schema = defineSchema({
   complimentaryProduct: defineTable(complimentaryProductSchema)
     .index("by_storeId", ["storeId"])
     .index("by_collectionId", ["collectionId"]),
-  customer: defineTable(customerSchema),
   customerProfile: defineTable(customerProfileSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeId_email", ["storeId", "email"])

--- a/packages/athena-webapp/convex/schemas/storeFront/customer.ts
+++ b/packages/athena-webapp/convex/schemas/storeFront/customer.ts
@@ -1,6 +1,0 @@
-import { v } from "convex/values";
-
-export const customerSchema = v.object({
-  name: v.string(),
-  email: v.string(),
-});

--- a/packages/athena-webapp/convex/schemas/storeFront/index.ts
+++ b/packages/athena-webapp/convex/schemas/storeFront/index.ts
@@ -2,7 +2,6 @@ export * from "./bag";
 export * from "./bagItem";
 export * from "./savedBag";
 export * from "./savedBagItem";
-export * from "./customer";
 export * from "./storeFrontUser";
 export * from "./guest";
 export * from "./storeFrontVerificationCode";

--- a/packages/athena-webapp/types.ts
+++ b/packages/athena-webapp/types.ts
@@ -47,8 +47,6 @@ export type SavedBagItem = Doc<"savedBagItem"> & {
   length?: number;
 };
 
-export type Customer = Doc<"customer">;
-
 export type Guest = Doc<"guest">;
 
 export type Address = Infer<typeof addressSchema>;


### PR DESCRIPTION
## Summary
- Removes the unused storefront customer schema/table from Convex
- Drops the unused exported Customer type alias
- Updates generated Convex API typings and graphify output

## Validation
- bun run --filter '@athena/webapp' build
- bun run graphify:rebuild