### PR TITLE
[V26-000]: Refine POS quick add variant flow

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3904 nodes · 3463 edges · 1433 communities detected
+- 3905 nodes · 3465 edges · 1433 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1879,16 +1879,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 102 - "Community 102"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 103 - "Community 103"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 104 - "Community 104"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 105 - "Community 105"
 Cohesion: 0.52
@@ -2139,8 +2139,8 @@ Cohesion: 0.4
 Nodes (1): Header()
 
 ### Community 167 - "Community 167"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
 
 ### Community 168 - "Community 168"
 Cohesion: 0.4
@@ -2159,28 +2159,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 172 - "Community 172"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 173 - "Community 173"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 175 - "Community 175"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 176 - "Community 176"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 177 - "Community 177"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.4
@@ -2191,36 +2191,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 180 - "Community 180"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 181 - "Community 181"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 183 - "Community 183"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 184 - "Community 184"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 185 - "Community 185"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 186 - "Community 186"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 187 - "Community 187"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 188 - "Community 188"
 Cohesion: 0.5
@@ -2247,72 +2247,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 194 - "Community 194"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 196 - "Community 196"
-Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 199 - "Community 199"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 200 - "Community 200"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 201 - "Community 201"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 203 - "Community 203"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 202 - "Community 202"
+### Community 204 - "Community 204"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 203 - "Community 203"
+### Community 205 - "Community 205"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 204 - "Community 204"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 205 - "Community 205"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 207 - "Community 207"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 208 - "Community 208"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 208 - "Community 208"
+### Community 210 - "Community 210"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 209 - "Community 209"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 210 - "Community 210"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 211 - "Community 211"
 Cohesion: 0.5
@@ -2335,32 +2335,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 216 - "Community 216"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 218 - "Community 218"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 219 - "Community 219"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 220 - "Community 220"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 221 - "Community 221"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 222 - "Community 222"
-Cohesion: 0.67
-Nodes (2): handleClearSearch(), handleQuickAddSubmit()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.5
@@ -2383,24 +2383,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 228 - "Community 228"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 229 - "Community 229"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 229 - "Community 229"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 231 - "Community 231"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 232 - "Community 232"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 232 - "Community 232"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.5
@@ -2411,36 +2411,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 235 - "Community 235"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 236 - "Community 236"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 242 - "Community 242"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.5
@@ -2467,8 +2467,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 249 - "Community 249"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 0.67

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19607,7 +19607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L277",
+      "source_location": "L279",
       "target": "productentry_handleclearsearch",
       "weight": 1
     },
@@ -19619,7 +19619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L281",
+      "source_location": "L284",
       "target": "productentry_handleopenquickadd",
       "weight": 1
     },
@@ -19631,8 +19631,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L295",
+      "source_location": "L312",
       "target": "productentry_handlequickaddsubmit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "_tgt": "productentry_resetquickaddform",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L303",
+      "target": "productentry_resetquickaddform",
       "weight": 1
     },
     {
@@ -32807,7 +32819,19 @@
       "relation": "calls",
       "source": "productentry_handleclearsearch",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L342",
+      "source_location": "L383",
+      "target": "productentry_handlequickaddsubmit",
+      "weight": 1
+    },
+    {
+      "_src": "productentry_handlequickaddsubmit",
+      "_tgt": "productentry_resetquickaddform",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "productentry_resetquickaddform",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L381",
       "target": "productentry_handlequickaddsubmit",
       "weight": 1
     },
@@ -32903,7 +32927,7 @@
       "relation": "calls",
       "source": "quickaddcatalogitem_findexistingsku",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L198",
+      "source_location": "L199",
       "target": "quickaddcatalogitem_quickaddcatalogitem",
       "weight": 1
     },
@@ -32915,7 +32939,7 @@
       "relation": "calls",
       "source": "quickaddcatalogitem_findorcreatequickaddcategory",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L213",
+      "source_location": "L218",
       "target": "quickaddcatalogitem_quickaddcatalogitem",
       "weight": 1
     },
@@ -32927,7 +32951,7 @@
       "relation": "calls",
       "source": "quickaddcatalogitem_findorcreatequickaddsubcategory",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L214",
+      "source_location": "L219",
       "target": "quickaddcatalogitem_quickaddcatalogitem",
       "weight": 1
     },
@@ -32939,7 +32963,7 @@
       "relation": "calls",
       "source": "quickaddcatalogitem_generatesku",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L259",
+      "source_location": "L273",
       "target": "quickaddcatalogitem_quickaddcatalogitem",
       "weight": 1
     },
@@ -32951,7 +32975,7 @@
       "relation": "calls",
       "source": "quickaddcatalogitem_isbarcodelike",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L240",
+      "source_location": "L254",
       "target": "quickaddcatalogitem_quickaddcatalogitem",
       "weight": 1
     },
@@ -32963,7 +32987,7 @@
       "relation": "calls",
       "source": "quickaddcatalogitem_mapskutocatalogresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L206",
+      "source_location": "L207",
       "target": "quickaddcatalogitem_quickaddcatalogitem",
       "weight": 1
     },
