### PR TITLE
feat(storefront): restore receipt route for storefront transactions

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1517 files · ~0 words
+- 1518 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3900 nodes · 3460 edges · 1432 communities detected
+- 3903 nodes · 3462 edges · 1433 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1442,6 +1442,7 @@
 - [[_COMMUNITY_Community 1429|Community 1429]]
 - [[_COMMUNITY_Community 1430|Community 1430]]
 - [[_COMMUNITY_Community 1431|Community 1431]]
+- [[_COMMUNITY_Community 1432|Community 1432]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1950,16 +1951,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 120 - "Community 120"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 121 - "Community 121"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 122 - "Community 122"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 122 - "Community 122"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 123 - "Community 123"
 Cohesion: 0.33
@@ -1974,16 +1975,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 126 - "Community 126"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 127 - "Community 127"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
-
-### Community 128 - "Community 128"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 129 - "Community 129"
 Cohesion: 0.33
@@ -1994,36 +1995,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 131 - "Community 131"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 132 - "Community 132"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 133 - "Community 133"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 138 - "Community 138"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 139 - "Community 139"
 Cohesion: 0.53
@@ -3062,16 +3063,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 399 - "Community 399"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 400 - "Community 400"
+### Community 399 - "Community 399"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 400 - "Community 400"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 1.0
@@ -3086,20 +3087,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 404 - "Community 404"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 406 - "Community 406"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 408 - "Community 408"
 Cohesion: 1.0
@@ -7197,2056 +7198,2060 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1432 - "Community 1432"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 407`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 408`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 409`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 410`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 411`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 412`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 413`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 414`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 415`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 416`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 417`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 418`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 419`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 420`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 421`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 422`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 423`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 424`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 425`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 426`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 427`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 428`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 429`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 430`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 431`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 432`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 433`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 434`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 435`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 436`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 437`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 438`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 439`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 440`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 441`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 442`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 443`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 444`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 445`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 446`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 447`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 448`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 449`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 450`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 451`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 452`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 453`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 454`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 455`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 456`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 457`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 458`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 459`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 460`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 461`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 462`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 463`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 464`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 465`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 466`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 467`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 468`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 469`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 470`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 471`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 472`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 473`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 474`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 475`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 476`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 477`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 478`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 479`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 480`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 481`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 482`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 483`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 484`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 485`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 486`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 487`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 488`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 489`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 490`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 491`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 492`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 493`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 494`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 495`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 496`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 497`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 498`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 499`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 500`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 501`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 502`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 503`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 504`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 505`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 506`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 507`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 508`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 509`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 510`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 511`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 512`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 513`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 514`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 515`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 516`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 517`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 518`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 519`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 520`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 521`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 522`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 523`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 524`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 525`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 526`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 527`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 528`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 529`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 530`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 531`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 532`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 533`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 534`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 535`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 536`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 537`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 538`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 539`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 540`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 541`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 542`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 543`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 544`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 545`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 546`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 547`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 548`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 549`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 550`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 551`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 552`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 553`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 554`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 555`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 556`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 557`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 558`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 559`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 560`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 561`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 562`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 563`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 564`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 565`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 566`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 567`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 568`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 569`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 570`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 571`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 572`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 573`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 574`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 575`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 576`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 577`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 578`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 579`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 580`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 581`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 582`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 583`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 584`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 585`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 586`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 587`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 588`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 589`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 590`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 591`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 592`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 593`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 594`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 595`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 596`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 597`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 598`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 599`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 600`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 601`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 602`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 603`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 604`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 605`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 606`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 607`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 608`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 609`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 610`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 611`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 612`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 613`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 614`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 615`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 616`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 617`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 618`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 619`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 620`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
+- **Thin community `Community 621`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 622`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 623`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 624`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 625`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 626`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 627`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 628`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 629`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 630`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 631`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 632`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 633`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 634`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 635`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 636`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 637`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 638`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 639`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 640`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 641`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 642`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 643`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 644`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 645`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 646`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 647`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 648`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 649`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 650`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 651`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 652`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 653`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 654`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 655`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 656`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 657`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 658`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 659`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 660`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 661`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 662`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 663`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 664`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 665`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 666`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 667`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 668`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 669`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 670`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 671`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 672`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 673`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 674`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 675`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 676`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 677`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 678`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 679`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 680`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 681`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 682`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 683`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 684`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 685`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 686`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 687`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 688`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 689`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 690`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 691`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 692`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 693`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 694`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 695`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 696`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 697`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 698`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 699`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 700`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 701`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 702`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 703`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 704`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 705`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 706`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 707`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 708`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 709`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 710`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 711`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 712`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 713`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 714`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 715`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 716`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 717`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 718`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 719`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 720`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 721`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 722`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 723`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 724`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 725`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 726`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 727`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 728`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 729`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 730`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 731`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 732`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 733`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 734`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 735`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 736`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 737`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 738`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 739`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 740`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 741`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 742`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 743`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 744`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 745`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 746`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 747`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 748`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 749`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 750`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 751`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 752`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 753`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 754`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 755`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 756`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 757`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 758`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 759`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 760`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `api.d.ts`
+- **Thin community `Community 761`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `api.js`
+- **Thin community `Community 762`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 763`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `server.d.ts`
+- **Thin community `Community 764`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `server.js`
+- **Thin community `Community 765`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `app.ts`
+- **Thin community `Community 766`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `auth.config.js`
+- **Thin community `Community 767`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `auth.ts`
+- **Thin community `Community 768`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 769`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `countries.ts`
+- **Thin community `Community 770`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `email.ts`
+- **Thin community `Community 771`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `ghana.ts`
+- **Thin community `Community 772`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `payment.ts`
+- **Thin community `Community 773`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `crons.ts`
+- **Thin community `Community 774`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 775`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 776`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 777`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 778`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `env.ts`
+- **Thin community `Community 779`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `analytics.ts`
+- **Thin community `Community 780`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `auth.ts`
+- **Thin community `Community 781`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 782`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `colors.ts`
+- **Thin community `Community 783`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `index.ts`
+- **Thin community `Community 784`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `organizations.ts`
+- **Thin community `Community 785`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `products.ts`
+- **Thin community `Community 786`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 787`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `stores.ts`
+- **Thin community `Community 788`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `index.ts`
+- **Thin community `Community 789`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `bag.ts`
+- **Thin community `Community 790`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `guest.ts`
+- **Thin community `Community 791`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `index.ts`
+- **Thin community `Community 792`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `me.ts`
+- **Thin community `Community 793`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `offers.ts`
+- **Thin community `Community 794`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 795`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `paystack.ts`
+- **Thin community `Community 796`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 797`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `reviews.ts`
+- **Thin community `Community 798`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `rewards.ts`
+- **Thin community `Community 799`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 800`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `security.test.ts`
+- **Thin community `Community 801`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `storefront.ts`
+- **Thin community `Community 802`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `upsells.ts`
+- **Thin community `Community 803`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `user.ts`
+- **Thin community `Community 804`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 805`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `health.test.ts`
+- **Thin community `Community 806`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `http.ts`
+- **Thin community `Community 807`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 808`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 809`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 810`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `categories.ts`
+- **Thin community `Community 811`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `colors.ts`
+- **Thin community `Community 812`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 813`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 814`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 815`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 816`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `organizations.ts`
+- **Thin community `Community 817`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `pos.ts`
+- **Thin community `Community 818`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 819`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 820`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `productSku.ts`
+- **Thin community `Community 821`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 822`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 823`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 824`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 825`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 826`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 827`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 828`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 829`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 830`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `client.test.ts`
+- **Thin community `Community 831`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `config.test.ts`
+- **Thin community `Community 832`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 833`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `types.ts`
+- **Thin community `Community 834`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 835`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 836`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 837`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 838`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 839`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `dto.ts`
+- **Thin community `Community 840`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 841`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 842`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `openDrawer.test.ts`
+- **Thin community `Community 843`** (1 nodes): `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 844`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 845`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `types.ts`
+- **Thin community `Community 846`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 847`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 848`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `catalog.ts`
+- **Thin community `Community 849`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `customers.ts`
+- **Thin community `Community 850`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `register.ts`
+- **Thin community `Community 851`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `terminals.ts`
+- **Thin community `Community 852`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `transactions.ts`
+- **Thin community `Community 853`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `schema.ts`
+- **Thin community `Community 854`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 855`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 856`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 857`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 858`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `category.ts`
+- **Thin community `Community 859`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `color.ts`
+- **Thin community `Community 860`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 861`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 862`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `index.ts`
+- **Thin community `Community 863`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 864`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `organization.ts`
+- **Thin community `Community 865`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 866`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `product.ts`
+- **Thin community `Community 867`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 868`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 869`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `store.ts`
+- **Thin community `Community 870`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 871`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `index.ts`
+- **Thin community `Community 872`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 873`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 874`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 875`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 876`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 877`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `index.ts`
+- **Thin community `Community 878`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 879`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 880`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 881`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 882`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 883`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 884`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 885`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 886`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 887`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `customer.ts`
+- **Thin community `Community 888`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 889`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 890`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 891`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 892`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `index.ts`
+- **Thin community `Community 893`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `posSession.ts`
+- **Thin community `Community 894`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 895`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 896`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 897`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 898`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `index.ts`
+- **Thin community `Community 899`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 900`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 901`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 902`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 903`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 904`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `index.ts`
+- **Thin community `Community 905`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 906`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 907`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 908`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 909`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `vendor.ts`
+- **Thin community `Community 910`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `analytics.ts`
+- **Thin community `Community 911`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `bag.ts`
+- **Thin community `Community 912`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 913`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 914`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 915`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `guest.ts`
+- **Thin community `Community 916`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `index.ts`
+- **Thin community `Community 917`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `offer.ts`
+- **Thin community `Community 918`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 919`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 920`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `review.ts`
+- **Thin community `Community 921`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `rewards.ts`
+- **Thin community `Community 922`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 923`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 924`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 925`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 926`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 927`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 928`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 929`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `bag.ts`
+- **Thin community `Community 930`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 931`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `customer.ts`
+- **Thin community `Community 932`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `guest.ts`
+- **Thin community `Community 933`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 934`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 935`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `payment.ts`
+- **Thin community `Community 936`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 937`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 938`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 939`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `users.ts`
+- **Thin community `Community 940`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `payment.ts`
+- **Thin community `Community 941`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 942`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 943`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 944`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 945`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `index.ts`
+- **Thin community `Community 946`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 947`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `auth.ts`
+- **Thin community `Community 948`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 949`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 950`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 951`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 952`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 953`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 954`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 955`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 956`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `constants.ts`
+- **Thin community `Community 957`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 958`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 959`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 960`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `types.ts`
+- **Thin community `Community 961`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 962`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 963`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 964`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 965`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 967`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 968`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 969`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `columns.tsx`
+- **Thin community `Community 970`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 971`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 972`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 973`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `columns.tsx`
+- **Thin community `Community 975`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `chart.tsx`
+- **Thin community `Community 978`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `columns.tsx`
+- **Thin community `Community 979`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 980`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 981`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `columns.tsx`
+- **Thin community `Community 982`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `constants.ts`
+- **Thin community `Community 983`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 984`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 985`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 986`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data.ts`
+- **Thin community `Community 987`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `columns.tsx`
+- **Thin community `Community 988`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 989`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 990`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `columns.tsx`
+- **Thin community `Community 991`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 992`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 994`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 995`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 996`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 997`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 998`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `constants.ts`
+- **Thin community `Community 999`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1000`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `data.ts`
+- **Thin community `Community 1003`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1004`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1005`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 1006`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1007`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1008`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1009`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1011`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1012`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1013`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1014`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1015`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `constants.ts`
+- **Thin community `Community 1016`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1017`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1018`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1019`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1020`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1021`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1022`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1023`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1024`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1025`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1026`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1027`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1028`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1029`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1030`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1031`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1032`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1033`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1034`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1035`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1036`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1037`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1038`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1039`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `constants.ts`
+- **Thin community `Community 1040`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1041`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1042`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1043`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `data.ts`
+- **Thin community `Community 1044`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1045`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `constants.ts`
+- **Thin community `Community 1046`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1047`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1048`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1049`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1050`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `data.ts`
+- **Thin community `Community 1051`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1052`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `constants.ts`
+- **Thin community `Community 1053`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1054`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1055`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1056`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1057`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `data.ts`
+- **Thin community `Community 1058`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1059`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1060`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1061`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1062`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `OrderSummary.test.tsx`
+- **Thin community `Community 1063`** (1 nodes): `OrderSummary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1064`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1065`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1066`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1067`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1068`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1069`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1070`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1071`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1072`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1073`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1074`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1075`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1076`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1077`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1078`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1079`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1080`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `types.ts`
+- **Thin community `Community 1081`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1082`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1083`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1084`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1085`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1086`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1087`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1088`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1089`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1090`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1091`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1092`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1093`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1094`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1095`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1096`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1097`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1098`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1099`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data.ts`
+- **Thin community `Community 1100`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1101`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1102`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1103`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1104`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1105`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1106`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1107`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1108`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1109`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1110`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1111`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1112`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1113`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `constants.ts`
+- **Thin community `Community 1114`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1115`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1116`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1117`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `data.ts`
+- **Thin community `Community 1118`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `types.ts`
+- **Thin community `Community 1119`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1120`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1121`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1122`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1123`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `index.tsx`
+- **Thin community `Community 1124`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1125`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1126`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1127`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1128`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `index.tsx`
+- **Thin community `Community 1129`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1130`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1131`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1132`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `button.tsx`
+- **Thin community `Community 1133`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1134`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `card.tsx`
+- **Thin community `Community 1135`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1136`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1137`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `command.tsx`
+- **Thin community `Community 1138`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1139`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1140`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1141`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `form.tsx`
+- **Thin community `Community 1142`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1143`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1144`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `input.tsx`
+- **Thin community `Community 1145`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1146`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1147`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1148`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1149`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1150`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `select.tsx`
+- **Thin community `Community 1151`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1152`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1153`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1154`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `table.tsx`
+- **Thin community `Community 1155`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1156`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1157`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1158`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1159`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1160`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1161`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1162`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1163`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `constants.ts`
+- **Thin community `Community 1164`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1165`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1166`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1167`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `data.ts`
+- **Thin community `Community 1168`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1169`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1170`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1171`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1172`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1173`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1174`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1175`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1177`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1178`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1179`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1180`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1181`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `index.ts`
+- **Thin community `Community 1182`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `config.ts`
+- **Thin community `Community 1183`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1184`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1185`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1186`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1188`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `aws.ts`
+- **Thin community `Community 1189`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `constants.ts`
+- **Thin community `Community 1190`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `countries.ts`
+- **Thin community `Community 1191`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1192`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1196`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1197`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `dto.ts`
+- **Thin community `Community 1199`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `ports.ts`
+- **Thin community `Community 1200`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `constants.ts`
+- **Thin community `Community 1201`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `index.ts`
+- **Thin community `Community 1204`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `types.ts`
+- **Thin community `Community 1206`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1207`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1208`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1209`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1210`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `category.ts`
+- **Thin community `Community 1212`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `product.ts`
+- **Thin community `Community 1213`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `store.ts`
+- **Thin community `Community 1214`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1215`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `user.ts`
+- **Thin community `Community 1216`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1217`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1220`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `index.tsx`
+- **Thin community `Community 1221`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1222`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1223`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1224`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1225`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1226`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1227`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1228`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `index.tsx`
+- **Thin community `Community 1229`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1230`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1231`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `home.tsx`
+- **Thin community `Community 1233`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1234`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1235`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1236`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `index.tsx`
+- **Thin community `Community 1237`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1238`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1239`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1240`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1241`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `index.tsx`
+- **Thin community `Community 1242`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1243`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1244`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1245`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1246`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1247`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1248`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1249`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `index.tsx`
+- **Thin community `Community 1250`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1251`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1252`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1253`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1254`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1255`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1256`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `index.tsx`
+- **Thin community `Community 1257`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1258`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `new.tsx`
+- **Thin community `Community 1259`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `index.tsx`
+- **Thin community `Community 1260`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `new.tsx`
+- **Thin community `Community 1261`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1262`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1263`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `index.tsx`
+- **Thin community `Community 1264`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `new.tsx`
+- **Thin community `Community 1265`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `index.tsx`
+- **Thin community `Community 1266`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1267`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1268`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1269`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1270`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1271`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1273`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `index.tsx`
+- **Thin community `Community 1274`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1275`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1276`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1278`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1279`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1280`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1281`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1283`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1285`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1286`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1288`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1289`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1290`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1291`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1292`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `setup.ts`
+- **Thin community `Community 1293`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1295`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `types.ts`
+- **Thin community `Community 1296`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1297`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1298`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1299`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1300`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1301`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `types.ts`
+- **Thin community `Community 1302`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1303`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1304`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1305`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1306`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1307`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1308`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1309`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1310`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1311`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `schema.ts`
+- **Thin community `Community 1312`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1313`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1317`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1318`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1319`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1320`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1321`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `types.ts`
+- **Thin community `Community 1322`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1324`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1325`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1326`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1327`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1329`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `constants.ts`
+- **Thin community `Community 1330`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1331`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `About.tsx`
+- **Thin community `Community 1332`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1333`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `MobileProductActions.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1335`** (1 nodes): `MobileProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1336`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1337`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1338`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1339`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1340`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1341`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1342`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `types.ts`
+- **Thin community `Community 1343`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1344`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1345`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1346`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1347`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1348`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1349`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1350`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1351`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1352`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1353`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `button.tsx`
+- **Thin community `Community 1354`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `card.tsx`
+- **Thin community `Community 1355`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1356`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `command.tsx`
+- **Thin community `Community 1357`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1358`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1359`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1360`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `form.tsx`
+- **Thin community `Community 1361`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1362`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1363`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1364`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1365`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `input.tsx`
+- **Thin community `Community 1366`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `label.tsx`
+- **Thin community `Community 1367`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1368`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1369`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1370`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `index.ts`
+- **Thin community `Community 1371`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `types.ts`
+- **Thin community `Community 1372`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1373`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1374`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1375`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1376`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `select.tsx`
+- **Thin community `Community 1377`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1378`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1379`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `table.tsx`
+- **Thin community `Community 1380`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1381`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1382`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1383`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1384`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1385`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `config.ts`
+- **Thin community `Community 1386`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1387`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1388`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1389`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `constants.ts`
+- **Thin community `Community 1390`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `countries.ts`
+- **Thin community `Community 1391`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1392`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1393`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1394`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1395`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `index.ts`
+- **Thin community `Community 1396`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `store.ts`
+- **Thin community `Community 1397`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `bag.ts`
+- **Thin community `Community 1398`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1399`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `category.ts`
+- **Thin community `Community 1400`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `organization.ts`
+- **Thin community `Community 1401`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `product.ts`
+- **Thin community `Community 1402`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `store.ts`
+- **Thin community `Community 1403`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1404`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `user.ts`
+- **Thin community `Community 1405`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `states.ts`
+- **Thin community `Community 1406`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1407`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1408`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1409`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1410`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1411`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1412`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1413`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `index.tsx`
+- **Thin community `Community 1414`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1415`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `index.tsx`
+- **Thin community `Community 1416`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1417`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1418`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1419`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1420`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1421`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `index.tsx`
+- **Thin community `Community 1422`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1423`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1424`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1425`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1426`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `index.js`
+- **Thin community `Community 1427`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1428`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1429`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1430`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1431`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1432`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -32068,6 +32068,30 @@
       "weight": 1
     },
     {
+      "_src": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
+      "_tgt": "index_money",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L51",
+      "target": "index_money",
+      "weight": 1
+    },
+    {
+      "_src": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
+      "_tgt": "index_paymentlabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L14",
+      "target": "index_paymentlabel",
+      "weight": 1
+    },
+    {
       "_src": "packages_storefront_webapp_src_routes_signup_tsx",
       "_tgt": "signup_onsubmit",
       "confidence": "EXTRACTED",
@@ -42618,6 +42642,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -42625,7 +42658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42634,7 +42667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -42643,7 +42676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -42652,7 +42685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -42661,7 +42694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -42670,7 +42703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -42679,7 +42712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -42688,21 +42721,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -42771,6 +42795,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -42778,7 +42811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42787,7 +42820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42796,7 +42829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42805,7 +42838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -42814,7 +42847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -42823,7 +42856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42832,7 +42865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42841,21 +42874,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "label": "BulkOperationsPage.tsx",
-      "norm_label": "bulkoperationspage.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1"
     },
     {
@@ -42924,6 +42948,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
+      "label": "BulkOperationsPage.tsx",
+      "norm_label": "bulkoperationspage.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
       "norm_label": "cashcontrolsdashboard.auth.test.tsx",
@@ -42931,7 +42964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -42940,7 +42973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -42949,7 +42982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -42958,7 +42991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -42967,7 +43000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -42976,7 +43009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -42985,7 +43018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42994,21 +43027,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "label": "MetricCard.tsx",
-      "norm_label": "metriccard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1"
     },
     {
@@ -43077,6 +43101,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
+      "label": "MetricCard.tsx",
+      "norm_label": "metriccard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
@@ -43084,7 +43117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -43093,7 +43126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -43102,7 +43135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -43111,7 +43144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -43120,7 +43153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -43129,7 +43162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -43138,7 +43171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -43147,21 +43180,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
       "norm_label": "returnexchangeview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
       "source_location": "L1"
     },
     {
@@ -43230,6 +43254,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -43237,7 +43270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43246,7 +43279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -43255,7 +43288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -43264,7 +43297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -43273,7 +43306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -43282,7 +43315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43291,7 +43324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43300,21 +43333,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -43383,6 +43407,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -43390,7 +43423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -43399,7 +43432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -43408,7 +43441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43417,7 +43450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43426,7 +43459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -43435,7 +43468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -43444,7 +43477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -43453,21 +43486,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
       "norm_label": "memberscolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
-      "label": "organization-switcher.test.tsx",
-      "norm_label": "organization-switcher.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43536,6 +43560,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
+      "label": "organization-switcher.test.tsx",
+      "norm_label": "organization-switcher.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
       "norm_label": "cartitems.tsx",
@@ -43543,7 +43576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -43552,7 +43585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -43561,7 +43594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -43570,7 +43603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -43579,7 +43612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -43588,7 +43621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -43597,7 +43630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -43606,21 +43639,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
       "norm_label": "sessionmanager.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
-      "label": "TotalsDisplay.test.tsx",
-      "norm_label": "totalsdisplay.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43689,6 +43713,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
+      "label": "TotalsDisplay.test.tsx",
+      "norm_label": "totalsdisplay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
       "norm_label": "totalsdisplay.tsx",
@@ -43696,7 +43729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -43705,7 +43738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -43714,7 +43747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -43723,7 +43756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -43732,7 +43765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -43741,7 +43774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -43750,7 +43783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -43759,21 +43792,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
       "norm_label": "transactionview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
-      "label": "TransactionsView.test.tsx",
-      "norm_label": "transactionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43833,6 +43857,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
+      "label": "TransactionsView.test.tsx",
+      "norm_label": "transactionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -43840,7 +43873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -43849,7 +43882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -43858,7 +43891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -43867,7 +43900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -43876,7 +43909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -43885,7 +43918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -43894,7 +43927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -43903,21 +43936,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
       "norm_label": "productsubcategorytogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L1"
     },
     {
@@ -43977,6 +44001,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
@@ -43984,7 +44017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -43993,7 +44026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -44002,7 +44035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -44011,7 +44044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -44020,7 +44053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44029,7 +44062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44038,7 +44071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44047,21 +44080,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -44301,6 +44325,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
       "norm_label": "productcolumns.tsx",
@@ -44308,7 +44341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -44317,7 +44350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -44326,7 +44359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -44335,7 +44368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -44344,7 +44377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -44353,7 +44386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -44362,7 +44395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -44371,21 +44404,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -44445,6 +44469,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -44452,7 +44485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44461,7 +44494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -44470,7 +44503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -44479,7 +44512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44488,7 +44521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44497,7 +44530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44506,7 +44539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -44515,21 +44548,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
-      "label": "welcome-offer-card.tsx",
-      "norm_label": "welcome-offer-card.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
       "source_location": "L1"
     },
     {
@@ -44589,6 +44613,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
+      "label": "welcome-offer-card.tsx",
+      "norm_label": "welcome-offer-card.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
       "norm_label": "ratingstars.tsx",
@@ -44596,7 +44629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -44605,7 +44638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -44614,7 +44647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -44623,7 +44656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -44632,7 +44665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -44641,7 +44674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -44650,7 +44683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -44659,21 +44692,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
-      "label": "WorkflowTraceView.test.tsx",
-      "norm_label": "workflowtraceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -44733,6 +44757,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
+      "label": "WorkflowTraceView.test.tsx",
+      "norm_label": "workflowtraceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
@@ -44740,7 +44773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -44749,7 +44782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -44758,7 +44791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -44767,7 +44800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -44776,7 +44809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -44785,7 +44818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -44794,7 +44827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -44803,21 +44836,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -44877,6 +44901,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
@@ -44884,7 +44917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -44893,7 +44926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -44902,7 +44935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -44911,7 +44944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -44920,7 +44953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -44929,7 +44962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -44938,7 +44971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -44947,21 +44980,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
@@ -45021,6 +45045,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
@@ -45028,7 +45061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -45037,7 +45070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -45046,7 +45079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -45055,7 +45088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -45064,7 +45097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -45073,7 +45106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -45082,7 +45115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -45091,21 +45124,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1"
     },
     {
@@ -45165,6 +45189,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
       "norm_label": "upload-button.tsx",
@@ -45172,7 +45205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -45181,7 +45214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -45190,7 +45223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -45199,7 +45232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45208,7 +45241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45217,7 +45250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45226,7 +45259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -45235,21 +45268,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
       "norm_label": "bag-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
@@ -45309,6 +45333,15 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -45316,7 +45349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -45325,7 +45358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45334,7 +45367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45343,7 +45376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -45352,7 +45385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45361,7 +45394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -45370,7 +45403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -45379,21 +45412,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
       "norm_label": "usercheckoutsession.tsx",
       "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -45453,6 +45477,15 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
       "norm_label": "userbehaviorinsights.tsx",
@@ -45460,7 +45493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -45469,7 +45502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -45478,7 +45511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -45487,7 +45520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -45496,7 +45529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -45505,7 +45538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -45514,7 +45547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -45523,21 +45556,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
       "source_file": "packages/athena-webapp/src/lib/aws.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
       "source_location": "L1"
     },
     {
@@ -45597,6 +45621,15 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
@@ -45604,7 +45637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -45613,7 +45646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -45622,7 +45655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -45631,7 +45664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -45640,7 +45673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -45649,7 +45682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -45658,7 +45691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -45667,21 +45700,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
       "source_location": "L1"
     },
     {
@@ -45867,59 +45891,68 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -45928,7 +45961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -45937,7 +45970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -45946,7 +45979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -45955,7 +45988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -45964,7 +45997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -45973,7 +46006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -45982,7 +46015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -45991,7 +46024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -46000,7 +46033,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 1210,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -46009,61 +46096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 1210,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -46072,7 +46105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -46081,7 +46114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -46090,7 +46123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -46099,7 +46132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -46108,7 +46141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -46117,7 +46150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -46126,7 +46159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -46135,7 +46168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -46144,7 +46177,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 1220,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -46153,61 +46240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 1220,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -46216,7 +46249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -46225,7 +46258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -46234,7 +46267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -46243,7 +46276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -46252,7 +46285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -46261,7 +46294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -46270,7 +46303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -46279,7 +46312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -46288,7 +46321,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1229,
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 1230,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -46297,61 +46384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 1230,
+      "community": 1231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -46360,7 +46393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -46369,7 +46402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -46378,7 +46411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -46387,7 +46420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -46396,7 +46429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -46405,7 +46438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -46414,7 +46447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -46423,7 +46456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -46432,7 +46465,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1239,
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 1240,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -46441,61 +46528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1240,
+      "community": 1241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -46504,7 +46537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -46513,7 +46546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -46522,7 +46555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -46531,7 +46564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -46540,7 +46573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -46549,7 +46582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -46558,7 +46591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -46567,7 +46600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -46576,7 +46609,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1249,
+      "community": 125,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1250,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -46585,61 +46672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 1250,
+      "community": 1251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -46648,7 +46681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -46657,7 +46690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -46666,7 +46699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -46675,7 +46708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -46684,7 +46717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -46693,7 +46726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -46702,7 +46735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -46711,7 +46744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -46720,7 +46753,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 1260,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -46729,61 +46816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 1260,
+      "community": 1261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -46792,7 +46825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -46801,7 +46834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -46810,7 +46843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -46819,7 +46852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -46828,7 +46861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -46837,7 +46870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -46846,7 +46879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -46855,7 +46888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -46864,7 +46897,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 1270,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -46873,61 +46960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1270,
+      "community": 1271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -46936,7 +46969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -46945,7 +46978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -46954,7 +46987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -46963,7 +46996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -46972,7 +47005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -46981,7 +47014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -46990,7 +47023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -46999,7 +47032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -47008,7 +47041,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1279,
+      "community": 128,
+      "file_type": "code",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1280,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -47017,61 +47104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 1280,
+      "community": 1281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -47080,7 +47113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -47089,7 +47122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -47098,7 +47131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -47107,7 +47140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -47116,7 +47149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -47125,7 +47158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -47134,7 +47167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -47143,7 +47176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -47152,7 +47185,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1289,
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 1290,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -47161,61 +47248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 1290,
+      "community": 1291,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -47224,7 +47257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -47233,7 +47266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -47242,7 +47275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -47251,7 +47284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -47260,7 +47293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -47269,7 +47302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -47278,7 +47311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -47287,21 +47320,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
       "source_file": "packages/storefront-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1"
     },
     {
@@ -47478,59 +47502,68 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -47539,7 +47572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -47548,7 +47581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -47557,7 +47590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -47566,7 +47599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -47575,7 +47608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -47584,7 +47617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -47593,7 +47626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -47602,7 +47635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -47611,7 +47644,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1309,
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 1310,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -47620,61 +47707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
-      "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1310,
+      "community": 1311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -47683,7 +47716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -47692,7 +47725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -47701,7 +47734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -47710,7 +47743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -47719,7 +47752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -47728,7 +47761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -47737,7 +47770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -47746,7 +47779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -47755,7 +47788,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1319,
+      "community": 132,
+      "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1320,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -47764,61 +47851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 1320,
+      "community": 1321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -47827,7 +47860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -47836,7 +47869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -47845,7 +47878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -47854,7 +47887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -47863,7 +47896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -47872,7 +47905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -47881,7 +47914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -47890,7 +47923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -47899,7 +47932,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1329,
+      "community": 133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 1330,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -47908,61 +47995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 1330,
+      "community": 1331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -47971,7 +48004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -47980,7 +48013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -47989,7 +48022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -47998,7 +48031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_test_tsx",
       "label": "MobileProductActions.test.tsx",
@@ -48007,7 +48040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -48016,7 +48049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -48025,7 +48058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -48034,7 +48067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -48043,7 +48076,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1339,
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 1340,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -48052,61 +48139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 1340,
+      "community": 1341,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -48115,7 +48148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -48124,7 +48157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -48133,7 +48166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -48142,7 +48175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -48151,7 +48184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -48160,7 +48193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -48169,7 +48202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -48178,7 +48211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -48187,7 +48220,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1349,
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1350,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -48196,61 +48283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1350,
+      "community": 1351,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -48259,7 +48292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -48268,7 +48301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -48277,7 +48310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -48286,7 +48319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -48295,7 +48328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -48304,7 +48337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -48313,7 +48346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -48322,7 +48355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -48331,7 +48364,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1359,
+      "community": 136,
+      "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1360,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -48340,61 +48427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
-      "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L124"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L142"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1360,
+      "community": 1361,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -48403,7 +48436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -48412,7 +48445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -48421,7 +48454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -48430,7 +48463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -48439,7 +48472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -48448,7 +48481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -48457,7 +48490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -48466,7 +48499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -48475,7 +48508,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1369,
+      "community": 137,
+      "file_type": "code",
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L124"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L142"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1370,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -48484,61 +48571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1370,
+      "community": 1371,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -48547,7 +48580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -48556,7 +48589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -48565,7 +48598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -48574,7 +48607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -48583,7 +48616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -48592,7 +48625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -48601,7 +48634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -48610,7 +48643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -48619,7 +48652,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1379,
+      "community": 138,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1380,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -48628,61 +48715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 138,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1380,
+      "community": 1381,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -48691,7 +48724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -48700,7 +48733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -48709,7 +48742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -48718,7 +48751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -48727,7 +48760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -48736,7 +48769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -48745,7 +48778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -48754,21 +48787,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "label": "useStorefrontObservability.ts",
-      "norm_label": "usestorefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1"
     },
     {
@@ -48828,6 +48852,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
+      "label": "useStorefrontObservability.ts",
+      "norm_label": "usestorefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -48835,7 +48868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -48844,7 +48877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -48853,7 +48886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -48862,7 +48895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -48871,7 +48904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -48880,7 +48913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -48889,7 +48922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -48898,21 +48931,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1"
     },
     {
@@ -49143,6 +49167,15 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
@@ -49150,7 +49183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -49159,7 +49192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -49168,7 +49201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -49177,7 +49210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -49186,7 +49219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -49195,7 +49228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -49204,7 +49237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -49213,21 +49246,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
       "norm_label": "storefrontjourneyevents.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -49287,6 +49311,15 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
@@ -49294,7 +49327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -49303,7 +49336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -49312,7 +49345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -49321,7 +49354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -49330,7 +49363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -49339,7 +49372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -49348,7 +49381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -49357,21 +49390,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
       "norm_label": "shop.saved.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "label": "bag.index.tsx",
-      "norm_label": "bag.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1"
     },
     {
@@ -49431,6 +49455,15 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
+      "label": "bag.index.tsx",
+      "norm_label": "bag.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
       "norm_label": "complete.tsx",
@@ -49438,7 +49471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -49447,7 +49480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -49456,7 +49489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -49465,7 +49498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -49474,7 +49507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -49483,7 +49516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -49492,7 +49525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -49501,21 +49534,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
       "norm_label": "harness-app-registry.test.ts",
       "source_file": "scripts/harness-app-registry.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
-      "label": "valkey-runtime-app.test.ts",
-      "norm_label": "valkey-runtime-app.test.ts",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
       "source_location": "L1"
     },
     {
@@ -49566,6 +49590,15 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
+      "label": "valkey-runtime-app.test.ts",
+      "norm_label": "valkey-runtime-app.test.ts",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
       "norm_label": "harness-behavior-scenarios.test.ts",
@@ -49573,7 +49606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -61797,6 +61830,33 @@
     {
       "community": 395,
       "file_type": "code",
+      "id": "index_money",
+      "label": "money()",
+      "norm_label": "money()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 395,
+      "file_type": "code",
+      "id": "index_paymentlabel",
+      "label": "paymentLabel()",
+      "norm_label": "paymentlabel()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 395,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 396,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
       "norm_label": "signup.tsx",
@@ -61804,7 +61864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -61813,7 +61873,7 @@
       "source_location": "L161"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -61822,7 +61882,7 @@
       "source_location": "L66"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -61831,7 +61891,7 @@
       "source_location": "L11"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -61840,7 +61900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -61849,7 +61909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -61858,7 +61918,7 @@
       "source_location": "L16"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -61867,7 +61927,7 @@
       "source_location": "L10"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -61876,7 +61936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -61885,7 +61945,7 @@
       "source_location": "L17"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -61894,39 +61954,12 @@
       "source_location": "L11"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
       "norm_label": "harness-audit.test.ts",
       "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "harness_behavior_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "harness_behavior_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_test_ts",
-      "label": "harness-behavior.test.ts",
-      "norm_label": "harness-behavior.test.ts",
-      "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L1"
     },
     {
@@ -62292,6 +62325,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "harness_behavior_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "harness_behavior_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_test_ts",
+      "label": "harness-behavior.test.ts",
+      "norm_label": "harness-behavior.test.ts",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -62299,7 +62359,7 @@
       "source_location": "L48"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -62308,7 +62368,7 @@
       "source_location": "L42"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -62317,7 +62377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62326,7 +62386,7 @@
       "source_location": "L16"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -62335,7 +62395,7 @@
       "source_location": "L10"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -62344,7 +62404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62353,7 +62413,7 @@
       "source_location": "L19"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -62362,7 +62422,7 @@
       "source_location": "L13"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -62371,7 +62431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62380,7 +62440,7 @@
       "source_location": "L16"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -62389,7 +62449,7 @@
       "source_location": "L10"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -62398,7 +62458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -62407,7 +62467,7 @@
       "source_location": "L20"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -62416,7 +62476,7 @@
       "source_location": "L14"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -62425,7 +62485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -62434,7 +62494,7 @@
       "source_location": "L26"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -62443,7 +62503,7 @@
       "source_location": "L18"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -62452,7 +62512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -62461,7 +62521,7 @@
       "source_location": "L45"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -62470,7 +62530,7 @@
       "source_location": "L20"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -62479,7 +62539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -62488,7 +62548,7 @@
       "source_location": "L8"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -62497,7 +62557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -62506,31 +62566,13 @@
       "source_location": "L9"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
       "norm_label": "deposits.test.ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
-      "label": "paymentAllocationAttribution.test.ts",
-      "norm_label": "paymentallocationattribution.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "paymentallocationattribution_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
-      "source_location": "L12"
     },
     {
       "community": 41,
@@ -62634,6 +62676,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
+      "label": "paymentAllocationAttribution.test.ts",
+      "norm_label": "paymentallocationattribution.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "paymentallocationattribution_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
       "norm_label": "stream.ts",
@@ -62641,7 +62701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -62650,7 +62710,7 @@
       "source_location": "L8"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -62659,7 +62719,7 @@
       "source_location": "L10"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -62668,7 +62728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -62677,7 +62737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -62686,7 +62746,7 @@
       "source_location": "L18"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -62695,7 +62755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
@@ -62704,7 +62764,7 @@
       "source_location": "L10"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -62713,7 +62773,7 @@
       "source_location": "L10"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -62722,7 +62782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -62731,7 +62791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -62740,7 +62800,7 @@
       "source_location": "L6"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -62749,7 +62809,7 @@
       "source_location": "L110"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -62758,7 +62818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -62767,7 +62827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -62776,7 +62836,7 @@
       "source_location": "L8"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -62785,31 +62845,13 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
       "norm_label": "usererrorfromsessionitemfailure()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L22"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "label": "productUtil.ts",
-      "norm_label": "productutil.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "productutil_buildallproductscachekey",
-      "label": "buildAllProductsCacheKey()",
-      "norm_label": "buildallproductscachekey()",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L8"
     },
     {
       "community": 42,
@@ -62913,6 +62955,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
+      "label": "productUtil.ts",
+      "norm_label": "productutil.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "productutil_buildallproductscachekey",
+      "label": "buildAllProductsCacheKey()",
+      "norm_label": "buildallproductscachekey()",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -62920,7 +62980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -62929,7 +62989,7 @@
       "source_location": "L29"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -62938,7 +62998,7 @@
       "source_location": "L22"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -62947,7 +63007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -62956,7 +63016,7 @@
       "source_location": "L4"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -62965,7 +63025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -62974,7 +63034,7 @@
       "source_location": "L3"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -62983,7 +63043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -62992,7 +63052,7 @@
       "source_location": "L3"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -63001,7 +63061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -63010,7 +63070,7 @@
       "source_location": "L6"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -63019,7 +63079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -63028,7 +63088,7 @@
       "source_location": "L3"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -63037,7 +63097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -63046,7 +63106,7 @@
       "source_location": "L19"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -63055,7 +63115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -63064,30 +63124,12 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
       "norm_label": "eventbuilders.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "emailotp_formatvalidtime",
-      "label": "formatValidTime()",
-      "norm_label": "formatvalidtime()",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
-      "label": "EmailOTP.ts",
-      "norm_label": "emailotp.ts",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
       "source_location": "L1"
     },
     {
@@ -63192,6 +63234,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "emailotp_formatvalidtime",
+      "label": "formatValidTime()",
+      "norm_label": "formatvalidtime()",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
+      "label": "EmailOTP.ts",
+      "norm_label": "emailotp.ts",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
       "norm_label": "quickaddcatalogitem.test.ts",
@@ -63199,7 +63259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -63208,7 +63268,7 @@
       "source_location": "L17"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -63217,7 +63277,7 @@
       "source_location": "L31"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -63226,7 +63286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -63235,7 +63295,7 @@
       "source_location": "L6"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -63244,7 +63304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -63253,7 +63313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -63262,7 +63322,7 @@
       "source_location": "L88"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -63271,7 +63331,7 @@
       "source_location": "L9"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -63280,7 +63340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -63289,7 +63349,7 @@
       "source_location": "L4"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -63298,7 +63358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -63307,7 +63367,7 @@
       "source_location": "L15"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -63316,7 +63376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -63325,7 +63385,7 @@
       "source_location": "L7"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -63334,7 +63394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -63343,31 +63403,13 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
-      "label": "vendors.test.ts",
-      "norm_label": "vendors.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "vendors_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L5"
     },
     {
       "community": 44,
@@ -63471,6 +63513,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
+      "label": "vendors.test.ts",
+      "norm_label": "vendors.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "vendors_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
@@ -63478,7 +63538,7 @@
       "source_location": "L15"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -63487,7 +63547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -63496,7 +63556,7 @@
       "source_location": "L8"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -63505,7 +63565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -63514,7 +63574,7 @@
       "source_location": "L17"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -63523,7 +63583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -63532,7 +63592,7 @@
       "source_location": "L6"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -63541,7 +63601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -63550,7 +63610,7 @@
       "source_location": "L5"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -63559,7 +63619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -63568,7 +63628,7 @@
       "source_location": "L25"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -63577,7 +63637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -63586,7 +63646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -63595,7 +63655,7 @@
       "source_location": "L19"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -63604,7 +63664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -63613,7 +63673,7 @@
       "source_location": "L7"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -63622,31 +63682,13 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
       "norm_label": "listsavedbagitems()",
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "label": "storefrontObservabilityReport.test.ts",
-      "norm_label": "storefrontobservabilityreport.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 45,
@@ -63750,6 +63792,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
+      "label": "storefrontObservabilityReport.test.ts",
+      "norm_label": "storefrontobservabilityreport.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
       "norm_label": "syntheticmonitor.ts",
@@ -63757,7 +63817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -63766,7 +63826,7 @@
       "source_location": "L3"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -63775,7 +63835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -63784,7 +63844,7 @@
       "source_location": "L5"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -63793,7 +63853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -63802,7 +63862,7 @@
       "source_location": "L16"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -63811,7 +63871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -63820,7 +63880,7 @@
       "source_location": "L30"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -63829,7 +63889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -63838,7 +63898,7 @@
       "source_location": "L42"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -63847,7 +63907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -63856,7 +63916,7 @@
       "source_location": "L31"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -63865,7 +63925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -63874,7 +63934,7 @@
       "source_location": "L5"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -63883,7 +63943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -63892,7 +63952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -63901,30 +63961,12 @@
       "source_location": "L7"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
       "norm_label": "organizationview.tsx",
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "organizationsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
-      "label": "OrganizationsView.tsx",
-      "norm_label": "organizationsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1"
     },
     {
@@ -64029,6 +64071,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "organizationsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
+      "label": "OrganizationsView.tsx",
+      "norm_label": "organizationsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
       "norm_label": "permissiongate.tsx",
@@ -64036,7 +64096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -64045,7 +64105,7 @@
       "source_location": "L11"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -64054,7 +64114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -64063,7 +64123,7 @@
       "source_location": "L11"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -64072,7 +64132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -64081,7 +64141,7 @@
       "source_location": "L3"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -64090,7 +64150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -64099,7 +64159,7 @@
       "source_location": "L12"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -64108,7 +64168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -64117,7 +64177,7 @@
       "source_location": "L42"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -64126,7 +64186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -64135,7 +64195,7 @@
       "source_location": "L13"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -64144,7 +64204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -64153,7 +64213,7 @@
       "source_location": "L42"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -64162,7 +64222,7 @@
       "source_location": "L31"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -64171,7 +64231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -64180,31 +64240,13 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
       "norm_label": "processingfeesview()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "productattributes_isallowedattribute",
-      "label": "isAllowedAttribute()",
-      "norm_label": "isallowedattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L14"
     },
     {
       "community": 47,
@@ -64299,6 +64341,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "productattributes_isallowedattribute",
+      "label": "isAllowedAttribute()",
+      "norm_label": "isallowedattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
       "norm_label": "productavailabilitytogglegroup.tsx",
@@ -64306,7 +64366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -64315,7 +64375,7 @@
       "source_location": "L5"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -64324,7 +64384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -64333,7 +64393,7 @@
       "source_location": "L10"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -64342,7 +64402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -64351,7 +64411,7 @@
       "source_location": "L15"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -64360,7 +64420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -64369,7 +64429,7 @@
       "source_location": "L13"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -64378,7 +64438,7 @@
       "source_location": "L116"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -64387,7 +64447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -64396,7 +64456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -64405,7 +64465,7 @@
       "source_location": "L47"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -64414,7 +64474,7 @@
       "source_location": "L151"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -64423,7 +64483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -64432,7 +64492,7 @@
       "source_location": "L6"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -64441,7 +64501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -64450,30 +64510,12 @@
       "source_location": "L19"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
       "norm_label": "analyticsproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "analyticsusers_analyticsusers",
-      "label": "AnalyticsUsers()",
-      "norm_label": "analyticsusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
-      "label": "AnalyticsUsers.tsx",
-      "norm_label": "analyticsusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1"
     },
     {
@@ -64569,6 +64611,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "analyticsusers_analyticsusers",
+      "label": "AnalyticsUsers()",
+      "norm_label": "analyticsusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
+      "label": "AnalyticsUsers.tsx",
+      "norm_label": "analyticsusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
       "norm_label": "getdaterangemilliseconds()",
@@ -64576,7 +64636,7 @@
       "source_location": "L42"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -64585,7 +64645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -64594,7 +64654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -64603,7 +64663,7 @@
       "source_location": "L66"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -64612,7 +64672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -64621,7 +64681,7 @@
       "source_location": "L18"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -64630,7 +64690,7 @@
       "source_location": "L6"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -64639,7 +64699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -64648,7 +64708,7 @@
       "source_location": "L10"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -64657,7 +64717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -64666,7 +64726,7 @@
       "source_location": "L27"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -64675,7 +64735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -64684,7 +64744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -64693,7 +64753,7 @@
       "source_location": "L12"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -64702,7 +64762,7 @@
       "source_location": "L3"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -64711,7 +64771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -64720,30 +64780,12 @@
       "source_location": "L5"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "bulkoperationsfilters_handleloadproducts",
-      "label": "handleLoadProducts()",
-      "norm_label": "handleloadproducts()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
-      "label": "BulkOperationsFilters.tsx",
-      "norm_label": "bulkoperationsfilters.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L1"
     },
     {
@@ -64839,6 +64881,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "bulkoperationsfilters_handleloadproducts",
+      "label": "handleLoadProducts()",
+      "norm_label": "handleloadproducts()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
+      "label": "BulkOperationsFilters.tsx",
+      "norm_label": "bulkoperationsfilters.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
       "norm_label": "makerow()",
@@ -64846,7 +64906,7 @@
       "source_location": "L23"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -64855,7 +64915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -64864,7 +64924,7 @@
       "source_location": "L50"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -64873,7 +64933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -64882,7 +64942,7 @@
       "source_location": "L13"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -64891,7 +64951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -64900,7 +64960,7 @@
       "source_location": "L11"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -64909,7 +64969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -64918,7 +64978,7 @@
       "source_location": "L31"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -64927,7 +64987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -64936,7 +64996,7 @@
       "source_location": "L29"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -64945,7 +65005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -64954,7 +65014,7 @@
       "source_location": "L37"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -64963,7 +65023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -64972,7 +65032,7 @@
       "source_location": "L25"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -64981,7 +65041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -64990,31 +65050,13 @@
       "source_location": "L83"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
       "norm_label": "landingpagereelversion.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
-      "label": "ShopLookDialog.tsx",
-      "norm_label": "shoplookdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "shoplookdialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L35"
     },
     {
       "community": 5,
@@ -65361,6 +65403,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
+      "label": "ShopLookDialog.tsx",
+      "norm_label": "shoplookdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "shoplookdialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
       "norm_label": "shoplookimageuploader.tsx",
@@ -65368,7 +65428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -65377,7 +65437,7 @@
       "source_location": "L28"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -65386,7 +65446,7 @@
       "source_location": "L12"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -65395,7 +65455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -65404,7 +65464,7 @@
       "source_location": "L13"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -65413,7 +65473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -65422,7 +65482,7 @@
       "source_location": "L43"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -65431,7 +65491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -65440,7 +65500,7 @@
       "source_location": "L33"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -65449,7 +65509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -65458,7 +65518,7 @@
       "source_location": "L35"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -65467,7 +65527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -65476,7 +65536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -65485,7 +65545,7 @@
       "source_location": "L81"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -65494,7 +65554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -65503,7 +65563,7 @@
       "source_location": "L6"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -65512,30 +65572,12 @@
       "source_location": "L34"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "ordercolumns_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
-      "label": "orderColumns.tsx",
-      "norm_label": "ordercolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -65631,6 +65673,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "ordercolumns_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
+      "label": "orderColumns.tsx",
+      "norm_label": "ordercolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
       "norm_label": "cashierview()",
@@ -65638,7 +65698,7 @@
       "source_location": "L8"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -65647,7 +65707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -65656,7 +65716,7 @@
       "source_location": "L5"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -65665,7 +65725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -65674,7 +65734,7 @@
       "source_location": "L7"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -65683,7 +65743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -65692,7 +65752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -65701,7 +65761,7 @@
       "source_location": "L13"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -65710,7 +65770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -65719,7 +65779,7 @@
       "source_location": "L35"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -65728,7 +65788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -65737,7 +65797,7 @@
       "source_location": "L3"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -65746,7 +65806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -65755,7 +65815,7 @@
       "source_location": "L14"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -65764,7 +65824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -65773,7 +65833,7 @@
       "source_location": "L15"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -65782,31 +65842,13 @@
       "source_location": "L18"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
       "norm_label": "expensereportsview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
-      "label": "RegisterCustomerAttribution.test.tsx",
-      "norm_label": "registercustomerattribution.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "registercustomerattribution_test_makecustomer",
-      "label": "makeCustomer()",
-      "norm_label": "makecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L28"
     },
     {
       "community": 52,
@@ -65901,6 +65943,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
+      "label": "RegisterCustomerAttribution.test.tsx",
+      "norm_label": "registercustomerattribution.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "registercustomerattribution_test_makecustomer",
+      "label": "makeCustomer()",
+      "norm_label": "makecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
       "norm_label": "registercustomerpanel.tsx",
@@ -65908,7 +65968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -65917,7 +65977,7 @@
       "source_location": "L8"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -65926,7 +65986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -65935,7 +65995,7 @@
       "source_location": "L9"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -65944,7 +66004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
@@ -65953,7 +66013,7 @@
       "source_location": "L31"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -65962,7 +66022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -65971,7 +66031,7 @@
       "source_location": "L25"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -65980,7 +66040,7 @@
       "source_location": "L14"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -65989,7 +66049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -65998,7 +66058,7 @@
       "source_location": "L6"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -66007,7 +66067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -66016,7 +66076,7 @@
       "source_location": "L37"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -66025,7 +66085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -66034,7 +66094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -66043,7 +66103,7 @@
       "source_location": "L11"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -66052,31 +66112,13 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
       "norm_label": "skuselector()",
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_actions_tsx",
-      "label": "product-actions.tsx",
-      "norm_label": "product-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "product_actions_usedeleteproduct",
-      "label": "useDeleteProduct()",
-      "norm_label": "usedeleteproduct()",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L6"
     },
     {
       "community": 53,
@@ -66171,6 +66213,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_actions_tsx",
+      "label": "product-actions.tsx",
+      "norm_label": "product-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "product_actions_usedeleteproduct",
+      "label": "useDeleteProduct()",
+      "norm_label": "usedeleteproduct()",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
       "norm_label": "productsview.tsx",
@@ -66178,7 +66238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -66187,7 +66247,7 @@
       "source_location": "L5"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -66196,7 +66256,7 @@
       "source_location": "L17"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -66205,7 +66265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -66214,7 +66274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -66223,7 +66283,7 @@
       "source_location": "L4"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -66232,7 +66292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -66241,7 +66301,7 @@
       "source_location": "L84"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -66250,7 +66310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -66259,7 +66319,7 @@
       "source_location": "L23"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -66268,7 +66328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -66277,7 +66337,7 @@
       "source_location": "L37"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -66286,7 +66346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -66295,7 +66355,7 @@
       "source_location": "L9"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -66304,7 +66364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -66313,7 +66373,7 @@
       "source_location": "L23"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -66322,31 +66382,13 @@
       "source_location": "L5"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
       "norm_label": "discounttypetogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
-      "label": "PromoCodeSpanToggleGroup.tsx",
-      "norm_label": "promocodespantogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "label": "PromoCodeSpanToggleGroup()",
-      "norm_label": "promocodespantogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L4"
     },
     {
       "community": 54,
@@ -66441,6 +66483,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
+      "label": "PromoCodeSpanToggleGroup.tsx",
+      "norm_label": "promocodespantogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "promocodespantogglegroup_promocodespantogglegroup",
+      "label": "PromoCodeSpanToggleGroup()",
+      "norm_label": "promocodespantogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
       "norm_label": "capturedemails()",
@@ -66448,7 +66508,7 @@
       "source_location": "L13"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -66457,7 +66517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -66466,7 +66526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -66475,7 +66535,7 @@
       "source_location": "L29"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -66484,7 +66544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -66493,7 +66553,7 @@
       "source_location": "L20"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -66502,7 +66562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -66511,7 +66571,7 @@
       "source_location": "L63"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -66520,7 +66580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -66529,7 +66589,7 @@
       "source_location": "L30"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -66538,7 +66598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -66547,7 +66607,7 @@
       "source_location": "L59"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -66556,7 +66616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -66565,7 +66625,7 @@
       "source_location": "L45"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -66574,7 +66634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -66583,7 +66643,7 @@
       "source_location": "L47"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -66592,30 +66652,12 @@
       "source_location": "L29"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
       "norm_label": "empty-state.tsx",
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "nopermission_nopermission",
-      "label": "NoPermission()",
-      "norm_label": "nopermission()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
-      "label": "NoPermission.tsx",
-      "norm_label": "nopermission.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1"
     },
     {
@@ -66711,6 +66753,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "nopermission_nopermission",
+      "label": "NoPermission()",
+      "norm_label": "nopermission()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
+      "label": "NoPermission.tsx",
+      "norm_label": "nopermission.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
       "norm_label": "nopermissionview()",
@@ -66718,7 +66778,7 @@
       "source_location": "L4"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -66727,7 +66787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -66736,7 +66796,7 @@
       "source_location": "L4"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -66745,7 +66805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -66754,7 +66814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -66763,7 +66823,7 @@
       "source_location": "L9"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -66772,7 +66832,7 @@
       "source_location": "L9"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -66781,7 +66841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -66790,7 +66850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -66799,7 +66859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -66808,7 +66868,7 @@
       "source_location": "L11"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -66817,7 +66877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -66826,7 +66886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -66835,7 +66895,7 @@
       "source_location": "L25"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -66844,7 +66904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -66853,7 +66913,7 @@
       "source_location": "L21"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -66862,31 +66922,13 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
       "norm_label": "onstoreselect()",
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "calendar_calendar",
-      "label": "Calendar()",
-      "norm_label": "calendar()",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
-      "label": "calendar.tsx",
-      "norm_label": "calendar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -66981,6 +67023,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "calendar_calendar",
+      "label": "Calendar()",
+      "norm_label": "calendar()",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
+      "label": "calendar.tsx",
+      "norm_label": "calendar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
       "norm_label": "usechart()",
@@ -66988,7 +67048,7 @@
       "source_location": "L25"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -66997,7 +67057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -67006,7 +67066,7 @@
       "source_location": "L15"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -67015,7 +67075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -67024,7 +67084,7 @@
       "source_location": "L21"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -67033,7 +67093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -67042,7 +67102,7 @@
       "source_location": "L6"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -67051,7 +67111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -67060,7 +67120,7 @@
       "source_location": "L25"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -67069,7 +67129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -67078,7 +67138,7 @@
       "source_location": "L49"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -67087,7 +67147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -67096,7 +67156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -67105,7 +67165,7 @@
       "source_location": "L63"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -67114,7 +67174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -67123,7 +67183,7 @@
       "source_location": "L5"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -67132,31 +67192,13 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
       "norm_label": "welcomebackmodal()",
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
-      "label": "select-native.tsx",
-      "norm_label": "select-native.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "select_native_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L15"
     },
     {
       "community": 57,
@@ -67251,6 +67293,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
+      "label": "select-native.tsx",
+      "norm_label": "select-native.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "select_native_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
       "norm_label": "timeline-item.tsx",
@@ -67258,7 +67318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -67267,7 +67327,7 @@
       "source_location": "L3"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -67276,7 +67336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -67285,7 +67345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -67294,7 +67354,7 @@
       "source_location": "L5"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -67303,7 +67363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -67312,7 +67372,7 @@
       "source_location": "L11"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -67321,7 +67381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -67330,7 +67390,7 @@
       "source_location": "L4"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -67339,7 +67399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -67348,7 +67408,7 @@
       "source_location": "L110"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -67357,7 +67417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -67366,7 +67426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -67375,7 +67435,7 @@
       "source_location": "L13"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -67384,7 +67444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -67393,7 +67453,7 @@
       "source_location": "L7"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -67402,31 +67462,13 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
       "norm_label": "useronlineorders()",
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
-      "label": "UserStatus.tsx",
-      "norm_label": "userstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "userstatus_userstatus",
-      "label": "UserStatus()",
-      "norm_label": "userstatus()",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L7"
     },
     {
       "community": 58,
@@ -67512,6 +67554,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
+      "label": "UserStatus.tsx",
+      "norm_label": "userstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "userstatus_userstatus",
+      "label": "UserStatus()",
+      "norm_label": "userstatus()",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
       "norm_label": "userview.tsx",
@@ -67519,7 +67579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -67528,7 +67588,7 @@
       "source_location": "L45"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -67537,7 +67597,7 @@
       "source_location": "L13"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -67546,7 +67606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -67555,7 +67615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -67564,7 +67624,7 @@
       "source_location": "L7"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -67573,7 +67633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -67582,7 +67642,7 @@
       "source_location": "L5"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -67591,7 +67651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -67600,7 +67660,7 @@
       "source_location": "L5"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -67609,7 +67669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -67618,7 +67678,7 @@
       "source_location": "L7"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -67627,7 +67687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -67636,7 +67696,7 @@
       "source_location": "L9"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -67645,7 +67705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -67654,7 +67714,7 @@
       "source_location": "L6"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -67663,31 +67723,13 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
       "norm_label": "makesku()",
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
-      "label": "useConvexAuthIdentity.ts",
-      "norm_label": "useconvexauthidentity.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "useconvexauthidentity_useconvexauthidentity",
-      "label": "useConvexAuthIdentity()",
-      "norm_label": "useconvexauthidentity()",
-      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
-      "source_location": "L5"
     },
     {
       "community": 59,
@@ -67773,6 +67815,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
+      "label": "useConvexAuthIdentity.ts",
+      "norm_label": "useconvexauthidentity.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "useconvexauthidentity_useconvexauthidentity",
+      "label": "useConvexAuthIdentity()",
+      "norm_label": "useconvexauthidentity()",
+      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
       "norm_label": "usecopytext.ts",
@@ -67780,7 +67840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -67789,7 +67849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -67798,7 +67858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -67807,7 +67867,7 @@
       "source_location": "L6"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -67816,7 +67876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -67825,7 +67885,7 @@
       "source_location": "L12"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -67834,7 +67894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -67843,7 +67903,7 @@
       "source_location": "L24"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -67852,7 +67912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -67861,7 +67921,7 @@
       "source_location": "L6"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -67870,7 +67930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -67879,7 +67939,7 @@
       "source_location": "L4"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -67888,7 +67948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -67897,7 +67957,7 @@
       "source_location": "L5"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -67906,7 +67966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -67915,7 +67975,7 @@
       "source_location": "L5"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -67924,31 +67984,13 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
       "norm_label": "usegetcurrencyformatter()",
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
-      "label": "useGetSubcategories.ts",
-      "norm_label": "usegetsubcategories.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "usegetsubcategories_usegetsubcategories",
-      "label": "useGetSubcategories()",
-      "norm_label": "usegetsubcategories()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
-      "source_location": "L5"
     },
     {
       "community": 6,
@@ -68268,6 +68310,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
+      "label": "useGetSubcategories.ts",
+      "norm_label": "usegetsubcategories.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "usegetsubcategories_usegetsubcategories",
+      "label": "useGetSubcategories()",
+      "norm_label": "usegetsubcategories()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
       "norm_label": "usegetterminal.ts",
@@ -68275,7 +68335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -68284,7 +68344,7 @@
       "source_location": "L5"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -68293,7 +68353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -68302,7 +68362,7 @@
       "source_location": "L8"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -68311,7 +68371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -68320,7 +68380,7 @@
       "source_location": "L13"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -68329,7 +68389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -68338,7 +68398,7 @@
       "source_location": "L3"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -68347,7 +68407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -68356,7 +68416,7 @@
       "source_location": "L27"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -68365,7 +68425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -68374,7 +68434,7 @@
       "source_location": "L7"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -68383,7 +68443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -68392,7 +68452,7 @@
       "source_location": "L5"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -68401,7 +68461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -68410,7 +68470,7 @@
       "source_location": "L12"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -68419,31 +68479,13 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
       "norm_label": "useskusreservedinpossession()",
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
-      "label": "useToggleComplimentaryProductActive.ts",
-      "norm_label": "usetogglecomplimentaryproductactive.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "label": "useToggleComplimentaryProductActive()",
-      "norm_label": "usetogglecomplimentaryproductactive()",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L5"
     },
     {
       "community": 61,
@@ -68529,6 +68571,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
+      "label": "useToggleComplimentaryProductActive.ts",
+      "norm_label": "usetogglecomplimentaryproductactive.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
+      "label": "useToggleComplimentaryProductActive()",
+      "norm_label": "usetogglecomplimentaryproductactive()",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
       "norm_label": "tooperatormessage()",
@@ -68536,7 +68596,7 @@
       "source_location": "L44"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -68545,7 +68605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -68554,7 +68614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -68563,7 +68623,7 @@
       "source_location": "L6"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -68572,7 +68632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -68581,7 +68641,7 @@
       "source_location": "L7"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -68590,7 +68650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -68599,7 +68659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -68608,7 +68668,7 @@
       "source_location": "L5"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -68617,7 +68677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -68626,7 +68686,7 @@
       "source_location": "L6"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -68635,7 +68695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -68644,7 +68704,7 @@
       "source_location": "L5"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -68653,7 +68713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -68662,7 +68722,7 @@
       "source_location": "L5"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -68671,7 +68731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -68680,31 +68740,13 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
       "norm_label": "startsession()",
       "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "calculations_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
-      "label": "calculations.ts",
-      "norm_label": "calculations.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L1"
     },
     {
       "community": 62,
@@ -68790,6 +68832,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "calculations_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
+      "label": "calculations.ts",
+      "norm_label": "calculations.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
       "norm_label": "useregisterviewmodel.test.ts",
@@ -68797,7 +68857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "useregisterviewmodel_test_deferred",
       "label": "deferred()",
@@ -68806,7 +68866,7 @@
       "source_location": "L165"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -68815,7 +68875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -68824,7 +68884,7 @@
       "source_location": "L12"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -68833,7 +68893,7 @@
       "source_location": "L9"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -68842,7 +68902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -68851,7 +68911,7 @@
       "source_location": "L6"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -68860,7 +68920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -68869,7 +68929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -68878,7 +68938,7 @@
       "source_location": "L6"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -68887,7 +68947,7 @@
       "source_location": "L13"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -68896,7 +68956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -68905,7 +68965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -68914,7 +68974,7 @@
       "source_location": "L9"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -68923,7 +68983,7 @@
       "source_location": "L13"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -68932,7 +68992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -68941,30 +69001,12 @@
       "source_location": "L4"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
       "norm_label": "_layout.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "organizationssettingsaccordion_organizationsettingsaccordion",
-      "label": "OrganizationSettingsAccordion()",
-      "norm_label": "organizationsettingsaccordion()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
-      "label": "OrganizationsSettingsAccordion.tsx",
-      "norm_label": "organizationssettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L1"
     },
     {
@@ -69051,6 +69093,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "organizationssettingsaccordion_organizationsettingsaccordion",
+      "label": "OrganizationSettingsAccordion()",
+      "norm_label": "organizationsettingsaccordion()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
+      "label": "OrganizationsSettingsAccordion.tsx",
+      "norm_label": "organizationssettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
       "norm_label": "patternsoverview()",
@@ -69058,7 +69118,7 @@
       "source_location": "L5"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -69067,7 +69127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -69076,7 +69136,7 @@
       "source_location": "L17"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -69085,7 +69145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -69094,7 +69154,7 @@
       "source_location": "L15"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -69103,7 +69163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -69112,7 +69172,7 @@
       "source_location": "L12"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -69121,7 +69181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -69130,7 +69190,7 @@
       "source_location": "L5"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -69139,7 +69199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -69148,7 +69208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -69157,7 +69217,7 @@
       "source_location": "L13"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -69166,7 +69226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -69175,7 +69235,7 @@
       "source_location": "L14"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -69184,7 +69244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -69193,7 +69253,7 @@
       "source_location": "L13"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -69202,31 +69262,13 @@
       "source_location": "L5"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
-      "label": "storybook-theme-decorator.tsx",
-      "norm_label": "storybook-theme-decorator.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "storybook_theme_decorator_withathenatheme",
-      "label": "withAthenaTheme()",
-      "norm_label": "withathenatheme()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
-      "source_location": "L17"
     },
     {
       "community": 64,
@@ -69312,6 +69354,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
+      "label": "storybook-theme-decorator.tsx",
+      "norm_label": "storybook-theme-decorator.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "storybook_theme_decorator_withathenatheme",
+      "label": "withAthenaTheme()",
+      "norm_label": "withathenatheme()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
       "norm_label": "formatnumber()",
@@ -69319,7 +69379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -69328,7 +69388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -69337,7 +69397,7 @@
       "source_location": "L4"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -69346,7 +69406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -69355,7 +69415,7 @@
       "source_location": "L27"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -69364,7 +69424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -69373,7 +69433,7 @@
       "source_location": "L4"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -69382,7 +69442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -69391,7 +69451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -69400,7 +69460,7 @@
       "source_location": "L5"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -69409,7 +69469,7 @@
       "source_location": "L10"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -69418,7 +69478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -69427,7 +69487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -69436,7 +69496,7 @@
       "source_location": "L10"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -69445,7 +69505,7 @@
       "source_location": "L4"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -69454,7 +69514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -69463,30 +69523,12 @@
       "source_location": "L39"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
       "norm_label": "bagsummary.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "checkoutform_checkoutform",
-      "label": "CheckoutForm()",
-      "norm_label": "checkoutform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
-      "label": "CheckoutForm.tsx",
-      "norm_label": "checkoutform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L1"
     },
     {
@@ -69573,6 +69615,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "checkoutform_checkoutform",
+      "label": "CheckoutForm()",
+      "norm_label": "checkoutform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
+      "label": "CheckoutForm.tsx",
+      "norm_label": "checkoutform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
       "norm_label": "checkoutprovider()",
@@ -69580,7 +69640,7 @@
       "source_location": "L71"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -69589,7 +69649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -69598,7 +69658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -69607,7 +69667,7 @@
       "source_location": "L12"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -69616,7 +69676,7 @@
       "source_location": "L6"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -69625,7 +69685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -69634,7 +69694,7 @@
       "source_location": "L18"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -69643,7 +69703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -69652,7 +69712,7 @@
       "source_location": "L10"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -69661,7 +69721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -69670,7 +69730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -69679,7 +69739,7 @@
       "source_location": "L8"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -69688,7 +69748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -69697,7 +69757,7 @@
       "source_location": "L27"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -69706,7 +69766,7 @@
       "source_location": "L40"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -69715,7 +69775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -69724,30 +69784,12 @@
       "source_location": "L3"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
       "norm_label": "derivecheckoutstate.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "checkoutschemas_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
-      "label": "checkoutSchemas.test.ts",
-      "norm_label": "checkoutschemas.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1"
     },
     {
@@ -69825,6 +69867,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "checkoutschemas_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
+      "label": "checkoutSchemas.test.ts",
+      "norm_label": "checkoutschemas.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
       "norm_label": "weborderschema.test.ts",
@@ -69832,7 +69892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -69841,7 +69901,7 @@
       "source_location": "L12"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -69850,7 +69910,7 @@
       "source_location": "L77"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -69859,7 +69919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -69868,7 +69928,7 @@
       "source_location": "L161"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -69877,7 +69937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -69886,7 +69946,7 @@
       "source_location": "L3"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -69895,7 +69955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -69904,7 +69964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -69913,7 +69973,7 @@
       "source_location": "L4"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -69922,7 +69982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -69931,7 +69991,7 @@
       "source_location": "L14"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -69940,7 +70000,7 @@
       "source_location": "L27"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -69949,7 +70009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -69958,7 +70018,7 @@
       "source_location": "L17"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -69967,7 +70027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -69976,30 +70036,12 @@
       "source_location": "L13"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
       "norm_label": "homepagecontent.ts",
       "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "bagmenu_handleonlinkclick",
-      "label": "handleOnLinkClick()",
-      "norm_label": "handleonlinkclick()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "label": "BagMenu.tsx",
-      "norm_label": "bagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1"
     },
     {
@@ -70077,6 +70119,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "bagmenu_handleonlinkclick",
+      "label": "handleOnLinkClick()",
+      "norm_label": "handleonlinkclick()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
+      "label": "BagMenu.tsx",
+      "norm_label": "bagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
       "norm_label": "mobilebagmenu()",
@@ -70084,7 +70144,7 @@
       "source_location": "L7"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -70093,7 +70153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -70102,7 +70162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -70111,7 +70171,7 @@
       "source_location": "L17"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -70120,7 +70180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -70129,7 +70189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -70138,7 +70198,7 @@
       "source_location": "L12"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -70147,7 +70207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -70156,7 +70216,7 @@
       "source_location": "L7"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -70165,7 +70225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -70174,7 +70234,7 @@
       "source_location": "L45"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -70183,7 +70243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -70192,7 +70252,7 @@
       "source_location": "L5"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -70201,7 +70261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -70210,7 +70270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -70219,7 +70279,7 @@
       "source_location": "L17"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -70228,31 +70288,13 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
       "norm_label": "productattributes()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
-      "label": "ProductPage.test.tsx",
-      "norm_label": "productpage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "productpage_test_makepagestate",
-      "label": "makePageState()",
-      "norm_label": "makepagestate()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
-      "source_location": "L37"
     },
     {
       "community": 68,
@@ -70329,6 +70371,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
+      "label": "ProductPage.test.tsx",
+      "norm_label": "productpage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "productpage_test_makepagestate",
+      "label": "makePageState()",
+      "norm_label": "makepagestate()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
       "norm_label": "productpage.tsx",
@@ -70336,7 +70396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -70345,7 +70405,7 @@
       "source_location": "L79"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -70354,7 +70414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -70363,7 +70423,7 @@
       "source_location": "L87"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -70372,7 +70432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -70381,7 +70441,7 @@
       "source_location": "L8"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -70390,7 +70450,7 @@
       "source_location": "L12"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -70399,7 +70459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -70408,7 +70468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -70417,7 +70477,7 @@
       "source_location": "L18"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -70426,7 +70486,7 @@
       "source_location": "L10"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -70435,7 +70495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -70444,7 +70504,7 @@
       "source_location": "L11"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -70453,7 +70513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -70462,7 +70522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -70471,7 +70531,7 @@
       "source_location": "L59"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -70480,31 +70540,13 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
       "norm_label": "handleredeemreward()",
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "bagitem_bagitem",
-      "label": "BagItem()",
-      "norm_label": "bagitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "label": "BagItem.tsx",
-      "norm_label": "bagitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 69,
@@ -70581,6 +70623,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "bagitem_bagitem",
+      "label": "BagItem()",
+      "norm_label": "bagitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
+      "label": "BagItem.tsx",
+      "norm_label": "bagitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
       "norm_label": "checkoutunavailable()",
@@ -70588,7 +70648,7 @@
       "source_location": "L4"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -70597,7 +70657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -70606,7 +70666,7 @@
       "source_location": "L22"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -70615,7 +70675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -70624,7 +70684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -70633,7 +70693,7 @@
       "source_location": "L11"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -70642,7 +70702,7 @@
       "source_location": "L3"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -70651,7 +70711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -70660,7 +70720,7 @@
       "source_location": "L3"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -70669,7 +70729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -70678,7 +70738,7 @@
       "source_location": "L9"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -70687,7 +70747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -70696,7 +70756,7 @@
       "source_location": "L66"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -70705,7 +70765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -70714,7 +70774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -70723,7 +70783,7 @@
       "source_location": "L19"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -70732,31 +70792,13 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
       "norm_label": "welcomebackmodalsuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "leavereviewmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "label": "leaveReviewModalConfig.tsx",
-      "norm_label": "leavereviewmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L1"
     },
     {
       "community": 7,
@@ -71058,6 +71100,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "leavereviewmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
+      "label": "leaveReviewModalConfig.tsx",
+      "norm_label": "leavereviewmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
       "norm_label": "welcomebackmodalconfig.tsx",
@@ -71065,7 +71125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -71074,7 +71134,7 @@
       "source_location": "L46"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -71083,7 +71143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -71092,7 +71152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -71101,7 +71161,7 @@
       "source_location": "L15"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -71110,7 +71170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -71119,7 +71179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -71128,7 +71188,7 @@
       "source_location": "L5"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -71137,7 +71197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -71146,7 +71206,7 @@
       "source_location": "L14"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -71155,7 +71215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -71164,7 +71224,7 @@
       "source_location": "L29"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -71173,7 +71233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -71182,7 +71242,7 @@
       "source_location": "L5"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -71191,7 +71251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -71200,7 +71260,7 @@
       "source_location": "L5"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -71209,31 +71269,13 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
       "norm_label": "usegetproductfilters()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "label": "useGetProductReviews.ts",
-      "norm_label": "usegetproductreviews.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "usegetproductreviews_usegetproductreviewsquery",
-      "label": "useGetProductReviewsQuery()",
-      "norm_label": "usegetproductreviewsquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L4"
     },
     {
       "community": 71,
@@ -71310,6 +71352,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
+      "label": "useGetProductReviews.ts",
+      "norm_label": "usegetproductreviews.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "usegetproductreviews_usegetproductreviewsquery",
+      "label": "useGetProductReviewsQuery()",
+      "norm_label": "usegetproductreviewsquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
       "norm_label": "usegetstore.ts",
@@ -71317,7 +71377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -71326,7 +71386,7 @@
       "source_location": "L4"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -71335,7 +71395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -71344,7 +71404,7 @@
       "source_location": "L9"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -71353,7 +71413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -71362,7 +71422,7 @@
       "source_location": "L17"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -71371,7 +71431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -71380,7 +71440,7 @@
       "source_location": "L5"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -71389,7 +71449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -71398,7 +71458,7 @@
       "source_location": "L15"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -71407,7 +71467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -71416,7 +71476,7 @@
       "source_location": "L18"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -71425,7 +71485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -71434,7 +71494,7 @@
       "source_location": "L9"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -71443,7 +71503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -71452,7 +71512,7 @@
       "source_location": "L16"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -71461,31 +71521,13 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
       "norm_label": "usequeryenabled()",
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "label": "useRewardsAlert.tsx",
-      "norm_label": "userewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "userewardsalert_userewardsalert",
-      "label": "useRewardsAlert()",
-      "norm_label": "userewardsalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L11"
     },
     {
       "community": 72,
@@ -71562,6 +71604,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
+      "label": "useRewardsAlert.tsx",
+      "norm_label": "userewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "userewardsalert_userewardsalert",
+      "label": "useRewardsAlert()",
+      "norm_label": "userewardsalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
       "norm_label": "usescrolltotop.ts",
@@ -71569,7 +71629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -71578,7 +71638,7 @@
       "source_location": "L3"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -71587,7 +71647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -71596,7 +71656,7 @@
       "source_location": "L7"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -71605,7 +71665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -71614,7 +71674,7 @@
       "source_location": "L4"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -71623,7 +71683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -71632,7 +71692,7 @@
       "source_location": "L14"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -71641,7 +71701,7 @@
       "source_location": "L4"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -71650,7 +71710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -71659,7 +71719,7 @@
       "source_location": "L7"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -71668,7 +71728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -71677,7 +71737,7 @@
       "source_location": "L6"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71686,7 +71746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -71695,7 +71755,7 @@
       "source_location": "L10"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -71704,7 +71764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -71713,30 +71773,12 @@
       "source_location": "L6"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
       "norm_label": "inventory.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "onlineorder_useonlineorderqueries",
-      "label": "useOnlineOrderQueries()",
-      "norm_label": "useonlineorderqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -71814,6 +71856,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "onlineorder_useonlineorderqueries",
+      "label": "useOnlineOrderQueries()",
+      "norm_label": "useonlineorderqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
@@ -71821,7 +71881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -71830,7 +71890,7 @@
       "source_location": "L5"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -71839,7 +71899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -71848,7 +71908,7 @@
       "source_location": "L14"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -71857,7 +71917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -71866,7 +71926,7 @@
       "source_location": "L9"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -71875,7 +71935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -71884,7 +71944,7 @@
       "source_location": "L10"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -71893,7 +71953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -71902,7 +71962,7 @@
       "source_location": "L11"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -71911,7 +71971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -71920,7 +71980,7 @@
       "source_location": "L6"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -71929,7 +71989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -71938,7 +71998,7 @@
       "source_location": "L5"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -71947,7 +72007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -71956,7 +72016,7 @@
       "source_location": "L6"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -71965,31 +72025,13 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
       "norm_label": "buildv2config()",
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
-      "label": "storefrontObservability.test.ts",
-      "norm_label": "storefrontobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "storefrontobservability_test_creatememorystorage",
-      "label": "createMemoryStorage()",
-      "norm_label": "creatememorystorage()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L15"
     },
     {
       "community": 74,
@@ -72066,6 +72108,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
+      "label": "storefrontObservability.test.ts",
+      "norm_label": "storefrontobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "storefrontobservability_test_creatememorystorage",
+      "label": "createMemoryStorage()",
+      "norm_label": "creatememorystorage()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
       "norm_label": "validateemail()",
@@ -72073,7 +72133,7 @@
       "source_location": "L14"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -72082,7 +72142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -72091,7 +72151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -72100,7 +72160,7 @@
       "source_location": "L6"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -72109,7 +72169,7 @@
       "source_location": "L13"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -72118,7 +72178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -72127,7 +72187,7 @@
       "source_location": "L8"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -72136,7 +72196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -72145,7 +72205,7 @@
       "source_location": "L14"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -72154,7 +72214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -72163,7 +72223,7 @@
       "source_location": "L13"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -72172,7 +72232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -72181,7 +72241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -72190,7 +72250,7 @@
       "source_location": "L9"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -72199,7 +72259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -72208,7 +72268,7 @@
       "source_location": "L15"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -72217,31 +72277,13 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
       "norm_label": "component()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "layout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L1"
     },
     {
       "community": 75,
@@ -72318,6 +72360,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "layout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
       "norm_label": "homeroute()",
@@ -72325,7 +72385,7 @@
       "source_location": "L10"
     },
     {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -72334,7 +72394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -72343,7 +72403,7 @@
       "source_location": "L21"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -72352,7 +72412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -72361,7 +72421,7 @@
       "source_location": "L33"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -72370,7 +72430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -72379,7 +72439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -72388,7 +72448,7 @@
       "source_location": "L193"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -72397,7 +72457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -72406,7 +72466,7 @@
       "source_location": "L7"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -72415,7 +72475,7 @@
       "source_location": "L10"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -72424,7 +72484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -72433,7 +72493,7 @@
       "source_location": "L32"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -72442,7 +72502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -72451,7 +72511,7 @@
       "source_location": "L211"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -72460,7 +72520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -72469,30 +72529,12 @@
       "source_location": "L85"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
       "norm_label": "sample-app.ts",
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "harness_runtime_trends_test_buildreportline",
-      "label": "buildReportLine()",
-      "norm_label": "buildreportline()",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_test_ts",
-      "label": "harness-runtime-trends.test.ts",
-      "norm_label": "harness-runtime-trends.test.ts",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
       "source_location": "L1"
     },
     {
@@ -72570,6 +72612,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "harness_runtime_trends_test_buildreportline",
+      "label": "buildReportLine()",
+      "norm_label": "buildreportline()",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_test_ts",
+      "label": "harness-runtime-trends.test.ts",
+      "norm_label": "harness-runtime-trends.test.ts",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
       "norm_label": "api.d.ts",
@@ -72577,7 +72637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -72586,7 +72646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -72595,7 +72655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -72604,7 +72664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -72613,7 +72673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -72622,7 +72682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -72631,7 +72691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -72640,21 +72700,12 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
       "norm_label": "registersessions.test.ts",
       "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
       "source_location": "L1"
     },
     {
@@ -72732,6 +72783,15 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
@@ -72739,7 +72799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -72748,7 +72808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -72757,7 +72817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -72766,7 +72826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -72775,7 +72835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -72784,7 +72844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -72793,7 +72853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -72802,21 +72862,12 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
       "norm_label": "env.ts",
       "source_file": "packages/athena-webapp/convex/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -72894,6 +72945,15 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -72901,7 +72961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -72910,7 +72970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -72919,7 +72979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -72928,7 +72988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -72937,7 +72997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -72946,7 +73006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -72955,7 +73015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -72964,21 +73024,12 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
       "source_location": "L1"
     },
     {
@@ -73056,6 +73107,15 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
@@ -73063,7 +73123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -73072,7 +73132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -73081,7 +73141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -73090,7 +73150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -73099,7 +73159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -73108,7 +73168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -73117,7 +73177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -73126,21 +73186,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
       "source_location": "L1"
     },
     {
@@ -73416,6 +73467,15 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
       "norm_label": "security.test.ts",
@@ -73423,7 +73483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -73432,7 +73492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -73441,7 +73501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -73450,7 +73510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -73459,7 +73519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -73468,7 +73528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -73477,7 +73537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -73486,21 +73546,12 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
       "source_location": "L1"
     },
     {
@@ -73578,6 +73629,15 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
@@ -73585,7 +73645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -73594,7 +73654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -73603,7 +73663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -73612,7 +73672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -73621,7 +73681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -73630,7 +73690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -73639,7 +73699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -73648,21 +73708,12 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
       "norm_label": "poscustomers.ts",
       "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
-      "label": "posTerminal.ts",
-      "norm_label": "posterminal.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
       "source_location": "L1"
     },
     {
@@ -73740,6 +73791,15 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
+      "label": "posTerminal.ts",
+      "norm_label": "posterminal.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
       "norm_label": "productsku.ts",
@@ -73747,7 +73807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
@@ -73756,7 +73816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -73765,7 +73825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -73774,7 +73834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -73783,7 +73843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -73792,7 +73852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -73801,7 +73861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -73810,21 +73870,12 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
-      "label": "migrateAmountsToPesewas.ts",
-      "norm_label": "migrateamountstopesewas.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1"
     },
     {
@@ -73902,6 +73953,15 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
+      "label": "migrateAmountsToPesewas.ts",
+      "norm_label": "migrateamountstopesewas.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
       "norm_label": "client.test.ts",
@@ -73909,7 +73969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -73918,7 +73978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -73927,7 +73987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -73936,7 +73996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -73945,7 +74005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -73954,7 +74014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -73963,7 +74023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -73972,21 +74032,12 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
       "norm_label": "completetransaction.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/dto.ts",
       "source_location": "L1"
     },
     {
@@ -74055,6 +74106,15 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/dto.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
       "norm_label": "getregisterstate.test.ts",
@@ -74062,7 +74122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -74071,7 +74131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -74080,7 +74140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -74089,7 +74149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -74098,7 +74158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -74107,7 +74167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -74116,7 +74176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -74125,21 +74185,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
-      "label": "customers.ts",
-      "norm_label": "customers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
       "source_location": "L1"
     },
     {
@@ -74208,6 +74259,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
+      "label": "customers.ts",
+      "norm_label": "customers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -74215,7 +74275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -74224,7 +74284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -74233,7 +74293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -74242,7 +74302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -74251,7 +74311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -74260,7 +74320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -74269,7 +74329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -74278,21 +74338,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
       "source_location": "L1"
     },
     {
@@ -74361,6 +74412,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -74368,7 +74428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -74377,7 +74437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -74386,7 +74446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -74395,7 +74455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -74404,7 +74464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -74413,7 +74473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -74422,7 +74482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -74431,21 +74491,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
       "norm_label": "redeemedpromocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
       "source_location": "L1"
     },
     {
@@ -74514,6 +74565,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -74521,7 +74581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -74530,7 +74590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -74539,7 +74599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -74548,7 +74608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -74557,7 +74617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -74566,7 +74626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -74575,7 +74635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -74584,21 +74644,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
       "norm_label": "inventorymovement.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
-      "label": "operationalEvent.ts",
-      "norm_label": "operationalevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
       "source_location": "L1"
     },
     {
@@ -74667,6 +74718,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
+      "label": "operationalEvent.ts",
+      "norm_label": "operationalevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
       "norm_label": "operationalworkitem.ts",
@@ -74674,7 +74734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -74683,7 +74743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -74692,7 +74752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -74701,7 +74761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -74710,7 +74770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -74719,7 +74779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -74728,7 +74788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -74737,21 +74797,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
       "norm_label": "expensesession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
-      "label": "expenseSessionItem.ts",
-      "norm_label": "expensesessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
       "source_location": "L1"
     },
     {
@@ -74820,6 +74871,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
+      "label": "expenseSessionItem.ts",
+      "norm_label": "expensesessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
       "norm_label": "expensetransaction.ts",
@@ -74827,7 +74887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -74836,7 +74896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -74845,7 +74905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -74854,7 +74914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -74863,7 +74923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -74872,7 +74932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -74881,7 +74941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -74890,21 +74950,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
-      "label": "serviceAppointment.ts",
-      "norm_label": "serviceappointment.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
       "source_location": "L1"
     },
     {
@@ -75162,6 +75213,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
+      "label": "serviceAppointment.ts",
+      "norm_label": "serviceappointment.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
       "norm_label": "servicecase.ts",
@@ -75169,7 +75229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -75178,7 +75238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -75187,7 +75247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -75196,7 +75256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -75205,7 +75265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -75214,7 +75274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -75223,7 +75283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -75232,21 +75292,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
       "norm_label": "stockadjustmentbatch.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
-      "label": "vendor.ts",
-      "norm_label": "vendor.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
       "source_location": "L1"
     },
     {
@@ -75315,6 +75366,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
+      "label": "vendor.ts",
+      "norm_label": "vendor.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
@@ -75322,7 +75382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -75331,7 +75391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -75340,7 +75400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -75349,7 +75409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -75358,7 +75418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -75367,7 +75427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -75376,7 +75436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -75385,21 +75445,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
       "source_location": "L1"
     },
     {
@@ -75468,6 +75519,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
       "norm_label": "review.ts",
@@ -75475,7 +75535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -75484,7 +75544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -75493,7 +75553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -75502,7 +75562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -75511,7 +75571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -75520,7 +75580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -75529,7 +75589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -75538,21 +75598,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
       "norm_label": "catalogappointments.test.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
       "source_location": "L1"
     },
     {
@@ -75621,6 +75672,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
@@ -75628,7 +75688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -75637,7 +75697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -75646,7 +75706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -75655,7 +75715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -75664,7 +75724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -75673,7 +75733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -75682,7 +75742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -75691,21 +75751,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_users_ts",
-      "label": "users.ts",
-      "norm_label": "users.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
       "source_location": "L1"
     },
     {
@@ -75774,6 +75825,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_users_ts",
+      "label": "users.ts",
+      "norm_label": "users.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
@@ -75781,7 +75841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -75790,7 +75850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -75799,7 +75859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -75808,7 +75868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -75817,7 +75877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -75826,7 +75886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -75835,7 +75895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -75844,21 +75904,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
       "norm_label": "commandresult.test.ts",
       "source_file": "packages/athena-webapp/shared/commandResult.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
-      "label": "registerSessionStatus.test.ts",
-      "norm_label": "registersessionstatus.test.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
       "source_location": "L1"
     },
     {
@@ -75927,6 +75978,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
+      "label": "registerSessionStatus.test.ts",
+      "norm_label": "registersessionstatus.test.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
       "norm_label": "genericcombobox.tsx",
@@ -75934,7 +75994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -75943,7 +76003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -75952,7 +76012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -75961,7 +76021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -75970,7 +76030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -75979,7 +76039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -75988,7 +76048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -75997,21 +76057,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -76080,6 +76131,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -76087,7 +76147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -76096,7 +76156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -76105,7 +76165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -76114,7 +76174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -76123,7 +76183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -76132,7 +76192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76141,7 +76201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -76150,21 +76210,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -76233,6 +76284,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -76240,7 +76300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76249,7 +76309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -76258,7 +76318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76267,7 +76327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -76276,7 +76336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76285,7 +76345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76294,7 +76354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -76303,21 +76363,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -76386,6 +76437,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -76393,7 +76453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -76402,7 +76462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -76411,7 +76471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -76420,7 +76480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76429,7 +76489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76438,7 +76498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -76447,7 +76507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -76456,21 +76516,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -76539,6 +76590,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -76546,7 +76606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -76555,7 +76615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -76564,7 +76624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76573,7 +76633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -76582,7 +76642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76591,7 +76651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -76600,7 +76660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -76609,21 +76669,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1517
-- Graph nodes: 3900
-- Graph edges: 3460
-- Communities: 1432
+- Code files discovered: 1518
+- Graph nodes: 3903
+- Graph edges: 3462
+- Communities: 1433
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/storefront-webapp/docs/agent/key-folder-index.md
+++ b/packages/storefront-webapp/docs/agent/key-folder-index.md
@@ -6,7 +6,7 @@ This key-folder index highlights the main directories agents are likely to need 
 
 ## Core app surfaces
 
-- [`src/routes`](../../src/routes) — TanStack Router routes, layouts, and browser journey entrypoints. Currently 34 file(s); key children: -homePageLoader.test.ts, -homePageLoader.ts, __root.tsx, _layout, _layout.tsx.
+- [`src/routes`](../../src/routes) — TanStack Router routes, layouts, and browser journey entrypoints. Currently 35 file(s); key children: -homePageLoader.test.ts, -homePageLoader.ts, __root.tsx, _layout, _layout.tsx.
 - [`src/components`](../../src/components) — Reusable storefront UI and feature-specific checkout/catalog components. Currently 189 file(s); key children: DefaultCatchBoundary.tsx, EntityPage.tsx, HomePage.test.tsx, HomePage.tsx, ProductActionBar.tsx.
 - [`src/hooks`](../../src/hooks) — Client hooks for bag, routing, observability, and auth interactions. Currently 28 file(s); key children: TRACKING_SCALABILITY.md, use-store-modal.tsx, useAuth.ts, useCheckout.ts, useDiscountCodeAlert.tsx.
 - [`src/contexts`](../../src/contexts) — Shared client providers for store, navigation, and observability state. Currently 4 file(s); key children: FormSubmissionProvider.tsx, NavigationBarProvider.tsx, StoreContext.tsx, StorefrontObservabilityProvider.tsx.

--- a/packages/storefront-webapp/docs/agent/route-index.md
+++ b/packages/storefront-webapp/docs/agent/route-index.md
@@ -46,4 +46,5 @@ This route index enumerates the current files under `src/routes` so agents can o
 - [`src/routes/shop/checkout/pending.tsx`](../../src/routes/shop/checkout/pending.tsx)
 - [`src/routes/shop/checkout/pod-confirmation.tsx`](../../src/routes/shop/checkout/pod-confirmation.tsx)
 - [`src/routes/shop/checkout/verify.index.tsx`](../../src/routes/shop/checkout/verify.index.tsx)
+- [`src/routes/shop/receipt/$transactionId/index.tsx`](../../src/routes/shop/receipt/$transactionId/index.tsx)
 

--- a/packages/storefront-webapp/src/routeTree.gen.ts
+++ b/packages/storefront-webapp/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as ShopBagIndexImport } from './routes/shop/bag.index'
 import { Route as LayoutRewardsIndexImport } from './routes/_layout/rewards.index'
 import { Route as ShopCheckoutPodConfirmationImport } from './routes/shop/checkout/pod-confirmation'
 import { Route as ShopCheckoutPendingImport } from './routes/shop/checkout/pending'
+import { Route as ShopReceiptTransactionIdIndexImport } from './routes/shop/receipt/$transactionId/index'
 import { Route as ShopCheckoutVerifyIndexImport } from './routes/shop/checkout/verify.index'
 import { Route as ShopCheckoutCompleteIndexImport } from './routes/shop/checkout/complete.index'
 import { Route as ShopCheckoutSessionIdSlugIndexImport } from './routes/shop/checkout/$sessionIdSlug/index'
@@ -126,6 +127,13 @@ const ShopCheckoutPendingRoute = ShopCheckoutPendingImport.update({
   path: '/shop/checkout/pending',
   getParentRoute: () => rootRoute,
 } as any)
+
+const ShopReceiptTransactionIdIndexRoute =
+  ShopReceiptTransactionIdIndexImport.update({
+    id: '/shop/receipt/$transactionId/',
+    path: '/shop/receipt/$transactionId/',
+    getParentRoute: () => rootRoute,
+  } as any)
 
 const ShopCheckoutVerifyIndexRoute = ShopCheckoutVerifyIndexImport.update({
   id: '/shop/checkout/verify/',
@@ -422,6 +430,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShopCheckoutVerifyIndexImport
       parentRoute: typeof rootRoute
     }
+    '/shop/receipt/$transactionId/': {
+      id: '/shop/receipt/$transactionId/'
+      path: '/shop/receipt/$transactionId'
+      fullPath: '/shop/receipt/$transactionId'
+      preLoaderRoute: typeof ShopReceiptTransactionIdIndexImport
+      parentRoute: typeof rootRoute
+    }
     '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug': {
       id: '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug'
       path: '/shop/$categorySlug/$subcategorySlug'
@@ -559,6 +574,7 @@ export interface FileRoutesByFullPath {
   '/shop/checkout/$sessionIdSlug': typeof ShopCheckoutSessionIdSlugIndexRoute
   '/shop/checkout/complete': typeof ShopCheckoutCompleteIndexRoute
   '/shop/checkout/verify': typeof ShopCheckoutVerifyIndexRoute
+  '/shop/receipt/$transactionId': typeof ShopReceiptTransactionIdIndexRoute
   '/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
   '/shop/orders': typeof LayoutOrdersLayoutShopOrdersIndexRoute
   '/shop/$categorySlug': typeof LayoutShopLayoutShopCategorySlugIndexRoute
@@ -591,6 +607,7 @@ export interface FileRoutesByTo {
   '/shop/checkout/$sessionIdSlug': typeof ShopCheckoutSessionIdSlugIndexRoute
   '/shop/checkout/complete': typeof ShopCheckoutCompleteIndexRoute
   '/shop/checkout/verify': typeof ShopCheckoutVerifyIndexRoute
+  '/shop/receipt/$transactionId': typeof ShopReceiptTransactionIdIndexRoute
   '/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
   '/shop/orders': typeof LayoutOrdersLayoutShopOrdersIndexRoute
   '/shop/$categorySlug': typeof LayoutShopLayoutShopCategorySlugIndexRoute
@@ -626,6 +643,7 @@ export interface FileRoutesById {
   '/shop/checkout/$sessionIdSlug/': typeof ShopCheckoutSessionIdSlugIndexRoute
   '/shop/checkout/complete/': typeof ShopCheckoutCompleteIndexRoute
   '/shop/checkout/verify/': typeof ShopCheckoutVerifyIndexRoute
+  '/shop/receipt/$transactionId/': typeof ShopReceiptTransactionIdIndexRoute
   '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug': typeof LayoutShopLayoutShopCategorySlugSubcategorySlugRoute
   '/_layout/_ordersLayout/shop/orders/': typeof LayoutOrdersLayoutShopOrdersIndexRoute
   '/_layout/_shopLayout/shop/$categorySlug/': typeof LayoutShopLayoutShopCategorySlugIndexRoute
@@ -660,6 +678,7 @@ export interface FileRouteTypes {
     | '/shop/checkout/$sessionIdSlug'
     | '/shop/checkout/complete'
     | '/shop/checkout/verify'
+    | '/shop/receipt/$transactionId'
     | '/shop/$categorySlug/$subcategorySlug'
     | '/shop/orders'
     | '/shop/$categorySlug'
@@ -691,6 +710,7 @@ export interface FileRouteTypes {
     | '/shop/checkout/$sessionIdSlug'
     | '/shop/checkout/complete'
     | '/shop/checkout/verify'
+    | '/shop/receipt/$transactionId'
     | '/shop/$categorySlug/$subcategorySlug'
     | '/shop/orders'
     | '/shop/$categorySlug'
@@ -724,6 +744,7 @@ export interface FileRouteTypes {
     | '/shop/checkout/$sessionIdSlug/'
     | '/shop/checkout/complete/'
     | '/shop/checkout/verify/'
+    | '/shop/receipt/$transactionId/'
     | '/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug'
     | '/_layout/_ordersLayout/shop/orders/'
     | '/_layout/_shopLayout/shop/$categorySlug/'
@@ -749,6 +770,7 @@ export interface RootRouteChildren {
   ShopCheckoutSessionIdSlugIndexRoute: typeof ShopCheckoutSessionIdSlugIndexRoute
   ShopCheckoutCompleteIndexRoute: typeof ShopCheckoutCompleteIndexRoute
   ShopCheckoutVerifyIndexRoute: typeof ShopCheckoutVerifyIndexRoute
+  ShopReceiptTransactionIdIndexRoute: typeof ShopReceiptTransactionIdIndexRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -770,6 +792,7 @@ const rootRouteChildren: RootRouteChildren = {
   ShopCheckoutSessionIdSlugIndexRoute: ShopCheckoutSessionIdSlugIndexRoute,
   ShopCheckoutCompleteIndexRoute: ShopCheckoutCompleteIndexRoute,
   ShopCheckoutVerifyIndexRoute: ShopCheckoutVerifyIndexRoute,
+  ShopReceiptTransactionIdIndexRoute: ShopReceiptTransactionIdIndexRoute,
 }
 
 export const routeTree = rootRoute
@@ -796,7 +819,8 @@ export const routeTree = rootRoute
         "/shop/checkout/$sessionIdSlug/incomplete",
         "/shop/checkout/$sessionIdSlug/",
         "/shop/checkout/complete/",
-        "/shop/checkout/verify/"
+        "/shop/checkout/verify/",
+        "/shop/receipt/$transactionId/"
       ]
     },
     "/": {
@@ -905,6 +929,9 @@ export const routeTree = rootRoute
     },
     "/shop/checkout/verify/": {
       "filePath": "shop/checkout/verify.index.tsx"
+    },
+    "/shop/receipt/$transactionId/": {
+      "filePath": "shop/receipt/$transactionId/index.tsx"
     },
     "/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug": {
       "filePath": "_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",

--- a/packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx
+++ b/packages/storefront-webapp/src/routes/shop/receipt/$transactionId/index.tsx
@@ -1,0 +1,319 @@
+import { useEffect } from "react";
+
+import { useStoreContext } from "@/contexts/StoreContext";
+import { usePosTransactionQueries } from "@/lib/queries/posTransaction";
+import { toDisplayAmount } from "@/lib/currency";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
+import { createFileRoute, useParams } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+
+export const Route = createFileRoute("/shop/receipt/$transactionId/")({
+  component: () => <PosReceiptPage />,
+});
+
+const paymentLabel = (method: string) => {
+  if (method === "cash") return "Cash";
+  if (method === "card") return "Card";
+  if (method === "mobile_money") return "Mobile Money";
+
+  return method.replace("_", " ");
+};
+
+export const PosReceiptPage = () => {
+  const { formatter, store, hideNavbar, showNavbar } = useStoreContext();
+  const { transactionId } = useParams({ strict: false });
+  const storeConfig = getStoreConfigV2(store);
+  const posTransactionQueries = usePosTransactionQueries();
+
+  useEffect(() => {
+    hideNavbar();
+
+    return () => {
+      showNavbar();
+    };
+  }, [hideNavbar, showNavbar]);
+
+  const { data, isLoading } = useQuery({
+    ...posTransactionQueries.detail(transactionId || ""),
+    retry: (failureCount, error) => {
+      if (failureCount >= 2) {
+        return false;
+      }
+
+      if (error && typeof error === "object" && "status" in error) {
+        return (error as { status?: number }).status != null && (error as { status?: number }).status! >= 500;
+      }
+
+      return error instanceof TypeError;
+    },
+  });
+
+  const money = (value?: number) => formatter.format(toDisplayAmount(value ?? 0));
+
+  if (isLoading) {
+    return <div className="h-screen" />;
+  }
+
+  if (!data) {
+    return (
+      <main className="h-screen bg-white flex items-center justify-center px-4">
+        <article
+          className="w-80 border border-dashed border-black p-4 text-black"
+          style={{
+            fontFamily: '"Courier New", Courier, monospace',
+          }}
+        >
+          <p className="text-center text-[28px] leading-none font-black tracking-[1px] uppercase">
+            Receipt
+          </p>
+          <div className="my-3 border-t border-dashed border-black" />
+          <p className="text-center text-xs">Not Found</p>
+          <div className="my-3 border-t border-dashed border-black" />
+          <p className="text-center text-xs">We could not find this receipt.</p>
+        </article>
+      </main>
+    );
+  }
+
+  const completedDateTime = new Date(data.completedAt);
+  const completedDate = completedDateTime.toLocaleDateString();
+  const completedTime = completedDateTime.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+  const customerName =
+    data.customer?.name || data.customerInfo?.name || "Walk-in customer";
+  const customerEmail = data.customer?.email || data.customerInfo?.email;
+  const customerPhone = data.customer?.phone || data.customerInfo?.phone;
+  const cashierName = data.cashier
+    ? `${data.cashier.firstName || ""} ${data.cashier.lastName || ""}`.trim()
+    : "Unassigned";
+  const registerNumber = data.registerNumber || "Unassigned";
+  const itemsCount = data.items.reduce((sum, item) => sum + item.quantity, 0);
+  const totalPaidFromPayments = data.payments.reduce(
+    (sum, payment) => sum + payment.amount,
+    0,
+  );
+  const changeGiven =
+    data.changeGiven ??
+    (totalPaidFromPayments > data.total ? totalPaidFromPayments - data.total : 0);
+
+  const locationParts = (storeConfig.contact.location || "").split(",").map((part) => part.trim()).filter(Boolean);
+  const [street, city, state, zipCode, country] = locationParts;
+
+  return (
+    <main className="min-h-screen h-screen bg-white flex items-center justify-center px-4 py-8">
+      <style>{`
+        .receipt-shell {
+          width: 320px;
+          max-width: calc(100vw - 2rem);
+          margin: 0 auto;
+          color: #111;
+          font-family: "Courier New", Courier, monospace;
+        }
+        .receipt {
+          border: 1px solid #111;
+          border-radius: 0;
+          padding: 18px 14px;
+          background: #fff;
+        }
+        .line {
+          height: 1px;
+          border-top: 1px dashed #111;
+          margin: 12px 0;
+        }
+        .section-title {
+          border-bottom: 1px solid #111;
+          font-weight: 700;
+          font-size: 10px;
+          letter-spacing: 1.4px;
+          text-transform: uppercase;
+          margin-bottom: 8px;
+          padding-bottom: 4px;
+        }
+        .row {
+          display: flex;
+          justify-content: space-between;
+          align-items: flex-start;
+          gap: 12px;
+          margin-bottom: 5px;
+          font-size: 12px;
+        }
+        .row-label {
+          color: #444;
+          font-weight: 700;
+          text-transform: uppercase;
+        }
+        .row-value {
+          font-weight: 700;
+          text-align: right;
+        }
+        .item-block {
+          border-bottom: 1px dotted #888;
+          padding-bottom: 10px;
+          margin-bottom: 10px;
+        }
+        .item-top {
+          display: flex;
+          justify-content: space-between;
+          gap: 12px;
+          font-weight: 700;
+          font-size: 12px;
+        }
+        .item-meta {
+          display: flex;
+          justify-content: space-between;
+          gap: 12px;
+          font-size: 10px;
+          text-transform: uppercase;
+          color: #555;
+        }
+        .small-muted {
+          color: #555;
+          font-size: 10px;
+        }
+        @media print {
+          .print-root {
+            min-height: auto;
+            margin: 0;
+            padding: 0;
+          }
+          .receipt-shell {
+            width: 100%;
+            max-width: 100%;
+          }
+        }
+      `}</style>
+
+      <article className="receipt-shell print-root">
+        <div className="receipt">
+          <header className="space-y-2">
+            <div className="text-center">
+              <p className="text-[22px] leading-6 font-black uppercase">
+                {store?.name || "Store"}
+              </p>
+              <div className="small-muted mt-1">
+                {street ? <p>{street}</p> : null}
+                {city || state || zipCode ? (
+                  <p>{[city, state, zipCode].filter(Boolean).join(", ")}</p>
+                ) : null}
+                {country ? <p>{country}</p> : null}
+                {storeConfig.contact.phoneNumber ? (
+                  <p>Tel {storeConfig.contact.phoneNumber}</p>
+                ) : null}
+              </div>
+            </div>
+            <div className="line" />
+          </header>
+
+          <section className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[12px] font-bold">
+                {completedDate} {completedTime}
+              </p>
+              <p className="text-[12px] tracking-[1.3px]">#{data.transactionNumber}</p>
+            </div>
+            <p className="text-[12px]">Cashier: {cashierName}</p>
+            <p className="small-muted text-[11px]">Register: {registerNumber}</p>
+          </section>
+
+          <div className="line" />
+
+          {(customerEmail || customerPhone) && (
+            <section className="space-y-2">
+              <h2 className="section-title">Customer</h2>
+              <div className="row">
+                <span className="row-label">Name</span>
+                <span className="row-value">{customerName}</span>
+              </div>
+              {customerEmail ? (
+                <div className="row">
+                  <span className="row-label">Email</span>
+                  <span className="row-value">{customerEmail}</span>
+                </div>
+              ) : null}
+              {customerPhone ? (
+                <div className="row">
+                  <span className="row-label">Phone</span>
+                  <span className="row-value">{customerPhone}</span>
+                </div>
+              ) : null}
+              <div className="line" />
+            </section>
+          )}
+
+          <section className="space-y-3">
+            <h2 className="section-title">Items</h2>
+            <p className="text-xs tracking-[1px] text-[#444]">
+              {itemsCount} item{itemsCount === 1 ? "" : "s"}
+            </p>
+            {data.items.map((item) => (
+              <div key={item._id} className="item-block">
+                <div className="item-top">
+                  <span>{item.productName.toUpperCase()}</span>
+                  <span>{money(item.totalPrice)}</span>
+                </div>
+                <div className="item-meta">
+                  <span>{`${item.quantity} x ${money(item.unitPrice)}`}</span>
+                  <span>{item.productSku || item.barcode || ""}</span>
+                </div>
+              </div>
+            ))}
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="section-title">Summary</h2>
+            <div className="row">
+              <span className="row-label">Subtotal</span>
+              <span className="row-value">{money(data.subtotal)}</span>
+            </div>
+            <div className="line" />
+            <div className="row">
+              <span className="row-label" style={{ fontSize: "16px" }}>
+                Total
+              </span>
+              <span className="row-value" style={{ fontSize: "16px" }}>
+                {money(data.total)}
+              </span>
+            </div>
+          </section>
+
+          <div className="line" />
+
+          <section className="space-y-2">
+            <h2 className="section-title">Payment</h2>
+            {data.payments.length > 0
+              ? data.payments.map((payment, idx) => (
+                  <div className="row" key={`${payment.method}-${idx}`}>
+                    <span className="row-label">{paymentLabel(payment.method)}</span>
+                    <span className="row-value">{money(payment.amount)}</span>
+                  </div>
+                ))
+              : (
+                  <div className="row">
+                    <span className="row-label">{paymentLabel(data.paymentMethod || "Unknown")}</span>
+                    <span className="row-value">{money(data.total)}</span>
+                  </div>
+                )}
+            <div className="row">
+              <span className="row-label">Tendered</span>
+              <span className="row-value">{money(totalPaidFromPayments || data.total)}</span>
+            </div>
+            {changeGiven > 0 ? (
+              <div className="row">
+                <span className="row-label">Change</span>
+                <span className="row-value">{money(changeGiven)}</span>
+              </div>
+            ) : null}
+          </section>
+
+          <div className="mt-4 pt-3 text-center">
+            <p className="text-xs font-bold">Thank you for your business!</p>
+            <p className="small-muted">Please keep this receipt for your records.</p>
+          </div>
+        </div>
+      </article>
+    </main>
+  );
+};


### PR DESCRIPTION
## Summary\n- restore /shop/receipt/{transactionId} route in storefront\n- render the transaction receipt in thermal-style HTML without navbar/footer\n- include minimal not-found receipt copy and retry behavior