@@ -42897,65 +42921,65 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1020,
@@ -43050,65 +43074,65 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1030,
@@ -43203,65 +43227,65 @@
     {
       "community": 104,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1040,
@@ -50988,6 +51012,51 @@
     {
       "community": 167,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "label": "ProductEntry.tsx",
+      "norm_label": "productentry.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "productentry_handleclearsearch",
+      "label": "handleClearSearch()",
+      "norm_label": "handleclearsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L279"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "productentry_handleopenquickadd",
+      "label": "handleOpenQuickAdd()",
+      "norm_label": "handleopenquickadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L284"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "productentry_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L312"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "productentry_resetquickaddform",
+      "label": "resetQuickAddForm()",
+      "norm_label": "resetquickaddform()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L303"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
       "norm_label": "posregisterview.tsx",
@@ -50995,7 +51064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "posregisterview_handlecmdk",
       "label": "handleCmdK()",
@@ -51004,7 +51073,7 @@
       "source_location": "L141"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "posregisterview_productlookupemptystate",
       "label": "ProductLookupEmptyState()",
@@ -51013,7 +51082,7 @@
       "source_location": "L82"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "posregisterview_usecollapsesidebarforposflow",
       "label": "useCollapseSidebarForPosFlow()",
@@ -51022,7 +51091,7 @@
       "source_location": "L23"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "posregisterview_uselockdocumentscroll",
       "label": "useLockDocumentScroll()",
@@ -51031,7 +51100,7 @@
       "source_location": "L55"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -51040,7 +51109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -51049,7 +51118,7 @@
       "source_location": "L37"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -51058,7 +51127,7 @@
       "source_location": "L46"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -51067,58 +51136,13 @@
       "source_location": "L33"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
       "norm_label": "receivingview()",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
       "source_location": "L72"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "label": "PromoCodeView.tsx",
-      "norm_label": "promocodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "promocodeview_handleaddpromocode",
-      "label": "handleAddPromoCode()",
-      "norm_label": "handleaddpromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "promocodeview_handleupdatepromocode",
-      "label": "handleUpdatePromoCode()",
-      "norm_label": "handleupdatepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L230"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "promocodeview_updatehomepagediscountcode",
-      "label": "updateHomepageDiscountCode()",
-      "norm_label": "updatehomepagediscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "promocodeview_updateleaveareviewdiscountcode",
-      "label": "updateLeaveAReviewDiscountCode()",
-      "norm_label": "updateleaveareviewdiscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L377"
     },
     {
       "community": 17,
@@ -51285,6 +51309,51 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
+      "label": "PromoCodeView.tsx",
+      "norm_label": "promocodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "promocodeview_handleaddpromocode",
+      "label": "handleAddPromoCode()",
+      "norm_label": "handleaddpromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "promocodeview_handleupdatepromocode",
+      "label": "handleUpdatePromoCode()",
+      "norm_label": "handleupdatepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "promocodeview_updatehomepagediscountcode",
+      "label": "updateHomepageDiscountCode()",
+      "norm_label": "updatehomepagediscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "promocodeview_updateleaveareviewdiscountcode",
+      "label": "updateLeaveAReviewDiscountCode()",
+      "norm_label": "updateleaveareviewdiscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L377"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
       "norm_label": "handleclear()",
@@ -51292,7 +51361,7 @@
       "source_location": "L99"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -51301,7 +51370,7 @@
       "source_location": "L53"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -51310,7 +51379,7 @@
       "source_location": "L75"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -51319,7 +51388,7 @@
       "source_location": "L63"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -51328,7 +51397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -51337,7 +51406,7 @@
       "source_location": "L7"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -51346,7 +51415,7 @@
       "source_location": "L69"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -51355,7 +51424,7 @@
       "source_location": "L44"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -51364,7 +51433,7 @@
       "source_location": "L103"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -51373,7 +51442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -51382,7 +51451,7 @@
       "source_location": "L18"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -51391,7 +51460,7 @@
       "source_location": "L23"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -51400,7 +51469,7 @@
       "source_location": "L65"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -51409,7 +51478,7 @@
       "source_location": "L45"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -51418,7 +51487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -51427,7 +51496,7 @@
       "source_location": "L78"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -51436,7 +51505,7 @@
       "source_location": "L74"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -51445,7 +51514,7 @@
       "source_location": "L103"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -51454,7 +51523,7 @@
       "source_location": "L109"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -51463,7 +51532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -51472,7 +51541,7 @@
       "source_location": "L75"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -51481,7 +51550,7 @@
       "source_location": "L26"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -51490,7 +51559,7 @@
       "source_location": "L38"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -51499,7 +51568,7 @@
       "source_location": "L4"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -51508,7 +51577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -51517,7 +51586,7 @@
       "source_location": "L3"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -51526,7 +51595,7 @@
       "source_location": "L29"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -51535,7 +51604,7 @@
       "source_location": "L33"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -51544,7 +51613,7 @@
       "source_location": "L40"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -51553,7 +51622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -51562,7 +51631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -51571,7 +51640,7 @@
       "source_location": "L12"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -51580,7 +51649,7 @@
       "source_location": "L27"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -51589,7 +51658,7 @@
       "source_location": "L33"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -51598,7 +51667,7 @@
       "source_location": "L55"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -51607,7 +51676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -51616,7 +51685,7 @@
       "source_location": "L42"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -51625,7 +51694,7 @@
       "source_location": "L29"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -51634,7 +51703,7 @@
       "source_location": "L49"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -51643,7 +51712,7 @@
       "source_location": "L14"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -51652,7 +51721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -51661,7 +51730,7 @@
       "source_location": "L184"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -51670,7 +51739,7 @@
       "source_location": "L200"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -51679,58 +51748,13 @@
       "source_location": "L244"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
       "norm_label": "groupeventsbytimeframe()",
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "analytics_getproductviewcount",
-      "label": "getProductViewCount()",
-      "norm_label": "getproductviewcount()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "analytics_logout",
-      "label": "logout()",
-      "norm_label": "logout()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "analytics_postanalytics",
-      "label": "postAnalytics()",
-      "norm_label": "postanalytics()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "analytics_updateanalyticsowner",
-      "label": "updateAnalyticsOwner()",
-      "norm_label": "updateanalyticsowner()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L1"
     },
     {
       "community": 18,
@@ -51888,6 +51912,51 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "analytics_getproductviewcount",
+      "label": "getProductViewCount()",
+      "norm_label": "getproductviewcount()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "analytics_logout",
+      "label": "logout()",
+      "norm_label": "logout()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "analytics_postanalytics",
+      "label": "postAnalytics()",
+      "norm_label": "postanalytics()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "analytics_updateanalyticsowner",
+      "label": "updateAnalyticsOwner()",
+      "norm_label": "updateanalyticsowner()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
       "norm_label": "getallcategories()",
@@ -51895,7 +51964,7 @@
       "source_location": "L11"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -51904,7 +51973,7 @@
       "source_location": "L25"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -51913,7 +51982,7 @@
       "source_location": "L9"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -51922,7 +51991,7 @@
       "source_location": "L39"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -51931,7 +52000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -51940,7 +52009,7 @@
       "source_location": "L4"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -51949,7 +52018,7 @@
       "source_location": "L24"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -51958,7 +52027,7 @@
       "source_location": "L6"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -51967,7 +52036,7 @@
       "source_location": "L42"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -51976,7 +52045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -51985,7 +52054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -51994,7 +52063,7 @@
       "source_location": "L28"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -52003,7 +52072,7 @@
       "source_location": "L5"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -52012,7 +52081,7 @@
       "source_location": "L7"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -52021,7 +52090,7 @@
       "source_location": "L46"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -52030,7 +52099,7 @@
       "source_location": "L147"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -52039,7 +52108,7 @@
       "source_location": "L185"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -52048,7 +52117,7 @@
       "source_location": "L115"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -52057,7 +52126,7 @@
       "source_location": "L31"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -52066,7 +52135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -52075,7 +52144,7 @@
       "source_location": "L14"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -52084,7 +52153,7 @@
       "source_location": "L22"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -52093,7 +52162,7 @@
       "source_location": "L30"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -52102,7 +52171,7 @@
       "source_location": "L3"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -52111,7 +52180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -52120,7 +52189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -52129,7 +52198,7 @@
       "source_location": "L136"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -52138,7 +52207,7 @@
       "source_location": "L154"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -52147,7 +52216,7 @@
       "source_location": "L25"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -52156,7 +52225,7 @@
       "source_location": "L47"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -52165,7 +52234,7 @@
       "source_location": "L44"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -52174,7 +52243,7 @@
       "source_location": "L36"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -52183,7 +52252,7 @@
       "source_location": "L26"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -52192,7 +52261,7 @@
       "source_location": "L30"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -52201,7 +52270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -52210,7 +52279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -52219,7 +52288,7 @@
       "source_location": "L63"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -52228,7 +52297,7 @@
       "source_location": "L79"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -52237,7 +52306,7 @@
       "source_location": "L206"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -52246,7 +52315,7 @@
       "source_location": "L12"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -52255,7 +52324,7 @@
       "source_location": "L26"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -52264,48 +52333,12 @@
       "source_location": "L20"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
       "norm_label": "convexpaginationantipatterncheck.test.ts",
       "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "checkout_hasallvisibilesessionitems",
-      "label": "hasAllVisibileSessionItems()",
-      "norm_label": "hasallvisibilesessionitems()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "checkout_hasvalidcanonicalbagitem",
-      "label": "hasValidCanonicalBagItem()",
-      "norm_label": "hasvalidcanonicalbagitem()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "checkout_hasvalidsessionitems",
-      "label": "hasValidSessionItems()",
-      "norm_label": "hasvalidsessionitems()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L1"
     },
     {
@@ -52464,6 +52497,42 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "checkout_hasallvisibilesessionitems",
+      "label": "hasAllVisibileSessionItems()",
+      "norm_label": "hasallvisibilesessionitems()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "checkout_hasvalidcanonicalbagitem",
+      "label": "hasValidCanonicalBagItem()",
+      "norm_label": "hasvalidcanonicalbagitem()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "checkout_hasvalidsessionitems",
+      "label": "hasValidSessionItems()",
+      "norm_label": "hasvalidsessionitems()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
@@ -52471,7 +52540,7 @@
       "source_location": "L70"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -52480,7 +52549,7 @@
       "source_location": "L29"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -52489,7 +52558,7 @@
       "source_location": "L80"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -52498,7 +52567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -52507,7 +52576,7 @@
       "source_location": "L21"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -52516,7 +52585,7 @@
       "source_location": "L35"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -52525,7 +52594,7 @@
       "source_location": "L45"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -52534,7 +52603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -52543,7 +52612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -52552,7 +52621,7 @@
       "source_location": "L21"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -52561,7 +52630,7 @@
       "source_location": "L35"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -52570,7 +52639,7 @@
       "source_location": "L45"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -52579,7 +52648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -52588,7 +52657,7 @@
       "source_location": "L225"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -52597,7 +52666,7 @@
       "source_location": "L89"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -52606,7 +52675,43 @@
       "source_location": "L242"
     },
     {
-      "community": 194,
+      "community": 195,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 196,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -52615,7 +52720,7 @@
       "source_location": "L26"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -52624,7 +52729,7 @@
       "source_location": "L79"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -52633,7 +52738,7 @@
       "source_location": "L33"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -52642,7 +52747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -52651,7 +52756,7 @@
       "source_location": "L10"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -52660,7 +52765,7 @@
       "source_location": "L18"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -52669,7 +52774,7 @@
       "source_location": "L52"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -52678,7 +52783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -52687,7 +52792,7 @@
       "source_location": "L28"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -52696,7 +52801,7 @@
       "source_location": "L42"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -52705,7 +52810,7 @@
       "source_location": "L73"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -52714,7 +52819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -52723,7 +52828,7 @@
       "source_location": "L8"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -52732,7 +52837,7 @@
       "source_location": "L32"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -52741,85 +52846,13 @@
       "source_location": "L64"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
       "norm_label": "operationalworkitems.ts",
       "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "operationsqueryindexes_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "operationsqueryindexes_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "operationsqueryindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
-      "label": "operationsQueryIndexes.test.ts",
-      "norm_label": "operationsqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
-      "label": "registerSessionTracing.test.ts",
-      "norm_label": "registersessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "registersessiontracing_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "registersessiontracing_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "registersessiontracing_test_formatstoredtraceamount",
-      "label": "formatStoredTraceAmount()",
-      "norm_label": "formatstoredtraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L42"
     },
     {
       "community": 2,
@@ -53274,6 +53307,78 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "operationsqueryindexes_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "operationsqueryindexes_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "operationsqueryindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
+      "label": "operationsQueryIndexes.test.ts",
+      "norm_label": "operationsqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "label": "registerSessionTracing.test.ts",
+      "norm_label": "registersessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registersessiontracing_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registersessiontracing_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registersessiontracing_test_formatstoredtraceamount",
+      "label": "formatStoredTraceAmount()",
+      "norm_label": "formatstoredtraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
       "norm_label": "registersessions.trace.test.ts",
@@ -53281,7 +53386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -53290,7 +53395,7 @@
       "source_location": "L31"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -53299,7 +53404,7 @@
       "source_location": "L48"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -53308,7 +53413,7 @@
       "source_location": "L131"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -53317,7 +53422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -53326,7 +53431,7 @@
       "source_location": "L37"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -53335,7 +53440,7 @@
       "source_location": "L24"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -53344,7 +53449,7 @@
       "source_location": "L19"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -53353,7 +53458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -53362,7 +53467,7 @@
       "source_location": "L29"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -53371,7 +53476,7 @@
       "source_location": "L24"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -53380,7 +53485,7 @@
       "source_location": "L51"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -53389,7 +53494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -53398,7 +53503,7 @@
       "source_location": "L122"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -53407,7 +53512,7 @@
       "source_location": "L34"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -53416,7 +53521,7 @@
       "source_location": "L72"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -53425,7 +53530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -53434,7 +53539,7 @@
       "source_location": "L162"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -53443,7 +53548,7 @@
       "source_location": "L56"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
@@ -53452,7 +53557,7 @@
       "source_location": "L180"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -53461,7 +53566,7 @@
       "source_location": "L31"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -53470,7 +53575,7 @@
       "source_location": "L176"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -53479,7 +53584,7 @@
       "source_location": "L27"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -53488,7 +53593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -53497,7 +53602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -53506,7 +53611,7 @@
       "source_location": "L23"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -53515,7 +53620,7 @@
       "source_location": "L9"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -53524,7 +53629,7 @@
       "source_location": "L13"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -53533,7 +53638,7 @@
       "source_location": "L19"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -53542,7 +53647,7 @@
       "source_location": "L26"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -53551,85 +53656,13 @@
       "source_location": "L12"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
       "norm_label": "commercequeryindexes.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "customerengagementevents_findexistingcustomerprofileid",
-      "label": "findExistingCustomerProfileId()",
-      "norm_label": "findexistingcustomerprofileid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "customerengagementevents_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "customerengagementevents_recordstorefrontcustomermilestone",
-      "label": "recordStoreFrontCustomerMilestone()",
-      "norm_label": "recordstorefrontcustomermilestone()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
-      "label": "customerEngagementEvents.ts",
-      "norm_label": "customerengagementevents.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
-      "label": "returnExchangeOperations.test.ts",
-      "norm_label": "returnexchangeoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createorderitem",
-      "label": "createOrderItem()",
-      "norm_label": "createorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createreplacement",
-      "label": "createReplacement()",
-      "norm_label": "createreplacement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 21,
@@ -53787,6 +53820,78 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "customerengagementevents_findexistingcustomerprofileid",
+      "label": "findExistingCustomerProfileId()",
+      "norm_label": "findexistingcustomerprofileid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "customerengagementevents_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "customerengagementevents_recordstorefrontcustomermilestone",
+      "label": "recordStoreFrontCustomerMilestone()",
+      "norm_label": "recordstorefrontcustomermilestone()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "label": "customerEngagementEvents.ts",
+      "norm_label": "customerengagementevents.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
       "norm_label": "isusererrorresult()",
@@ -53794,7 +53899,7 @@
       "source_location": "L51"
     },
     {
-      "community": 210,
+      "community": 212,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -53803,7 +53908,7 @@
       "source_location": "L37"
     },
     {
-      "community": 210,
+      "community": 212,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -53812,7 +53917,7 @@
       "source_location": "L44"
     },
     {
-      "community": 210,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -53821,7 +53926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -53830,7 +53935,7 @@
       "source_location": "L227"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -53839,7 +53944,7 @@
       "source_location": "L46"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -53848,7 +53953,7 @@
       "source_location": "L27"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -53857,7 +53962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -53866,7 +53971,7 @@
       "source_location": "L55"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -53875,7 +53980,7 @@
       "source_location": "L32"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -53884,7 +53989,7 @@
       "source_location": "L211"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -53893,7 +53998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -53902,7 +54007,7 @@
       "source_location": "L52"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -53911,7 +54016,7 @@
       "source_location": "L27"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -53920,7 +54025,7 @@
       "source_location": "L288"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -53929,7 +54034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -53938,7 +54043,7 @@
       "source_location": "L48"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -53947,7 +54052,7 @@
       "source_location": "L88"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -53956,7 +54061,7 @@
       "source_location": "L14"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -53965,7 +54070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -53974,7 +54079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -53983,7 +54088,7 @@
       "source_location": "L15"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -53992,7 +54097,7 @@
       "source_location": "L28"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -54001,7 +54106,7 @@
       "source_location": "L19"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -54010,7 +54115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -54019,7 +54124,7 @@
       "source_location": "L52"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -54028,7 +54133,7 @@
       "source_location": "L3"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -54037,7 +54142,7 @@
       "source_location": "L90"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -54046,7 +54151,7 @@
       "source_location": "L86"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -54055,7 +54160,7 @@
       "source_location": "L76"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -54064,85 +54169,13 @@
       "source_location": "L52"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
       "norm_label": "maintenancemessageeditor.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "label": "ShopLook.tsx",
-      "norm_label": "shoplook.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "shoplook_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "shoplook_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "shoplook_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
-      "label": "ReturnExchangeView.tsx",
-      "norm_label": "returnexchangeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "returnexchangeview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "returnexchangeview_resetreplacementfields",
-      "label": "resetReplacementFields()",
-      "norm_label": "resetreplacementfields()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L97"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "returnexchangeview_toggleitem",
-      "label": "toggleItem()",
-      "norm_label": "toggleitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L83"
     },
     {
       "community": 22,
@@ -54300,6 +54333,78 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
+      "label": "ShopLook.tsx",
+      "norm_label": "shoplook.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "shoplook_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "shoplook_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "shoplook_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "label": "ReturnExchangeView.tsx",
+      "norm_label": "returnexchangeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "returnexchangeview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "returnexchangeview_resetreplacementfields",
+      "label": "resetReplacementFields()",
+      "norm_label": "resetreplacementfields()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "returnexchangeview_toggleitem",
+      "label": "toggleItem()",
+      "norm_label": "toggleitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
       "norm_label": "handlequickstart()",
@@ -54307,7 +54412,7 @@
       "source_location": "L91"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -54316,7 +54421,7 @@
       "source_location": "L68"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -54325,7 +54430,7 @@
       "source_location": "L22"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -54334,7 +54439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "ordersummary_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -54343,7 +54448,7 @@
       "source_location": "L309"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -54352,7 +54457,7 @@
       "source_location": "L191"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -54361,7 +54466,7 @@
       "source_location": "L208"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -54370,43 +54475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "label": "ProductEntry.tsx",
-      "norm_label": "productentry.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "productentry_handleclearsearch",
-      "label": "handleClearSearch()",
-      "norm_label": "handleclearsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L277"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "productentry_handleopenquickadd",
-      "label": "handleOpenQuickAdd()",
-      "norm_label": "handleopenquickadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L281"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "productentry_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L295"
-    },
-    {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -54415,7 +54484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -54424,7 +54493,7 @@
       "source_location": "L312"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -54433,7 +54502,7 @@
       "source_location": "L364"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -54442,7 +54511,7 @@
       "source_location": "L219"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -54451,7 +54520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -54460,7 +54529,7 @@
       "source_location": "L78"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -54469,7 +54538,7 @@
       "source_location": "L118"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -54478,7 +54547,7 @@
       "source_location": "L89"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -54487,7 +54556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -54496,7 +54565,7 @@
       "source_location": "L63"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -54505,7 +54574,7 @@
       "source_location": "L54"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -54514,7 +54583,7 @@
       "source_location": "L11"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -54523,7 +54592,7 @@
       "source_location": "L16"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -54532,7 +54601,7 @@
       "source_location": "L35"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -54541,7 +54610,7 @@
       "source_location": "L6"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -54550,7 +54619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -54559,7 +54628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -54568,7 +54637,7 @@
       "source_location": "L5"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -54577,7 +54646,7 @@
       "source_location": "L30"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -54586,7 +54655,7 @@
       "source_location": "L21"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -54595,7 +54664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -54604,7 +54673,7 @@
       "source_location": "L178"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -54613,49 +54682,13 @@
       "source_location": "L205"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
       "norm_label": "withsavestate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
       "source_location": "L806"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "label": "WorkflowTraceView.tsx",
-      "norm_label": "workflowtraceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "workflowtraceview_formattracelabel",
-      "label": "formatTraceLabel()",
-      "norm_label": "formattracelabel()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "workflowtraceview_getstatustone",
-      "label": "getStatusTone()",
-      "norm_label": "getstatustone()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "workflowtraceview_workflowtraceheader",
-      "label": "WorkflowTraceHeader()",
-      "norm_label": "workflowtraceheader()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L65"
     },
     {
       "community": 23,
@@ -54804,6 +54837,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
+      "label": "WorkflowTraceView.tsx",
+      "norm_label": "workflowtraceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "workflowtraceview_formattracelabel",
+      "label": "formatTraceLabel()",
+      "norm_label": "formattracelabel()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "workflowtraceview_getstatustone",
+      "label": "getStatusTone()",
+      "norm_label": "getstatustone()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "workflowtraceview_workflowtraceheader",
+      "label": "WorkflowTraceHeader()",
+      "norm_label": "workflowtraceheader()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
       "norm_label": "formatlastactivity()",
@@ -54811,7 +54880,7 @@
       "source_location": "L75"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -54820,7 +54889,7 @@
       "source_location": "L82"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -54829,7 +54898,7 @@
       "source_location": "L93"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -54838,7 +54907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -54847,7 +54916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -54856,7 +54925,7 @@
       "source_location": "L15"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -54865,7 +54934,7 @@
       "source_location": "L28"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -54874,7 +54943,7 @@
       "source_location": "L54"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -54883,7 +54952,7 @@
       "source_location": "L66"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -54892,7 +54961,7 @@
       "source_location": "L121"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -54901,7 +54970,7 @@
       "source_location": "L74"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -54910,7 +54979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -54919,7 +54988,7 @@
       "source_location": "L51"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -54928,7 +54997,7 @@
       "source_location": "L92"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -54937,7 +55006,7 @@
       "source_location": "L16"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -54946,7 +55015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -54955,7 +55024,7 @@
       "source_location": "L22"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -54964,7 +55033,7 @@
       "source_location": "L10"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -54973,7 +55042,7 @@
       "source_location": "L57"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -54982,7 +55051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -54991,7 +55060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -55000,7 +55069,7 @@
       "source_location": "L83"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -55009,7 +55078,7 @@
       "source_location": "L100"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -55018,7 +55087,7 @@
       "source_location": "L79"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -55027,7 +55096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -55036,7 +55105,7 @@
       "source_location": "L38"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -55045,7 +55114,7 @@
       "source_location": "L65"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -55054,7 +55123,7 @@
       "source_location": "L91"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -55063,7 +55132,7 @@
       "source_location": "L4"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -55072,7 +55141,7 @@
       "source_location": "L20"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -55081,7 +55150,7 @@
       "source_location": "L42"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -55090,7 +55159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -55099,7 +55168,7 @@
       "source_location": "L102"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -55108,7 +55177,7 @@
       "source_location": "L69"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -55117,48 +55186,12 @@
       "source_location": "L43"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
       "norm_label": "_layout.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "offers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "offers_getuserredeemedoffers",
-      "label": "getUserRedeemedOffers()",
-      "norm_label": "getuserredeemedoffers()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "offers_submitoffer",
-      "label": "submitOffer()",
-      "norm_label": "submitoffer()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
     },
     {
@@ -55308,6 +55341,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "offers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "offers_getuserredeemedoffers",
+      "label": "getUserRedeemedOffers()",
+      "norm_label": "getuserredeemedoffers()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "offers_submitoffer",
+      "label": "submitOffer()",
+      "norm_label": "submitoffer()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -55315,7 +55384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -55324,7 +55393,7 @@
       "source_location": "L8"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -55333,7 +55402,7 @@
       "source_location": "L5"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -55342,7 +55411,7 @@
       "source_location": "L20"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -55351,7 +55420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -55360,7 +55429,7 @@
       "source_location": "L11"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -55369,7 +55438,7 @@
       "source_location": "L9"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -55378,7 +55447,7 @@
       "source_location": "L25"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -55387,7 +55456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -55396,7 +55465,7 @@
       "source_location": "L50"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -55405,7 +55474,7 @@
       "source_location": "L92"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -55414,7 +55483,7 @@
       "source_location": "L74"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -55423,7 +55492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -55432,7 +55501,7 @@
       "source_location": "L62"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -55441,7 +55510,7 @@
       "source_location": "L109"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -55450,7 +55519,7 @@
       "source_location": "L177"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -55459,7 +55528,7 @@
       "source_location": "L18"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -55468,7 +55537,7 @@
       "source_location": "L52"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -55477,7 +55546,7 @@
       "source_location": "L68"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -55486,7 +55555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -55495,7 +55564,7 @@
       "source_location": "L68"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -55504,7 +55573,7 @@
       "source_location": "L26"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -55513,7 +55582,7 @@
       "source_location": "L7"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -55522,7 +55591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -55531,7 +55600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -55540,7 +55609,7 @@
       "source_location": "L81"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -55549,7 +55618,7 @@
       "source_location": "L85"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -55558,7 +55627,7 @@
       "source_location": "L27"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -55567,7 +55636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -55576,7 +55645,7 @@
       "source_location": "L43"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -55585,7 +55654,7 @@
       "source_location": "L13"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -55594,7 +55663,7 @@
       "source_location": "L88"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -55603,7 +55672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -55612,7 +55681,7 @@
       "source_location": "L111"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -55621,49 +55690,13 @@
       "source_location": "L66"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
     },
     {
       "community": 25,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1518
-- Graph nodes: 3904
-- Graph edges: 3463
+- Graph nodes: 3905
+- Graph edges: 3465
 - Communities: 1433
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts
@@ -198,6 +198,7 @@ describe("quickAddCatalogItem", () => {
         {
           _id: "product001",
           categoryId: "category001",
+          storeId: "storezzzz",
           description: "",
           name: "Existing wig",
           areProcessingFeesAbsorbed: false,
@@ -233,6 +234,52 @@ describe("quickAddCatalogItem", () => {
       name: "Existing wig",
       barcode: "998877665544",
       sku: "EXISTING-SKU",
+    });
+  });
+
+  it("adds a new SKU variant to an existing product when productId is provided", async () => {
+    const { ctx, tables } = createQuickAddCtx({
+      ...baseSeed,
+      category: [
+        { _id: "category001", storeId: "storezzzz", slug: "wigs", name: "Wigs" },
+      ],
+      product: [
+        {
+          _id: "product001",
+          categoryId: "category001",
+          storeId: "storezzzz",
+          description: "",
+          name: "Existing wig",
+          areProcessingFeesAbsorbed: false,
+        },
+      ],
+    });
+
+    const result = await quickAddCatalogItem(ctx, {
+      storeId: "storezzzz" as Id<"store">,
+      createdByUserId: "user0001" as Id<"athenaUser">,
+      name: "Should ignore this title",
+      price: 110000,
+      quantityAvailable: 4.2,
+      productId: "product001" as Id<"product">,
+    });
+
+    const sku = Array.from(tables.productSku.values())[0];
+
+    expect(Array.from(tables.product).length).toBe(1);
+    expect(Array.from(tables.productSku).length).toBe(1);
+    expect(sku).toMatchObject({
+      productId: "product001",
+      barcode: undefined,
+      price: 110000,
+      quantityAvailable: 4,
+    });
+    expect(sku?.sku).toMatch(/^[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+$/);
+    expect(result).toMatchObject({
+      productId: "product001",
+      name: "Existing wig",
+      barcode: "",
+      inStock: true,
     });
   });
 });

--- a/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts
@@ -185,6 +185,7 @@ export async function quickAddCatalogItem(
     createdByUserId: Id<"athenaUser">;
     name: string;
     lookupCode?: string;
+    productId?: Id<"product">;
     price: number;
     quantityAvailable: number;
   },
@@ -210,31 +211,44 @@ export async function quickAddCatalogItem(
     }
   }
 
-  const category = await findOrCreateQuickAddCategory(ctx, args.storeId);
-  const subcategory = await findOrCreateQuickAddSubcategory(ctx, {
-    storeId: args.storeId,
-    categoryId: category._id,
-  });
-  const productName = args.name.trim() || lookupCode || "Quick add item";
   const quantityAvailable = Math.max(0, Math.trunc(args.quantityAvailable));
+  let productId = args.productId;
 
-  const productId = await ctx.db.insert("product", {
-    availability: "live",
-    areProcessingFeesAbsorbed: false,
-    attributes: {},
-    categoryId: category._id,
-    createdByUserId: args.createdByUserId,
-    currency: store.currency,
-    description: "",
-    inventoryCount: quantityAvailable,
-    isVisible: false,
-    name: productName,
-    organizationId: store.organizationId,
-    quantityAvailable,
-    slug: toSlug(productName),
-    storeId: args.storeId,
-    subcategoryId: subcategory._id,
-  });
+  if (!productId) {
+    const category = await findOrCreateQuickAddCategory(ctx, args.storeId);
+    const subcategory = await findOrCreateQuickAddSubcategory(ctx, {
+      storeId: args.storeId,
+      categoryId: category._id,
+    });
+    const productName = args.name.trim() || lookupCode || "Quick add item";
+    productId = (await ctx.db.insert("product", {
+      availability: "live",
+      areProcessingFeesAbsorbed: false,
+      attributes: {},
+      categoryId: category._id,
+      createdByUserId: args.createdByUserId,
+      currency: store.currency,
+      description: "",
+      inventoryCount: quantityAvailable,
+      isVisible: false,
+      name: productName,
+      organizationId: store.organizationId,
+      quantityAvailable,
+      slug: toSlug(productName),
+      storeId: args.storeId,
+      subcategoryId: subcategory._id,
+    })) as Id<"product">;
+  }
+
+  const product = await ctx.db.get("product", productId);
+  if (!product || String(product.storeId) !== String(args.storeId)) {
+    throw new Error("Product not found");
+  }
+
+  const productName = product.name;
+  if (productName === undefined) {
+    throw new Error("Product not found");
+  }
 
   const barcode =
     lookupCode && isBarcodeLike(lookupCode) ? lookupCode : undefined;
@@ -264,11 +278,9 @@ export async function quickAddCatalogItem(
   await ctx.db.patch("productSku", skuId, { sku });
 
   const productSku = (await ctx.db.get("productSku", skuId))!;
-  const product = (await ctx.db.get("product", productId))!;
 
   return mapSkuToCatalogResult(ctx, {
     product,
     sku: productSku,
-    categoryName: category.name,
   });
 }

--- a/packages/athena-webapp/convex/pos/public/catalog.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.ts
@@ -53,6 +53,7 @@ export const quickAddSku = mutation({
     createdByUserId: v.id("athenaUser"),
     name: v.string(),
     lookupCode: v.optional(v.string()),
+    productId: v.optional(v.id("product")),
     price: v.number(),
     quantityAvailable: v.number(),
   },

--- a/packages/athena-webapp/src/components/pos/ProductEntry.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.tsx
@@ -217,6 +217,8 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
   const [quickAddLookupCode, setQuickAddLookupCode] = useState("");
   const [quickAddPrice, setQuickAddPrice] = useState("");
   const [quickAddQuantity, setQuickAddQuantity] = useState("1");
+  const [quickAddSourceProduct, setQuickAddSourceProduct] =
+    useState<Product | null>(null);
   const [quickAddError, setQuickAddError] = useState<string | null>(null);
   const [isQuickAddSaving, setIsQuickAddSaving] = useState(false);
   const productSearchInputRef = useRef<HTMLInputElement>(null);
@@ -278,18 +280,33 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
     setProductSearchQuery("");
   };
 
-  const handleOpenQuickAdd = () => {
+  const isAddingVariant = Boolean(quickAddSourceProduct?.productId);
+  const handleOpenQuickAdd = (selectedProduct?: Product) => {
     const rawQuery = productSearchQuery.trim();
     const extractedQuery = extractBarcodeFromInput(rawQuery).value.trim();
     const shouldTreatQueryAsLookup =
       inputIsUrlOrBarcode || !/\s/.test(extractedQuery);
 
-    setQuickAddName(inputIsUrlOrBarcode ? "" : rawQuery);
+    setQuickAddName(
+      selectedProduct?.name || (inputIsUrlOrBarcode ? "" : rawQuery),
+    );
     setQuickAddLookupCode(shouldTreatQueryAsLookup ? extractedQuery : "");
     setQuickAddPrice("");
     setQuickAddQuantity("1");
     setQuickAddError(null);
+    setQuickAddSourceProduct(
+      selectedProduct && selectedProduct.productId ? selectedProduct : null,
+    );
     setIsQuickAddOpen(true);
+  };
+
+  const resetQuickAddForm = () => {
+    setQuickAddName("");
+    setQuickAddLookupCode("");
+    setQuickAddPrice("");
+    setQuickAddQuantity("1");
+    setQuickAddError(null);
+    setQuickAddSourceProduct(null);
   };
 
   const handleQuickAddSubmit = async (event: React.FormEvent) => {
@@ -319,8 +336,30 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
     }
 
     const parsedQuantity = quickAddQuantity.trim() ? +quickAddQuantity : 0;
-    if (!Number.isFinite(parsedQuantity) || parsedQuantity < 0) {
-      setQuickAddError("Enter a valid quantity.");
+    if (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0) {
+      setQuickAddError("Enter a valid quantity greater than 0.");
+      return;
+    }
+    const roundedQuantity = Math.trunc(parsedQuantity);
+    const isReferenceVariantAvailable = Boolean(
+      quickAddSourceProduct && quickAddSourceProduct.quantityAvailable !== undefined,
+    );
+    const isReferencePriceDifferent =
+      quickAddSourceProduct?.price !== undefined &&
+      quickAddSourceProduct.price !== parsedPrice;
+    const isReferenceQuantityDifferent =
+      isReferenceVariantAvailable &&
+      quickAddSourceProduct?.quantityAvailable !== undefined &&
+      Math.trunc(quickAddSourceProduct.quantityAvailable) !== roundedQuantity;
+
+    if (
+      quickAddSourceProduct &&
+      !isReferencePriceDifferent &&
+      !isReferenceQuantityDifferent
+    ) {
+      setQuickAddError(
+        "Add a different price or quantity than the selected variant.",
+      );
       return;
     }
 
@@ -334,10 +373,12 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
         name: quickAddName.trim(),
         lookupCode: normalizedQuickAddLookupCode || undefined,
         price: parsedPrice,
-        quantityAvailable: Math.trunc(parsedQuantity),
+        quantityAvailable: roundedQuantity,
+        productId: quickAddSourceProduct?.productId,
       });
 
       await onAddProduct(createdProduct);
+      resetQuickAddForm();
       setIsQuickAddOpen(false);
       handleClearSearch();
       toast.success("Product added to catalog.");
@@ -388,14 +429,25 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
         </div>
       </div>
 
-      <Dialog open={isQuickAddOpen} onOpenChange={setIsQuickAddOpen}>
+      <Dialog
+        open={isQuickAddOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            resetQuickAddForm();
+          }
+          setIsQuickAddOpen(open);
+        }}
+      >
         <DialogContent className="sm:max-w-md">
           <form onSubmit={handleQuickAddSubmit} className="space-y-5">
             <DialogHeader>
-              <DialogTitle>Quick add product</DialogTitle>
+              <DialogTitle>
+                {isAddingVariant ? "Quick add variant" : "Quick add product"}
+              </DialogTitle>
               <DialogDescription>
-                Add the SKU needed for this sale. You can complete catalog
-                details later.
+                {isAddingVariant
+                  ? "Add a different variant for this product."
+                  : "Add the SKU needed for this sale. You can complete catalog details later."}
               </DialogDescription>
             </DialogHeader>
 
@@ -460,7 +512,10 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => setIsQuickAddOpen(false)}
+                onClick={() => {
+                  resetQuickAddForm();
+                  setIsQuickAddOpen(false);
+                }}
                 disabled={isQuickAddSaving}
               >
                 Cancel

--- a/packages/athena-webapp/src/components/pos/SearchResultsSection.tsx
+++ b/packages/athena-webapp/src/components/pos/SearchResultsSection.tsx
@@ -10,7 +10,7 @@ interface SearchResultsSectionProps {
   onAddProduct: (product: Product) => void;
   formatter: Intl.NumberFormat;
   onClearSearch: () => void;
-  onQuickAddProduct?: () => void;
+  onQuickAddProduct?: (product?: Product) => void;
   quickAddQuery?: string;
   className?: string;
 }
@@ -25,6 +25,11 @@ export function SearchResultsSection({
   quickAddQuery,
   className,
 }: SearchResultsSectionProps) {
+  const allResultsForSameProduct =
+    products.length > 0 &&
+    products[0].productId !== undefined &&
+    products.every((product) => product.productId === products[0].productId);
+
   if (isLoading) {
     return (
       <div className={cn("max-h-[586px] space-y-1 overflow-y-auto", className)}>
@@ -38,12 +43,7 @@ export function SearchResultsSection({
 
   if (products.length === 0) {
     return (
-      <div
-        className={cn(
-          "max-h-[586px] space-y-1 overflow-y-auto",
-          className,
-        )}
-      >
+      <div className={cn("max-h-[586px] space-y-1 overflow-y-auto", className)}>
         <div className="flex h-full flex-col items-center justify-center py-8 text-center text-gray-500">
           <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-3">
             <Search className="w-6 h-6 text-gray-400" />
@@ -52,7 +52,7 @@ export function SearchResultsSection({
           <p className="text-xs text-gray-400 mt-1">
             Try a different search term or check spelling
           </p>
-          {onQuickAddProduct && quickAddQuery?.trim() && (
+          {onQuickAddProduct && (
             <Button
               type="button"
               size="sm"
@@ -69,9 +69,7 @@ export function SearchResultsSection({
   }
 
   return (
-    <div
-      className={cn("max-h-[586px] space-y-1 overflow-y-auto", className)}
-    >
+    <div className={cn("max-h-[586px] space-y-1 overflow-y-auto", className)}>
       <div className="space-y-8 py-8">
         {products.map((product: Product) => (
           <ProductCard
@@ -82,6 +80,19 @@ export function SearchResultsSection({
             onAfterAdd={onClearSearch}
           />
         ))}
+        {onQuickAddProduct && allResultsForSameProduct && (
+          <div className="flex justify-center pb-8">
+            <Button
+              type="button"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={() => onQuickAddProduct(products[0])}
+            >
+              <PackagePlus className="mr-2 h-4 w-4" />
+              Add variant for this product
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Implemented POS quick add flow to support variant creation for all SKUs under the same product and updated quick-add SKU validation behavior.
- Added guardrails on quick add quantity and validation consistency in frontend and backend quick-add mutation wiring.
- Updated Quick-add backend command to attach new SKUs to an existing product when `productId` is provided.
- Included regression coverage for existing-product variant creation and regenerated graphify artifacts.

## Why
- Improves operator speed by allowing variant creation from search results while keeping catalog integrity.
- Keeps SKU optional for quick add so auto-generation still works when barcode/sku input is not provided.

## Validation
- `bun run --filter '@athena/webapp' test`
- `bun run --filter '@athena/webapp' audit:convex`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' lint:architecture`
- `bun scripts/harness-inferential-review.ts`

Direct ticket: https://linear.app/athena/issue/V26-000
