### PR TITLE
[V26-399..406]: Harden POS session workflow coverage

### DIFF
--- a/docs/plans/2026-04-28-001-test-pos-session-workflow-hardening-spec.md
+++ b/docs/plans/2026-04-28-001-test-pos-session-workflow-hardening-spec.md
@@ -1,0 +1,328 @@
+---
+title: test: Harden POS session workflow coverage
+type: test-spec
+status: proposed
+date: 2026-04-28
+---
+
+# test: Harden POS session workflow coverage
+
+## Summary
+
+Add comprehensive regression coverage for the POS session workflow from cashier sign-in through drawer gating, session start/resume/hold/recovery, cart and payment mutation, customer attribution, checkout completion, trace recording, and stale-client failure handling. This is a test-only hardening pass unless implementation discovers an uncovered production bug; any behavior change should be isolated and documented as a follow-up fix.
+
+## Problem Frame
+
+POS is a production-critical workflow with several invariants that must hold beyond the visible register UI. Existing coverage already protects important slices: drawer binding on item mutation, closeout-blocked UI, payment checkout-state ordering, trace milestones, and profile-backed customer attribution. The surface is still broad enough that gaps can hide in transitions between those slices: bootstrap decisions, stale clients, recovery binding, cashier/session ownership, payment/cart races, checkout register-session attribution, and customer state preservation.
+
+This spec gives another agent a concrete test implementation plan. It should be implemented characterization-first: capture expected current behavior before changing production code. If a proposed test fails because the code is wrong, keep the test, fix the smallest production bug needed, and record the bug in handoff.
+
+## Requirements
+
+- R1. Every POS sale mutation path must require an active cashier-owned session and a POS-usable matching drawer where the operation mutates sale, cart, payment, or checkout state.
+- R2. Drawer startup, recovery, closeout-blocked, and stale-client states must be differentiated at both command and presentation boundaries.
+- R3. Session lifecycle transitions must preserve cart, customer, payment, drawer, cashier, expiration, and trace state according to the transition being performed.
+- R4. Checkout completion must create the transaction, inventory/accounting side effects, register-session sale record, and POS trace events only after drawer and payment preconditions pass.
+- R5. Payment and cart sync must be race-resistant through `checkoutStateVersion` and must not resurrect stale checkout snapshots.
+- R6. Customer attribution must preserve `customerProfileId` as the canonical identity when available and must not clear cart, payments, cashier, or drawer state.
+- R7. Operator-facing failures should be normalized through existing command-result and POS operator-message paths, not raw thrown text.
+- R8. The focused POS validation slice in `packages/athena-webapp/docs/agent/testing.md` must remain accurate after adding tests.
+
+## Scope Boundaries
+
+- Do not redesign POS behavior, customer attribution, checkout, traces, cash controls, or drawer lifecycle.
+- Do not introduce browser E2E coverage unless a missing behavior cannot be honestly tested with existing Vitest/unit harnesses.
+- Do not edit generated Convex artifacts unless a real public Convex API signature changes.
+- Do not broaden this into storefront checkout, expense sessions, stock operations, or service-case payment workflows.
+- Do not clean up unrelated legacy POS tests unless they directly block the new coverage.
+
+## Existing Context
+
+### Code Surfaces
+
+- Backend session command service: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Public POS session mutations and queries: `packages/athena-webapp/convex/inventory/posSessions.ts`
+- POS session item public mutations: `packages/athena-webapp/convex/inventory/posSessionItems.ts`
+- Transaction completion: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Register state query: `packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts`
+- Drawer/session state policy: `packages/athena-webapp/shared/registerSessionStatus.ts`
+- Register view-model: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Register UI state types/selectors: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`, `packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts`
+- Convex client gateways: `packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts`
+- Register shell and drawer gate UI: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`, `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx`, `packages/athena-webapp/src/components/pos/SessionManager.tsx`, `packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx`
+
+### Existing Tests To Extend
+
+- `packages/athena-webapp/convex/pos/application/sessionCommands.test.ts`
+- `packages/athena-webapp/convex/inventory/posSessions.trace.test.ts`
+- `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- `packages/athena-webapp/convex/pos/application/getRegisterState.test.ts`
+- `packages/athena-webapp/convex/operations/registerSessions.trace.test.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts`
+- `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- `packages/athena-webapp/src/components/pos/SessionManager.test.tsx`
+- `packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx`
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`: UI gates are ergonomics; Convex command boundaries must enforce drawer invariants.
+- `docs/solutions/logic-errors/athena-pos-customer-profile-attribution-compatibility-2026-04-25.md`: POS attribution should carry `customerProfileId` as canonical identity while preserving POS compatibility fields.
+
+## Test Implementation Units
+
+### U1. Session Command Boundary Matrix
+
+**Goal:** Expand command-service coverage so every session command proves its preconditions and side-effect boundaries.
+
+**Files:**
+- Extend: `packages/athena-webapp/convex/pos/application/sessionCommands.test.ts`
+- Production under test: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+
+**Test scenarios:**
+- Start session requires a normalized register number when no terminal register number can be resolved.
+- Start session trims register numbers and binds to the terminal's configured register number over an incoming stale argument.
+- Start session rejects an explicitly provided drawer from another store.
+- Start session rejects an explicitly provided drawer with missing terminal identity.
+- Start session reuses same-terminal active empty session without auto-holding it, while binding a valid drawer if missing.
+- Start session auto-holds same-terminal active non-empty session and preserves customer/payment metadata when returning the existing session id.
+- Resume session rejects active cashier sessions on other terminals before mutating the held session.
+- Resume session binds only to a POS-usable drawer matching the held session's terminal/register identity.
+- Bind recovery is idempotent for the same drawer and does not refresh expiration or mutate unrelated fields.
+- Bind recovery rejects an already-bound different drawer without changing cart items, customer metadata, payments, or expiration.
+- Hold session accepts active or held modifiable sessions only for the owning cashier and does not refresh expiration.
+- Add/update/remove item all reject missing, closed, closing, mismatched-terminal, mismatched-register, and mismatched-store drawer bindings before inventory calls.
+- Inventory hold acquire/adjust/release failures return `inventoryUnavailable` and do not patch the session expiration or trace item milestones.
+- Trace recording failures remain best-effort for start, hold, resume, auto-hold, item add/update, and item removal.
+
+**Acceptance:** The fake repository asserts no side-effect calls happen after failed preconditions: no item writes, no inventory calls, no session expiration refresh, and no trace calls unless the operation has already committed.
+
+### U2. Public Session Mutation and Race Coverage
+
+**Goal:** Prove browser-callable Convex mutations enforce the same invariants as the command service, including stale-client and checkout-state ordering paths.
+
+**Files:**
+- Extend: `packages/athena-webapp/convex/inventory/posSessions.trace.test.ts`
+- Consider extending if item public mutation coverage is separate: `packages/athena-webapp/convex/inventory/posSessionItems.ts`
+- Production under test: `packages/athena-webapp/convex/inventory/posSessions.ts`
+
+**Test scenarios:**
+- `updateSession` preserves `customerProfileId` and records `customerLinked` when profile id changes from empty to populated.
+- `updateSession` records `customerUpdated` when only name/email/phone changes under the same profile id.
+- `updateSession` records `customerCleared` when both profile id and customer info are cleared.
+- `updateSession` treats completed, voided, and expired sessions owned by the same cashier as no-op metadata updates, with no trace writes.
+- `updateSession` rejects cashier mismatch, missing session, completed by another cashier, and expired by another cashier with safe command-result errors.
+- `syncSessionCheckoutState` ignores stale versions and does not write payments, expiration, or trace events.
+- `syncSessionCheckoutState` accepts strictly newer versions and records payment-added, payment-updated, payment-removed, and payments-cleared trace data.
+- `syncSessionCheckoutState` rejects missing, closed, closing, mismatched-terminal, mismatched-register, and mismatched-store drawer bindings before patching payments.
+- `releaseSessionInventoryHoldsAndDeleteItems` ignores stale clear-cart versions after newer payment state.
+- `releaseSessionInventoryHoldsAndDeleteItems` deletes items, releases all held SKU quantities, clears payments, records `cartCleared`, and advances the checkout version only when drawer binding is valid.
+- `releaseSessionInventoryHoldsAndDeleteItems` rejects missing, closed, closing, mismatched-terminal, mismatched-register, and mismatched-store drawer bindings before deleting items or releasing holds.
+- `voidSession` releases inventory holds aggregated per SKU, marks the session void, keeps item audit records, and records a void trace.
+- `voidSession` handles empty sessions without release calls and still records a void lifecycle.
+- Expiration cleanup does not overwrite existing void/completed trace identity and releases only eligible session statuses.
+
+**Acceptance:** Tests assert exact `CommandResult` shape (`kind`, `code`, safe message) for expected user errors and assert stale writes leave the in-memory session unchanged.
+
+### U3. Register State and Bootstrap Decisions
+
+**Goal:** Cover the query/application layer that decides whether POS should require cashier auth, open drawer setup, recover a sale, resume a held sale, or start selling.
+
+**Files:**
+- Extend: `packages/athena-webapp/convex/pos/application/getRegisterState.test.ts`
+- Extend: `packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts`
+- Production under test: `packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts`, `packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts`
+
+**Test scenarios:**
+- No terminal returns the existing terminal-unavailable phase without querying session-specific state.
+- Terminal with no cashier returns `requiresCashier`.
+- Open or active register session plus no active POS session returns `readyToStart`.
+- Closing register session is visible enough for closeout-blocked UI but never sets `canStartSession` or `canResumeSession`.
+- Active POS session with valid open drawer returns `active`.
+- Active POS session missing `registerSessionId` returns a recoverable active state that the view-model can gate.
+- Held session plus POS-usable drawer returns `resumable`.
+- Held session plus missing or closing drawer returns `resumable` data but with start/resume disabled by `bootstrapRegister`.
+- Expired active/held sessions are ignored or marked expired according to current query behavior.
+- When both active and held candidates exist, active session wins for the same cashier/terminal.
+
+**Acceptance:** `bootstrapRegister` tests cover every phase and every `canStartSession` / `canResumeSession` boolean combination.
+
+### U4. Register View-Model Workflow Coverage
+
+**Goal:** Exercise the POS register view-model as the user-facing orchestrator, especially around hidden race and recovery paths.
+
+**Files:**
+- Extend: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Production under test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+
+**Test scenarios:**
+- Cashier authentication requests bootstrap and does not start a session until active store, terminal, cashier, and usable drawer are available.
+- Missing drawer initial setup disables product entry, cart actions, and checkout completion, and exposes drawer gate state with opening-float validation.
+- Drawer open success clears drawer input/error state, requests bootstrap, and does not clear cashier.
+- Drawer open failure maps backend text through `toOperatorMessage` and keeps the gate open.
+- Closeout-blocked state disables sale controls and exposes no drawer submit path.
+- Active session without drawer binding shows recovery gate and attempts exactly one bind request per active session/drawer pair.
+- Recovery bind success requests bootstrap and preserves cart, customer, and payment local state.
+- Recovery bind failure resets the bind request key so the cashier can retry after state changes.
+- Mismatched drawer binding surfaces the different-drawer operator message and blocks product, cart, payment, and checkout actions.
+- Product add creates a session only when no active session exists and a usable drawer is present.
+- Product add reuses active session id when present and does not call `startSession`.
+- Quantity update to zero calls remove item; positive quantity calls add/update; malformed item without sku metadata is rejected client-side.
+- Clear cart increments checkout state version, calls release/delete mutation, clears local payments only on success, and preserves customer/cashier.
+- Payment add/update/remove/clear syncs the latest combined payment snapshot and uses monotonically increasing checkout versions.
+- Payment sync is skipped while drawer recovery is required.
+- Clearing the last cart item clears pending payments through the checkout-state mutation.
+- Hold current session first persists metadata, then holds; hold failure leaves local draft state intact.
+- Starting a new session auto-holds a non-empty active sale before starting, and does not start if hold fails.
+- Resuming a held session auto-holds a different non-empty active sale first, resets local payments, and preserves cashier.
+- Cashier sign-out holds non-empty active sale, voids empty active sale, and clears local state only on success.
+- Navigate back holds non-empty active sale or voids empty active sale before navigating.
+- Session expiration timeout clears cashier and local draft state and requests bootstrap.
+- Completion persists metadata first, then completes with the current payment ref snapshot and active totals.
+- Completion failure keeps the sale editable and maps the message through the operator copy path.
+- Completion success sets completed order number/data, preserves receipt snapshot, and allows `onStartNewTransaction` to reset draft state while keeping cashier.
+- Customer commit queues sequential updates and drops stale writes when the component unmounts or active session changes.
+- Customer clear commits empty customer info without clearing cart, payments, cashier, drawer gate state, or product search.
+
+**Acceptance:** View-model tests assert command call order where order matters, local state after success/failure, and that blocked UI actions do not call Convex mutations.
+
+### U5. Convex Gateway and Error-Normalization Coverage
+
+**Goal:** Ensure browser gateways normalize POS command results consistently and do not leak raw Convex failures.
+
+**Files:**
+- Extend: `packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts`
+- Extend: `packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts`
+- Production under test: `packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts`, `packages/athena-webapp/src/lib/errors/runCommand.ts`, `packages/athena-webapp/src/lib/errors/operatorMessages.ts`
+
+**Test scenarios:**
+- Session actions return `kind: "ok"` with payload for start/resume/bind/update/sync/clear/remove success.
+- Session actions return `kind: "user_error"` for Convex command-result failures and preserve safe business messages.
+- Thrown Convex errors normalize to `kind: "unexpected_error"` and are suitable for generic operator handling.
+- Active session mapper carries `registerSessionId`, `customerProfileId`, customer display fields, payments, checkout state version, totals, and cart item identity.
+- Held session mapper carries trace id, hold reason, customer profile summary, totals, and cart item identity.
+- Register gateway distinguishes usable `open`/`active` active drawer from `closing` closeout-blocked drawer data.
+- Operator message mapping includes start, resume, recovery, modifying, completing, duplicate drawer, and different-drawer messages.
+
+**Acceptance:** No browser gateway test imports Convex server-only modules outside existing accepted test seams.
+
+### U6. Component-Level Register Shell Coverage
+
+**Goal:** Prove the rendered POS shell routes the view-model states to the correct UI and hides controls during unsafe states.
+
+**Files:**
+- Extend: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Extend: `packages/athena-webapp/src/components/pos/SessionManager.test.tsx`
+- Extend: `packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx`
+- Production under test: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`, `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx`, `packages/athena-webapp/src/components/pos/SessionManager.tsx`, `packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx`
+
+**Test scenarios:**
+- POS register renders auth dialog when cashier is missing and does not render selling controls.
+- Drawer gate state renders instead of product entry, cart, checkout, and session controls.
+- Recovery drawer gate renders recovery copy, inline errors, opening controls, and sign-out action.
+- Closeout-blocked drawer gate renders Cash Controls guidance and sign-out action, with no opening-float input, notes field, or open-drawer button.
+- Selling state renders customer strip/panel, product entry, cart, checkout, cashier card, and session panel.
+- Completed transaction state hides product entry until starting a new transaction and shows completed checkout/receipt data.
+- Expense workflow mode does not accidentally render POS checkout/session controls.
+- Held sessions list renders trace links when present, customer summary when present, empty state when absent, and disables resume/void actions while the caller reports pending state if that pattern exists.
+- Session manager disables start-new-session while an active sale is already active and enables hold only when cart draft exists.
+
+**Acceptance:** Component tests stay presentation-focused and mock the view-model; orchestration behavior remains in U4.
+
+### U7. Checkout Completion and Register-Session Attribution
+
+**Goal:** Deepen transaction completion tests around drawer binding, payment validation, inventory/accounting side effects, and transaction/session linkage.
+
+**Files:**
+- Extend: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Production under test: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+
+**Test scenarios:**
+- Session-based checkout fails before transaction creation when the session has no drawer binding.
+- Session-based checkout fails before transaction creation when the drawer is closed, closing, wrong store, wrong terminal, or otherwise not POS-usable.
+- If both stored and provided register session ids are present and differ, checkout fails before transaction creation.
+- Session-based checkout uses the stored session drawer binding for transaction, payment allocations, and register-session sale record.
+- Direct sale checkout with register session id requires terminal id.
+- Direct sale checkout records register-session sale and retail payment allocations when a valid register session id and terminal are supplied.
+- Checkout rejects empty payments and insufficient payment before inventory mutation.
+- Checkout aggregates duplicate SKU quantities before availability checks.
+- Checkout failure on missing SKU or insufficient inventory does not create transaction items, patch inventory, allocate payments, or patch session.
+- Successful session checkout creates transaction and items, decrements inventory, patches session completed, records payment allocations, records register-session sale, updates customer stats best-effort, and returns transaction number.
+- Customer profile id from session is copied to the transaction.
+- Workflow trace creation/linking is not attempted before the transaction and session write have succeeded.
+- Payment-allocation failure does not hide a completed transaction if current behavior is best-effort; otherwise assert failure before session patch according to the existing contract.
+
+**Acceptance:** Tests assert operation order for "must happen before" safety points and assert no side effects on validation failures.
+
+### U8. Harness and Validation Map Follow-Through
+
+**Goal:** Keep Athena's agent harness honest after expanding the POS test surface.
+
+**Files:**
+- Review/update source registry if needed: `scripts/harness-app-registry.ts`
+- Regenerate if registry changes: `packages/athena-webapp/docs/agent/validation-map.json`, `packages/athena-webapp/docs/agent/validation-guide.md`, `packages/athena-webapp/docs/agent/test-index.md`
+- Do not hand-edit generated harness docs.
+
+**Test scenarios:**
+- Touched POS command, inventory session, register view-model, gateway, and register UI files map to the focused POS validation slice in `packages/athena-webapp/docs/agent/testing.md`.
+- If new test files are added, `bun run harness:check` recognizes the paths and does not report stale docs.
+- If `bun run harness:review` reports a validation-map gap, update `scripts/harness-app-registry.ts` and rerun `bun run harness:generate`.
+
+**Acceptance:** The final handoff includes the focused test command, broader package test command, type/build checks, and harness checks.
+
+## Suggested Implementation Sequence
+
+1. U1 and U2 first. These are the command-boundary and public-mutation safety net.
+2. U3 next. Bootstrap state determines whether UI and view-model tests are describing the right workflow phases.
+3. U4 and U5 together. View-model orchestration and gateway normalization are tightly coupled but can be implemented in separate commits.
+4. U6 after U4. Component tests should consume stable view-model state shapes.
+5. U7 after command/mutation tests. Checkout is the highest-risk completion path and benefits from earlier drawer-invariant fixtures.
+6. U8 last. Regenerate harness docs only if the new/changed files create a real mapping gap.
+
+## Required Validation
+
+Run the smallest honest focused slice first:
+
+```sh
+bun run --filter '@athena/webapp' test -- \
+  convex/pos/application/sessionCommands.test.ts \
+  convex/inventory/posSessions.trace.test.ts \
+  convex/pos/application/completeTransaction.test.ts \
+  convex/pos/application/getRegisterState.test.ts \
+  convex/operations/registerSessions.trace.test.ts \
+  shared/registerSessionStatus.test.ts \
+  src/lib/pos/application/bootstrapRegister.test.ts \
+  src/lib/pos/infrastructure/convex/sessionGateway.test.ts \
+  src/lib/pos/infrastructure/convex/registerGateway.test.ts \
+  src/lib/pos/presentation/register/useRegisterViewModel.test.ts \
+  src/components/pos/register/POSRegisterView.test.tsx \
+  src/components/pos/SessionManager.test.tsx \
+  src/components/pos/session/HeldSessionsList.test.tsx
+```
+
+Then run the package and repo checks required for POS session / register-session write paths:
+
+```sh
+bun run --filter '@athena/webapp' test
+bun run --filter '@athena/webapp' audit:convex
+bun run --filter '@athena/webapp' lint:convex:changed
+bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
+bun run --filter '@athena/webapp' build
+bun run harness:check
+bun run harness:review
+```
+
+If any production code files are modified while implementing this spec, also run:
+
+```sh
+bun run graphify:rebuild
+```
+
+## Done Criteria
+
+- The new tests cover every scenario listed in U1-U7 or the handoff explains why a scenario was intentionally moved out of scope.
+- Any production behavior bug exposed by these tests is fixed with the smallest scoped change and has a regression test.
+- No raw backend errors are asserted in browser-facing tests unless they are explicitly normalized through existing operator-message helpers.
+- Focused validation and required package checks pass.
+- Harness docs remain current, and graphify is rebuilt if production code changed.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3906 nodes · 3461 edges · 1436 communities detected
+- 3909 nodes · 3464 edges · 1436 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1642,24 +1642,24 @@ Cohesion: 0.24
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
 ### Community 42 - "Community 42"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 43 - "Community 43"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.24
 Nodes (4): applyCommandResult(), buildDepositSubmissionKey(), handleRecordDeposit(), trimOptional()
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 46 - "Community 46"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 47 - "Community 47"
 Cohesion: 0.18
@@ -1950,16 +1950,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 119 - "Community 119"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 120 - "Community 120"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 121 - "Community 121"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 122 - "Community 122"
 Cohesion: 0.33
@@ -1974,16 +1974,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 125 - "Community 125"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 126 - "Community 126"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
+
+### Community 127 - "Community 127"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 128 - "Community 128"
 Cohesion: 0.33
@@ -1994,36 +1994,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 131 - "Community 131"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 132 - "Community 132"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 137 - "Community 137"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 138 - "Community 138"
 Cohesion: 0.53
@@ -2107,7 +2107,7 @@ Nodes (0):
 
 ### Community 158 - "Community 158"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 159 - "Community 159"
 Cohesion: 0.4
@@ -2118,12 +2118,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 161 - "Community 161"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 162 - "Community 162"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 162 - "Community 162"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 163 - "Community 163"
 Cohesion: 0.4
@@ -2135,7 +2135,7 @@ Nodes (0):
 
 ### Community 165 - "Community 165"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 166 - "Community 166"
 Cohesion: 0.6
@@ -2902,72 +2902,72 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 357 - "Community 357"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 358 - "Community 358"
 Cohesion: 1.0
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (1): App()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 1.0
 Nodes (2): collectSourceFiles(), findIllegalConvexImports()
-
-### Community 360 - "Community 360"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 362 - "Community 362"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 363 - "Community 363"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 365 - "Community 365"
-Cohesion: 0.67
-Nodes (1): manualChunks()
-
 ### Community 366 - "Community 366"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 368 - "Community 368"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 369 - "Community 369"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 370 - "Community 370"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 371 - "Community 371"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getBaseUrl(), getPosTransaction()
 
 ### Community 372 - "Community 372"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 373 - "Community 373"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.67
@@ -2978,12 +2978,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 376 - "Community 376"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 377 - "Community 377"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 377 - "Community 377"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 378 - "Community 378"
 Cohesion: 0.67
@@ -2994,12 +2994,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 380 - "Community 380"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 381 - "Community 381"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 381 - "Community 381"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.67
@@ -3078,16 +3078,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 401 - "Community 401"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 402 - "Community 402"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 403 - "Community 403"
+### Community 402 - "Community 402"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 403 - "Community 403"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 404 - "Community 404"
 Cohesion: 1.0
@@ -3102,20 +3102,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 407 - "Community 407"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 409 - "Community 409"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 410 - "Community 410"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 411 - "Community 411"
 Cohesion: 1.0
@@ -7218,1593 +7218,1591 @@ Cohesion: 1.0
 Nodes (0):
 
 ## Knowledge Gaps
-- **Thin community `Community 410`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 411`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 412`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 413`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 414`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 415`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 416`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 417`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 418`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 419`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 420`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 421`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 422`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 423`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 424`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 425`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 426`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 427`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 428`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 429`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 430`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 431`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 432`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 433`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 434`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 435`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 436`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 437`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 438`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 439`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 440`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 441`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 442`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 443`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 444`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 445`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 446`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 447`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 448`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 449`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 450`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 451`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 452`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 453`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 454`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 455`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 456`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 457`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 458`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 459`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 460`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 461`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 462`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 463`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 464`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 465`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 466`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 467`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 468`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 469`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 470`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 471`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 472`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 473`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 474`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 475`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 476`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 477`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 478`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 479`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 480`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 481`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 482`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 483`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 484`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 485`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 486`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 487`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 488`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 489`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 490`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 491`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 492`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 493`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 494`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 495`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 496`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 497`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 498`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 499`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 500`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 501`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 502`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 503`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 504`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 505`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 506`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 507`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 508`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 509`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 510`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 511`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 512`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 513`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 514`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 515`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 516`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 517`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 518`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 519`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 520`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 521`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 522`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 523`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 524`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 525`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 526`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 527`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 528`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 529`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 530`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 531`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 532`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 533`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 534`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 535`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 536`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 537`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 538`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 539`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 540`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 541`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 542`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 543`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 544`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 545`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 546`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 547`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 548`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 549`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 550`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 551`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 552`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 553`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 554`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 555`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 556`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 557`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 558`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 559`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 560`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 561`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 562`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 563`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 564`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 565`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 566`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 567`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 568`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 569`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 570`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 571`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 572`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 573`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 574`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 575`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 576`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 577`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 578`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 579`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 580`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 581`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 582`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 583`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 584`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 585`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 586`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 587`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 588`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 589`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 590`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 591`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 592`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 593`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 594`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 595`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 596`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 597`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 598`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 599`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 600`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 601`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 602`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 603`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 604`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 605`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 606`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 607`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 608`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 609`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 610`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 611`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 612`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 613`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 614`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 615`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 616`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 617`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 618`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 619`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 620`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 621`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 622`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 623`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 624`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 625`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
+- **Thin community `Community 626`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 627`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 628`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 629`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 630`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 631`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 632`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 633`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 634`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 635`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 636`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 637`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 638`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 639`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 640`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 641`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 642`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 643`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 644`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 645`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 646`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 647`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 648`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 649`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 650`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 651`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 652`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 653`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 654`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 655`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 656`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 657`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 658`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 659`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 660`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 661`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 662`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 663`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 664`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 665`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 666`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 667`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 668`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 669`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 670`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 671`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 672`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 673`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 674`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 675`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 676`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 677`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 678`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 679`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 680`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 681`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 682`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 683`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 684`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 685`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 686`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 687`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 688`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 689`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 690`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 691`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 692`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 693`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 694`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 695`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 696`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 697`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 698`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 699`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 700`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 701`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 702`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 703`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 704`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 705`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 706`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 707`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 708`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 709`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 710`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 711`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 712`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 713`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 714`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 715`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 716`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 717`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 718`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 719`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 720`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 721`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 722`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 723`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 724`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 725`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 726`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 727`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 728`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 729`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 730`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 731`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 732`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 733`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 734`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 735`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 736`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 737`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 738`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 739`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 740`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 741`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 742`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 743`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 744`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 745`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 746`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 747`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 748`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 749`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 750`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 751`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 752`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 753`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 754`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 755`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 756`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 757`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 758`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 759`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 760`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 761`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 762`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 763`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 764`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 765`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 766`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `api.d.ts`
+- **Thin community `Community 767`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `api.js`
+- **Thin community `Community 768`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 769`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `server.d.ts`
+- **Thin community `Community 770`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `server.js`
+- **Thin community `Community 771`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `app.ts`
+- **Thin community `Community 772`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `auth.config.js`
+- **Thin community `Community 773`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `auth.ts`
+- **Thin community `Community 774`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 775`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `countries.ts`
+- **Thin community `Community 776`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `email.ts`
+- **Thin community `Community 777`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `ghana.ts`
+- **Thin community `Community 778`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `payment.ts`
+- **Thin community `Community 779`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `crons.ts`
+- **Thin community `Community 780`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 781`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 782`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 783`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 784`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `env.ts`
+- **Thin community `Community 785`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `analytics.ts`
+- **Thin community `Community 786`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `auth.ts`
+- **Thin community `Community 787`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 788`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `colors.ts`
+- **Thin community `Community 789`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `index.ts`
+- **Thin community `Community 790`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `organizations.ts`
+- **Thin community `Community 791`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `products.ts`
+- **Thin community `Community 792`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 793`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `stores.ts`
+- **Thin community `Community 794`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `index.ts`
+- **Thin community `Community 795`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `bag.ts`
+- **Thin community `Community 796`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `guest.ts`
+- **Thin community `Community 797`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `index.ts`
+- **Thin community `Community 798`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `me.ts`
+- **Thin community `Community 799`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `offers.ts`
+- **Thin community `Community 800`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 801`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `paystack.ts`
+- **Thin community `Community 802`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 803`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `reviews.ts`
+- **Thin community `Community 804`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `rewards.ts`
+- **Thin community `Community 805`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 806`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `security.test.ts`
+- **Thin community `Community 807`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `storefront.ts`
+- **Thin community `Community 808`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `upsells.ts`
+- **Thin community `Community 809`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `user.ts`
+- **Thin community `Community 810`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 811`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `health.test.ts`
+- **Thin community `Community 812`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `http.ts`
+- **Thin community `Community 813`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 814`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 815`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 816`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `categories.ts`
+- **Thin community `Community 817`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `colors.ts`
+- **Thin community `Community 818`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 819`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 820`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 821`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 822`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `organizations.ts`
+- **Thin community `Community 823`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `pos.ts`
+- **Thin community `Community 824`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 825`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 826`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `productSku.ts`
+- **Thin community `Community 827`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 828`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 829`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 830`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 831`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 832`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 833`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 834`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 835`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 836`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `client.test.ts`
+- **Thin community `Community 837`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `config.test.ts`
+- **Thin community `Community 838`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 839`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `types.ts`
+- **Thin community `Community 840`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 841`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 842`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 843`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 844`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 845`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `dto.ts`
+- **Thin community `Community 846`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 847`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 848`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `openDrawer.test.ts`
+- **Thin community `Community 849`** (1 nodes): `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 850`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 851`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `types.ts`
+- **Thin community `Community 852`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 853`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 854`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `catalog.ts`
+- **Thin community `Community 855`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `customers.ts`
+- **Thin community `Community 856`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `register.ts`
+- **Thin community `Community 857`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `terminals.ts`
+- **Thin community `Community 858`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `transactions.ts`
+- **Thin community `Community 859`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `schema.ts`
+- **Thin community `Community 860`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 861`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 862`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 863`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 864`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `category.ts`
+- **Thin community `Community 865`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `color.ts`
+- **Thin community `Community 866`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 867`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 868`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `index.ts`
+- **Thin community `Community 869`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 870`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `organization.ts`
+- **Thin community `Community 871`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 872`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `product.ts`
+- **Thin community `Community 873`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 874`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 875`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `store.ts`
+- **Thin community `Community 876`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 877`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `index.ts`
+- **Thin community `Community 878`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 879`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 880`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 881`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 882`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 883`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `index.ts`
+- **Thin community `Community 884`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 885`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 886`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 887`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 888`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 889`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 890`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 891`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 892`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 893`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `customer.ts`
+- **Thin community `Community 894`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 895`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 896`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 897`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 898`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `index.ts`
+- **Thin community `Community 899`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `posSession.ts`
+- **Thin community `Community 900`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 901`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 902`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 903`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 904`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `index.ts`
+- **Thin community `Community 905`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 906`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 907`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 908`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 909`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 910`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `index.ts`
+- **Thin community `Community 911`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 912`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 913`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 914`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 915`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `vendor.ts`
+- **Thin community `Community 916`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `analytics.ts`
+- **Thin community `Community 917`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `bag.ts`
+- **Thin community `Community 918`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 919`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 920`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 921`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `guest.ts`
+- **Thin community `Community 922`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `index.ts`
+- **Thin community `Community 923`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `offer.ts`
+- **Thin community `Community 924`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 925`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 926`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `review.ts`
+- **Thin community `Community 927`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `rewards.ts`
+- **Thin community `Community 928`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 929`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 930`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 931`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 932`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 933`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 934`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 935`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `bag.ts`
+- **Thin community `Community 936`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 937`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `customer.ts`
+- **Thin community `Community 938`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `guest.ts`
+- **Thin community `Community 939`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 940`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 941`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `payment.ts`
+- **Thin community `Community 942`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 943`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 944`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 945`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `users.ts`
+- **Thin community `Community 946`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `payment.ts`
+- **Thin community `Community 947`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 948`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 949`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 950`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 951`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `index.ts`
+- **Thin community `Community 952`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 953`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `auth.ts`
+- **Thin community `Community 954`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 955`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 956`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 957`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 958`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 959`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 960`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 961`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 962`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `constants.ts`
+- **Thin community `Community 963`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 964`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 965`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `types.ts`
+- **Thin community `Community 967`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 968`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 969`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 970`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 971`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 972`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 973`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `columns.tsx`
+- **Thin community `Community 976`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 979`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 980`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `columns.tsx`
+- **Thin community `Community 981`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 982`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `chart.tsx`
+- **Thin community `Community 984`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `columns.tsx`
+- **Thin community `Community 985`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 986`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 987`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `columns.tsx`
+- **Thin community `Community 988`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `constants.ts`
+- **Thin community `Community 989`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 990`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 991`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 992`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `data.ts`
+- **Thin community `Community 993`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `columns.tsx`
+- **Thin community `Community 994`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 995`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 996`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `columns.tsx`
+- **Thin community `Community 997`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 998`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 999`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1000`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 1003`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1004`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `constants.ts`
+- **Thin community `Community 1005`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1006`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1007`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1008`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data.ts`
+- **Thin community `Community 1009`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1010`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1011`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 1012`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1013`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1014`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1015`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1016`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1017`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1018`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1019`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1020`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1021`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `constants.ts`
+- **Thin community `Community 1022`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1023`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1024`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1025`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1026`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1027`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1028`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1029`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1030`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1031`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1032`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1033`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1034`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1035`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1036`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1037`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1038`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1039`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1040`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1041`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1042`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1043`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1044`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1045`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `constants.ts`
+- **Thin community `Community 1046`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1047`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1048`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1049`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `data.ts`
+- **Thin community `Community 1050`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1051`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `constants.ts`
+- **Thin community `Community 1052`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1053`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1054`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1055`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1056`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `data.ts`
+- **Thin community `Community 1057`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1058`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `constants.ts`
+- **Thin community `Community 1059`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1060`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1061`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1062`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1063`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `data.ts`
+- **Thin community `Community 1064`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1065`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1066`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1067`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1068`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1069`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1070`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1071`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1072`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1073`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1074`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1075`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1076`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1077`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1078`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1079`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1080`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1081`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1082`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1083`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1084`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1085`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1086`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `types.ts`
+- **Thin community `Community 1087`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1088`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1089`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1090`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1091`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1092`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1093`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1094`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1095`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1096`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1097`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1098`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1099`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1100`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1101`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1102`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1103`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1104`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1105`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `data.ts`
+- **Thin community `Community 1106`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1107`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1108`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1109`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1110`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1111`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1112`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1113`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1114`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1115`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1116`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1117`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1118`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1119`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `constants.ts`
+- **Thin community `Community 1120`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1121`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1122`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1123`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `data.ts`
+- **Thin community `Community 1124`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `types.ts`
+- **Thin community `Community 1125`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1126`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1127`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1128`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1129`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `index.tsx`
+- **Thin community `Community 1130`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1131`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1132`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1133`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1134`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `index.tsx`
+- **Thin community `Community 1135`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1136`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1137`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1138`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `button.tsx`
+- **Thin community `Community 1139`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1140`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `card.tsx`
+- **Thin community `Community 1141`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1142`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1143`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `command.tsx`
+- **Thin community `Community 1144`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1145`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1146`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1147`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `form.tsx`
+- **Thin community `Community 1148`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1149`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1150`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `input.tsx`
+- **Thin community `Community 1151`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1152`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1153`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1154`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1155`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1156`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `select.tsx`
+- **Thin community `Community 1157`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1158`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1159`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1160`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `table.tsx`
+- **Thin community `Community 1161`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1162`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1163`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1164`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1165`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1166`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1167`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1168`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1169`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `constants.ts`
+- **Thin community `Community 1170`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1171`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1172`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1173`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `data.ts`
+- **Thin community `Community 1174`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1175`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1176`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1177`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1178`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1179`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1180`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1181`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1182`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1183`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1184`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1185`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1186`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1187`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `index.ts`
+- **Thin community `Community 1188`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `config.ts`
+- **Thin community `Community 1189`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1190`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1191`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1192`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1194`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `aws.ts`
+- **Thin community `Community 1195`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `constants.ts`
+- **Thin community `Community 1196`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `countries.ts`
+- **Thin community `Community 1197`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1199`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1201`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1202`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `ghanaRegions.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1204`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1127,7 +1127,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L607",
+      "source_location": "L615",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1139,7 +1139,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L555",
+      "source_location": "L563",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1151,7 +1151,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L597",
+      "source_location": "L605",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1163,7 +1163,7 @@
       "relation": "calls",
       "source": "completetransaction_resolvesessionregistersessionid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L512",
+      "source_location": "L520",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -8231,7 +8231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L225",
+      "source_location": "L227",
       "target": "possessions_trace_test_buildsession",
       "weight": 1
     },
@@ -8243,7 +8243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L89",
+      "source_location": "L90",
       "target": "possessions_trace_test_createmutationctx",
       "weight": 1
     },
@@ -8255,7 +8255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L242",
+      "source_location": "L244",
       "target": "possessions_trace_test_gethandler",
       "weight": 1
     },
@@ -11255,7 +11255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L747",
+      "source_location": "L754",
       "target": "sessioncommands_buildnextsessionnumber",
       "weight": 1
     },
@@ -11267,7 +11267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L702",
+      "source_location": "L709",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -11291,7 +11291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L940",
+      "source_location": "L947",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -11303,7 +11303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L758",
+      "source_location": "L765",
       "target": "sessioncommands_isactiveregistersession",
       "weight": 1
     },
@@ -11315,7 +11315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L849",
+      "source_location": "L856",
       "target": "sessioncommands_issessionexpired",
       "weight": 1
     },
@@ -11339,7 +11339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L714",
+      "source_location": "L721",
       "target": "sessioncommands_recordsessionlifecyclebesteffort",
       "weight": 1
     },
@@ -11351,7 +11351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L764",
+      "source_location": "L771",
       "target": "sessioncommands_registersessionmatchesidentity",
       "weight": 1
     },
@@ -11363,7 +11363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L793",
+      "source_location": "L800",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -11375,7 +11375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L679",
+      "source_location": "L686",
       "target": "sessioncommands_runbindsessiontoregistersessioncommand",
       "weight": 1
     },
@@ -11387,7 +11387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L668",
+      "source_location": "L675",
       "target": "sessioncommands_runholdsessioncommand",
       "weight": 1
     },
@@ -11399,7 +11399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L695",
+      "source_location": "L702",
       "target": "sessioncommands_runremovesessionitemcommand",
       "weight": 1
     },
@@ -11411,7 +11411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L672",
+      "source_location": "L679",
       "target": "sessioncommands_runresumesessioncommand",
       "weight": 1
     },
@@ -11423,7 +11423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L651",
+      "source_location": "L658",
       "target": "sessioncommands_runstartsessioncommand",
       "weight": 1
     },
@@ -11435,7 +11435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L688",
+      "source_location": "L695",
       "target": "sessioncommands_runupsertsessionitemcommand",
       "weight": 1
     },
@@ -11447,7 +11447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L933",
+      "source_location": "L940",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -11459,7 +11459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L856",
+      "source_location": "L863",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -11471,7 +11471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L829",
+      "source_location": "L836",
       "target": "sessioncommands_validateactivesessionregisterbinding",
       "weight": 1
     },
@@ -11483,7 +11483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L900",
+      "source_location": "L907",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -11557,6 +11557,18 @@
       "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
       "source_location": "L134",
       "target": "terminals_updateterminal",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
+      "_tgt": "completetransaction_test_expectnocompletionsideeffects",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
+      "source_location": "L63",
+      "target": "completetransaction_test_expectnocompletionsideeffects",
       "weight": 1
     },
     {
@@ -11831,7 +11843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1499",
+      "source_location": "L2348",
       "target": "sessioncommands_test_builditem",
       "weight": 1
     },
@@ -11843,7 +11855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1493",
+      "source_location": "L2342",
       "target": "sessioncommands_test_buildregistersession",
       "weight": 1
     },
@@ -11855,7 +11867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1489",
+      "source_location": "L2338",
       "target": "sessioncommands_test_buildsession",
       "weight": 1
     },
@@ -11867,7 +11879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1509",
+      "source_location": "L2358",
       "target": "sessioncommands_test_createcommandservice",
       "weight": 1
     },
@@ -11879,7 +11891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1278",
+      "source_location": "L2104",
       "target": "sessioncommands_test_createdependencies",
       "weight": 1
     },
@@ -11891,7 +11903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1355",
+      "source_location": "L2194",
       "target": "sessioncommands_test_createfakerepository",
       "weight": 1
     },
@@ -11903,7 +11915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1260",
+      "source_location": "L2086",
       "target": "sessioncommands_test_loadcommandservice",
       "weight": 1
     },
@@ -19631,7 +19643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L133",
+      "source_location": "L138",
       "target": "posregisterview_handlecmdk",
       "weight": 1
     },
@@ -24052,6 +24064,30 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "_tgt": "bootstrapregister_test_drawer",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L9",
+      "target": "bootstrapregister_test_drawer",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "_tgt": "bootstrapregister_test_state",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L23",
+      "target": "bootstrapregister_test_state",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "_tgt": "results_isposusecasesuccess",
       "confidence": "EXTRACTED",
@@ -24515,7 +24551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
-      "source_location": "L59",
+      "source_location": "L60",
       "target": "commandgateway_useconvexdirecttransactionmutation",
       "weight": 1
     },
@@ -38783,7 +38819,7 @@
       "relation": "calls",
       "source": "sessioncommands_createpossessioncommandservice",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L705",
+      "source_location": "L712",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -38795,7 +38831,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L821",
+      "source_location": "L828",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -38807,7 +38843,7 @@
       "relation": "calls",
       "source": "sessioncommands_isactiveregistersession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L818",
+      "source_location": "L825",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -38819,7 +38855,7 @@
       "relation": "calls",
       "source": "sessioncommands_registersessionmatchesidentity",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L819",
+      "source_location": "L826",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -38831,7 +38867,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L824",
+      "source_location": "L831",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -38843,7 +38879,7 @@
       "relation": "calls",
       "source": "sessioncommands_runbindsessiontoregistersessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L683",
+      "source_location": "L690",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -38855,7 +38891,7 @@
       "relation": "calls",
       "source": "sessioncommands_runholdsessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L669",
+      "source_location": "L676",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -38867,7 +38903,7 @@
       "relation": "calls",
       "source": "sessioncommands_runremovesessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L699",
+      "source_location": "L706",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -38879,7 +38915,7 @@
       "relation": "calls",
       "source": "sessioncommands_runresumesessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L676",
+      "source_location": "L683",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -38891,7 +38927,7 @@
       "relation": "calls",
       "source": "sessioncommands_runupsertsessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L692",
+      "source_location": "L699",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -38903,7 +38939,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L862",
+      "source_location": "L869",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -38915,7 +38951,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L875",
+      "source_location": "L882",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -38927,7 +38963,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L897",
+      "source_location": "L904",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -38939,7 +38975,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesessionregisterbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L837",
+      "source_location": "L844",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -38951,7 +38987,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L840",
+      "source_location": "L847",
       "target": "sessioncommands_validateactivesessionregisterbinding",
       "weight": 1
     },
@@ -38963,7 +38999,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L906",
+      "source_location": "L913",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -38975,7 +39011,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L916",
+      "source_location": "L923",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -38987,7 +39023,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L930",
+      "source_location": "L937",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -42630,6 +42666,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -42637,7 +42682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42646,7 +42691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -42655,7 +42700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -42664,7 +42709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -42673,7 +42718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42682,7 +42727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42691,7 +42736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42700,21 +42745,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
-      "label": "DefaultCatchBoundary.test.tsx",
-      "norm_label": "defaultcatchboundary.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.test.tsx",
       "source_location": "L1"
     },
     {
@@ -42783,6 +42819,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
+      "label": "DefaultCatchBoundary.test.tsx",
+      "norm_label": "defaultcatchboundary.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
       "norm_label": "defaultcatchboundary.tsx",
@@ -42790,7 +42835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -42799,7 +42844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -42808,7 +42853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -42817,7 +42862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -42826,7 +42871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -42835,7 +42880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42844,7 +42889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42853,21 +42898,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -42936,6 +42972,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -42943,7 +42988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -42952,7 +42997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -42961,7 +43006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -42970,7 +43015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -42979,7 +43024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -42988,7 +43033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -42997,7 +43042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -43006,21 +43051,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
       "norm_label": "cashcontrolsworkspaceheader.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
-      "label": "RegisterCloseoutView.test.tsx",
-      "norm_label": "registercloseoutview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43089,6 +43125,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
+      "label": "RegisterCloseoutView.test.tsx",
+      "norm_label": "registercloseoutview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
       "norm_label": "registersessionview.auth.test.tsx",
@@ -43096,7 +43141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -43105,7 +43150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -43114,7 +43159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43123,7 +43168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43132,7 +43177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -43141,7 +43186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -43150,7 +43195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -43159,21 +43204,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
       "norm_label": "operationsqueueview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
-      "label": "StockAdjustmentWorkspace.test.tsx",
-      "norm_label": "stockadjustmentworkspace.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43242,6 +43278,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
+      "label": "StockAdjustmentWorkspace.test.tsx",
+      "norm_label": "stockadjustmentworkspace.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
       "norm_label": "orderstatus.test.tsx",
@@ -43249,7 +43294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -43258,7 +43303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -43267,7 +43312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -43276,7 +43321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -43285,7 +43330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -43294,7 +43339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43303,7 +43348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43312,21 +43357,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -43395,6 +43431,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -43402,7 +43447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -43411,7 +43456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -43420,7 +43465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43429,7 +43474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -43438,7 +43483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -43447,7 +43492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -43456,7 +43501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -43465,21 +43510,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -43548,6 +43584,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -43555,7 +43600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -43564,7 +43609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -43573,7 +43618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -43582,7 +43627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -43591,7 +43636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -43600,7 +43645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -43609,7 +43654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -43618,21 +43663,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
       "norm_label": "posregisterview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
-      "label": "PaymentView.test.tsx",
-      "norm_label": "paymentview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43692,6 +43728,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
+      "label": "PaymentView.test.tsx",
+      "norm_label": "paymentview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
       "norm_label": "productlookup.tsx",
@@ -43699,7 +43744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -43708,7 +43753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -43717,7 +43762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -43726,7 +43771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -43735,7 +43780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -43744,7 +43789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -43753,7 +43798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -43762,21 +43807,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
       "norm_label": "expensereportcolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
-      "label": "POSRegisterView.test.tsx",
-      "norm_label": "posregisterview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -43836,6 +43872,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
+      "label": "POSRegisterView.test.tsx",
+      "norm_label": "posregisterview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
       "norm_label": "registeractionbar.tsx",
@@ -43843,7 +43888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -43852,7 +43897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -43861,7 +43906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -43870,7 +43915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -43879,7 +43924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -43888,7 +43933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -43897,7 +43942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -43906,21 +43951,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
       "norm_label": "receivingview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "label": "AnalyticsInsights.tsx",
-      "norm_label": "analyticsinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1"
     },
     {
@@ -43980,6 +44016,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
+      "label": "AnalyticsInsights.tsx",
+      "norm_label": "analyticsinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
       "norm_label": "attributesview.tsx",
@@ -43987,7 +44032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -43996,7 +44041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -44005,7 +44050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -44014,7 +44059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -44023,7 +44068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -44032,7 +44077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -44041,7 +44086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -44050,21 +44095,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
       "norm_label": "complimentaryproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
-      "label": "complimentaryProductsColumn.tsx",
-      "norm_label": "complimentaryproductscolumn.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1"
     },
     {
@@ -44304,6 +44340,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
+      "label": "complimentaryProductsColumn.tsx",
+      "norm_label": "complimentaryproductscolumn.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
@@ -44311,7 +44356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44320,7 +44365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44329,7 +44374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44338,7 +44383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -44347,7 +44392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -44356,7 +44401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -44365,7 +44410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -44374,21 +44419,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
       "norm_label": "promocodes.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
-      "label": "PromoCodeAnalytics.tsx",
-      "norm_label": "promocodeanalytics.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
       "source_location": "L1"
     },
     {
@@ -44448,6 +44484,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
+      "label": "PromoCodeAnalytics.tsx",
+      "norm_label": "promocodeanalytics.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
       "norm_label": "captured-emails-columns.tsx",
@@ -44455,7 +44500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -44464,7 +44509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -44473,7 +44518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -44482,7 +44527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44491,7 +44536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44500,7 +44545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44509,7 +44554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44518,21 +44563,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -44592,6 +44628,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -44599,7 +44644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44608,7 +44653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44617,7 +44662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -44626,7 +44671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -44635,7 +44680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -44644,7 +44689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -44653,7 +44698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -44662,21 +44707,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_staff_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/staff/index.tsx",
       "source_location": "L1"
     },
     {
@@ -44736,6 +44772,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_staff_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/staff/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
       "norm_label": "fulfillmentview.test.tsx",
@@ -44743,7 +44788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -44752,7 +44797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -44761,7 +44806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -44770,7 +44815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -44779,7 +44824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -44788,7 +44833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -44797,7 +44842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -44806,21 +44851,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "label": "calendar.test.tsx",
-      "norm_label": "calendar.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1"
     },
     {
@@ -44880,6 +44916,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
+      "label": "calendar.test.tsx",
+      "norm_label": "calendar.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
@@ -44887,7 +44932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -44896,7 +44941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -44905,7 +44950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -44914,7 +44959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -44923,7 +44968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -44932,7 +44977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -44941,7 +44986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -44950,21 +44995,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1"
     },
     {
@@ -45024,6 +45060,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
       "norm_label": "input.tsx",
@@ -45031,7 +45076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -45040,7 +45085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -45049,7 +45094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -45058,7 +45103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -45067,7 +45112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -45076,7 +45121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -45085,7 +45130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -45094,21 +45139,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1"
     },
     {
@@ -45168,6 +45204,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
@@ -45175,7 +45220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -45184,7 +45229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -45193,7 +45238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -45202,7 +45247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -45211,7 +45256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -45220,7 +45265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -45229,7 +45274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -45238,21 +45283,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -45312,6 +45348,15 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -45319,7 +45364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45328,7 +45373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45337,7 +45382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -45346,7 +45391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -45355,7 +45400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -45364,7 +45409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -45373,7 +45418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -45382,21 +45427,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -45456,6 +45492,15 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -45463,7 +45508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45472,7 +45517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -45481,7 +45526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -45490,7 +45535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -45499,7 +45544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -45508,7 +45553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -45517,7 +45562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -45526,7 +45571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -45535,7 +45580,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 1190,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -45544,61 +45643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1190,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -45607,7 +45652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -45616,7 +45661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -45625,7 +45670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -45634,7 +45679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -45643,7 +45688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -45652,7 +45697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -45661,7 +45706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -45670,21 +45715,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
       "norm_label": "presentcommandtoast.test.ts",
       "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
-      "label": "presentUnexpectedErrorToast.test.ts",
-      "norm_label": "presentunexpectederrortoast.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.test.ts",
       "source_location": "L1"
     },
     {
@@ -45870,59 +45906,68 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
+      "label": "presentUnexpectedErrorToast.test.ts",
+      "norm_label": "presentunexpectederrortoast.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -45931,7 +45976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -45940,21 +45985,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
       "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1203,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
-      "label": "bootstrapRegister.test.ts",
-      "norm_label": "bootstrapregister.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
       "source_location": "L1"
     },
     {
@@ -46014,56 +46050,56 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L101"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
     },
     {
       "community": 1210,
@@ -46158,56 +46194,56 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
     },
     {
       "community": 1220,
@@ -46302,56 +46338,56 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 1230,
@@ -46446,56 +46482,56 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L97"
     },
     {
       "community": 1240,
@@ -46590,56 +46626,56 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L107"
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L63"
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L80"
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L46"
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L97"
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
     },
     {
       "community": 1250,
@@ -46734,56 +46770,56 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
     },
     {
       "community": 1260,
@@ -46878,56 +46914,56 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L48"
     },
     {
       "community": 1270,
@@ -47022,56 +47058,56 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L27"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L36"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L11"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L5"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L48"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1280,
@@ -47166,56 +47202,56 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1290,
@@ -47481,56 +47517,56 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
     },
     {
       "community": 1300,
@@ -47625,56 +47661,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
+      "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
+      "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L83"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
     },
     {
       "community": 1310,
@@ -47769,56 +47805,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L83"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1320,
@@ -47913,56 +47949,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1330,
@@ -48057,56 +48093,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
     },
     {
       "community": 1340,
@@ -48201,55 +48237,55 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
       "source_location": "L1"
     },
     {
@@ -48345,55 +48381,55 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
@@ -48489,55 +48525,55 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -50406,51 +50442,6 @@
     {
       "community": 158,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
       "norm_label": "pageheader.tsx",
@@ -50458,7 +50449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -50467,7 +50458,7 @@
       "source_location": "L29"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -50476,7 +50467,7 @@
       "source_location": "L7"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -50485,13 +50476,58 @@
       "source_location": "L48"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
       "norm_label": "viewheader()",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L65"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
     },
     {
       "community": 16,
@@ -50658,51 +50694,6 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
       "norm_label": "handledisplaytypechange()",
@@ -50710,7 +50701,7 @@
       "source_location": "L61"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -50719,7 +50710,7 @@
       "source_location": "L57"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -50728,7 +50719,7 @@
       "source_location": "L98"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -50737,7 +50728,7 @@
       "source_location": "L134"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -50746,7 +50737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -50755,7 +50746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -50764,7 +50755,7 @@
       "source_location": "L38"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -50773,7 +50764,7 @@
       "source_location": "L64"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -50782,7 +50773,7 @@
       "source_location": "L135"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -50791,7 +50782,7 @@
       "source_location": "L43"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -50800,7 +50791,7 @@
       "source_location": "L58"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -50809,7 +50800,7 @@
       "source_location": "L63"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -50818,7 +50809,7 @@
       "source_location": "L50"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -50827,7 +50818,7 @@
       "source_location": "L53"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -50836,7 +50827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -50845,7 +50836,7 @@
       "source_location": "L140"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -50854,7 +50845,7 @@
       "source_location": "L177"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -50863,7 +50854,7 @@
       "source_location": "L195"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -50872,7 +50863,7 @@
       "source_location": "L45"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -50881,7 +50872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -50890,7 +50881,7 @@
       "source_location": "L92"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -50899,7 +50890,7 @@
       "source_location": "L307"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -50908,7 +50899,7 @@
       "source_location": "L70"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -50917,12 +50908,57 @@
       "source_location": "L50"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -52525,7 +52561,7 @@
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L225"
+      "source_location": "L227"
     },
     {
       "community": 192,
@@ -52534,7 +52570,7 @@
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L89"
+      "source_location": "L90"
     },
     {
       "community": 192,
@@ -52543,7 +52579,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
-      "source_location": "L242"
+      "source_location": "L244"
     },
     {
       "community": 193,
@@ -54388,7 +54424,7 @@
       "label": "handleCmdK()",
       "norm_label": "handlecmdk()",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L133"
+      "source_location": "L138"
     },
     {
       "community": 223,
@@ -60252,6 +60288,33 @@
     {
       "community": 355,
       "file_type": "code",
+      "id": "bootstrapregister_test_drawer",
+      "label": "drawer()",
+      "norm_label": "drawer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 355,
+      "file_type": "code",
+      "id": "bootstrapregister_test_state",
+      "label": "state()",
+      "norm_label": "state()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 355,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "label": "bootstrapRegister.test.ts",
+      "norm_label": "bootstrapregister.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 356,
+      "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
       "norm_label": "formatstoredamount()",
@@ -60259,7 +60322,7 @@
       "source_location": "L3"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -60268,7 +60331,7 @@
       "source_location": "L10"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -60277,7 +60340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -60286,16 +60349,16 @@
       "source_location": "L18"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
       "norm_label": "useconvexdirecttransactionmutation()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
-      "source_location": "L59"
+      "source_location": "L60"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -60304,7 +60367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -60313,7 +60376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -60322,7 +60385,7 @@
       "source_location": "L32"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -60331,7 +60394,7 @@
       "source_location": "L48"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -60340,7 +60403,7 @@
       "source_location": "L31"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -60349,40 +60412,13 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
       "norm_label": "main.tsx",
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
-      "label": "routeTree.browser-boundary.test.ts",
-      "norm_label": "routetree.browser-boundary.test.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "routetree_browser_boundary_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "routetree_browser_boundary_test_findillegalconveximports",
-      "label": "findIllegalConvexImports()",
-      "norm_label": "findillegalconveximports()",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L46"
     },
     {
       "community": 36,
@@ -60504,6 +60540,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
+      "label": "routeTree.browser-boundary.test.ts",
+      "norm_label": "routetree.browser-boundary.test.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "routetree_browser_boundary_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "routetree_browser_boundary_test_findillegalconveximports",
+      "label": "findIllegalConvexImports()",
+      "norm_label": "findillegalconveximports()",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
       "norm_label": "authedcomponent()",
@@ -60511,7 +60574,7 @@
       "source_location": "L18"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -60520,7 +60583,7 @@
       "source_location": "L28"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -60529,7 +60592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -60538,7 +60601,7 @@
       "source_location": "L127"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -60547,7 +60610,7 @@
       "source_location": "L106"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -60556,7 +60619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -60565,7 +60628,7 @@
       "source_location": "L66"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -60574,7 +60637,7 @@
       "source_location": "L20"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -60583,7 +60646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -60592,7 +60655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -60601,7 +60664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -60610,7 +60673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -60619,7 +60682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -60628,7 +60691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -60637,7 +60700,7 @@
       "source_location": "L16"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -60646,7 +60709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -60655,7 +60718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -60664,7 +60727,7 @@
       "source_location": "L19"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -60673,7 +60736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -60682,7 +60745,7 @@
       "source_location": "L23"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -60691,7 +60754,7 @@
       "source_location": "L24"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -60700,7 +60763,7 @@
       "source_location": "L32"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -60709,7 +60772,7 @@
       "source_location": "L3"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -60718,7 +60781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -60727,7 +60790,7 @@
       "source_location": "L7"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -60736,39 +60799,12 @@
       "source_location": "L5"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
       "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "organization_getallorganizations",
-      "label": "getAllOrganizations()",
-      "norm_label": "getallorganizations()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "organization_getorganization",
-      "label": "getOrganization()",
-      "norm_label": "getorganization()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
     },
     {
@@ -60891,6 +60927,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "organization_getallorganizations",
+      "label": "getAllOrganizations()",
+      "norm_label": "getallorganizations()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "organization_getorganization",
+      "label": "getOrganization()",
+      "norm_label": "getorganization()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
@@ -60898,7 +60961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -60907,7 +60970,7 @@
       "source_location": "L60"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "postransaction_getpostransaction",
       "label": "getPosTransaction()",
@@ -60916,7 +60979,7 @@
       "source_location": "L62"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -60925,7 +60988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -60934,7 +60997,7 @@
       "source_location": "L3"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -60943,7 +61006,7 @@
       "source_location": "L5"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -60952,7 +61015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -60961,7 +61024,7 @@
       "source_location": "L18"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -60970,7 +61033,7 @@
       "source_location": "L23"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -60979,7 +61042,7 @@
       "source_location": "L22"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -60988,7 +61051,7 @@
       "source_location": "L55"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -60997,7 +61060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -61006,7 +61069,7 @@
       "source_location": "L77"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -61015,7 +61078,7 @@
       "source_location": "L11"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -61024,7 +61087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -61033,7 +61096,7 @@
       "source_location": "L11"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -61042,7 +61105,7 @@
       "source_location": "L22"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -61051,7 +61114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -61060,7 +61123,7 @@
       "source_location": "L110"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -61069,7 +61132,7 @@
       "source_location": "L89"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -61078,7 +61141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -61087,7 +61150,7 @@
       "source_location": "L4"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -61096,7 +61159,7 @@
       "source_location": "L24"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -61105,7 +61168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -61114,7 +61177,7 @@
       "source_location": "L131"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -61123,39 +61186,12 @@
       "source_location": "L12"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
       "norm_label": "footer.tsx",
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredproductssection",
-      "label": "FeaturedProductsSection()",
-      "norm_label": "featuredproductssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredsection",
-      "label": "FeaturedSection()",
-      "norm_label": "featuredsection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "label": "FeaturedProductsSection.tsx",
-      "norm_label": "featuredproductssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -61278,6 +61314,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "featuredproductssection_featuredproductssection",
+      "label": "FeaturedProductsSection()",
+      "norm_label": "featuredproductssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "featuredproductssection_featuredsection",
+      "label": "FeaturedSection()",
+      "norm_label": "featuredsection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
+      "label": "FeaturedProductsSection.tsx",
+      "norm_label": "featuredproductssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
       "norm_label": "promoalert.tsx",
@@ -61285,7 +61348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -61294,7 +61357,7 @@
       "source_location": "L20"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -61303,7 +61366,7 @@
       "source_location": "L59"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -61312,7 +61375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -61321,7 +61384,7 @@
       "source_location": "L25"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -61330,7 +61393,7 @@
       "source_location": "L20"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -61339,7 +61402,7 @@
       "source_location": "L30"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -61348,7 +61411,7 @@
       "source_location": "L95"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -61357,7 +61420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -61366,7 +61429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -61375,7 +61438,7 @@
       "source_location": "L150"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -61384,7 +61447,7 @@
       "source_location": "L157"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -61393,7 +61456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -61402,7 +61465,7 @@
       "source_location": "L63"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -61411,7 +61474,7 @@
       "source_location": "L48"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -61420,7 +61483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -61429,7 +61492,7 @@
       "source_location": "L63"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -61438,7 +61501,7 @@
       "source_location": "L76"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -61447,7 +61510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -61456,7 +61519,7 @@
       "source_location": "L51"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -61465,7 +61528,7 @@
       "source_location": "L36"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -61474,7 +61537,7 @@
       "source_location": "L16"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -61483,7 +61546,7 @@
       "source_location": "L39"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -61492,7 +61555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -61501,7 +61564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -61510,40 +61573,13 @@
       "source_location": "L25"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
       "norm_label": "usestorecontext()",
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "label": "StorefrontObservabilityProvider.tsx",
-      "norm_label": "storefrontobservabilityprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "label": "StorefrontObservabilityProvider()",
-      "norm_label": "storefrontobservabilityprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "label": "useStorefrontObservability()",
-      "norm_label": "usestorefrontobservability()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L55"
     },
     {
       "community": 39,
@@ -61656,6 +61692,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
+      "label": "StorefrontObservabilityProvider.tsx",
+      "norm_label": "storefrontobservabilityprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
+      "label": "StorefrontObservabilityProvider()",
+      "norm_label": "storefrontobservabilityprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_usestorefrontobservability",
+      "label": "useStorefrontObservability()",
+      "norm_label": "usestorefrontobservability()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
       "norm_label": "useproductdiscount.ts",
@@ -61663,7 +61726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -61672,7 +61735,7 @@
       "source_location": "L107"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -61681,7 +61744,7 @@
       "source_location": "L25"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -61690,7 +61753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -61699,7 +61762,7 @@
       "source_location": "L556"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -61708,7 +61771,7 @@
       "source_location": "L52"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -61717,7 +61780,7 @@
       "source_location": "L429"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -61726,7 +61789,7 @@
       "source_location": "L102"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -61735,7 +61798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -61744,7 +61807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -61753,7 +61816,7 @@
       "source_location": "L250"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -61762,7 +61825,7 @@
       "source_location": "L46"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -61771,7 +61834,7 @@
       "source_location": "L17"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -61780,7 +61843,7 @@
       "source_location": "L63"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -61789,7 +61852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -61798,7 +61861,7 @@
       "source_location": "L47"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -61807,7 +61870,7 @@
       "source_location": "L141"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -61816,7 +61879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -61825,7 +61888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -61834,7 +61897,7 @@
       "source_location": "L21"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -61843,7 +61906,7 @@
       "source_location": "L107"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "index_money",
       "label": "money()",
@@ -61852,7 +61915,7 @@
       "source_location": "L51"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "index_paymentlabel",
       "label": "paymentLabel()",
@@ -61861,7 +61924,7 @@
       "source_location": "L14"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_transactionid_index_tsx",
       "label": "index.tsx",
@@ -61870,7 +61933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -61879,7 +61942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -61888,40 +61951,13 @@
       "source_location": "L161"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
       "norm_label": "signupbeforeload()",
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "env_optionalnumberenv",
-      "label": "optionalNumberEnv()",
-      "norm_label": "optionalnumberenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "env_requireenv",
-      "label": "requireEnv()",
-      "norm_label": "requireenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -62286,6 +62322,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "env_optionalnumberenv",
+      "label": "optionalNumberEnv()",
+      "norm_label": "optionalnumberenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "env_requireenv",
+      "label": "requireEnv()",
+      "norm_label": "requireenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -62293,7 +62356,7 @@
       "source_location": "L16"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -62302,7 +62365,7 @@
       "source_location": "L10"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -62311,7 +62374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62320,7 +62383,7 @@
       "source_location": "L17"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -62329,7 +62392,7 @@
       "source_location": "L11"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -62338,7 +62401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -62347,7 +62410,7 @@
       "source_location": "L21"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -62356,7 +62419,7 @@
       "source_location": "L15"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -62365,7 +62428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62374,7 +62437,7 @@
       "source_location": "L48"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -62383,7 +62446,7 @@
       "source_location": "L42"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -62392,7 +62455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62401,7 +62464,7 @@
       "source_location": "L16"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -62410,7 +62473,7 @@
       "source_location": "L10"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -62419,7 +62482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62428,7 +62491,7 @@
       "source_location": "L19"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -62437,7 +62500,7 @@
       "source_location": "L13"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -62446,7 +62509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -62455,7 +62518,7 @@
       "source_location": "L16"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -62464,7 +62527,7 @@
       "source_location": "L10"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -62473,7 +62536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -62482,7 +62545,7 @@
       "source_location": "L20"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -62491,7 +62554,7 @@
       "source_location": "L14"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -62500,7 +62563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -62509,7 +62572,7 @@
       "source_location": "L26"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -62518,39 +62581,12 @@
       "source_location": "L18"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
       "norm_label": "pre-commit-generated-artifacts.test.ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
-      "label": "runPreCommitGeneratedArtifacts()",
-      "norm_label": "runprecommitgeneratedartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
-      "label": "stageTrackedGraphifyArtifacts()",
-      "norm_label": "stagetrackedgraphifyartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_ts",
-      "label": "pre-commit-generated-artifacts.ts",
-      "norm_label": "pre-commit-generated-artifacts.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
       "source_location": "L1"
     },
     {
@@ -62655,6 +62691,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "label": "runPreCommitGeneratedArtifacts()",
+      "norm_label": "runprecommitgeneratedartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "label": "stageTrackedGraphifyArtifacts()",
+      "norm_label": "stagetrackedgraphifyartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_ts",
+      "label": "pre-commit-generated-artifacts.ts",
+      "norm_label": "pre-commit-generated-artifacts.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
@@ -62662,7 +62725,7 @@
       "source_location": "L8"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -62671,7 +62734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -62680,7 +62743,7 @@
       "source_location": "L9"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -62689,7 +62752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -62698,7 +62761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -62707,7 +62770,7 @@
       "source_location": "L12"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -62716,7 +62779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -62725,7 +62788,7 @@
       "source_location": "L8"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -62734,7 +62797,7 @@
       "source_location": "L10"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -62743,7 +62806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -62752,7 +62815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -62761,7 +62824,7 @@
       "source_location": "L18"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -62770,7 +62833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
@@ -62779,7 +62842,7 @@
       "source_location": "L10"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -62788,7 +62851,7 @@
       "source_location": "L10"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -62797,7 +62860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -62806,7 +62869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -62815,1141 +62878,7 @@
       "source_location": "L6"
     },
     {
-      "community": 419,
-      "file_type": "code",
-      "id": "auth_mapathenaauthsyncerror",
-      "label": "mapAthenaAuthSyncError()",
-      "norm_label": "mapathenaauthsyncerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 42,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 420,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
-      "label": "posQueryCleanup.test.ts",
-      "norm_label": "posquerycleanup.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 420,
-      "file_type": "code",
-      "id": "posquerycleanup_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 421,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
-      "label": "posSessionItems.ts",
-      "norm_label": "possessionitems.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 421,
-      "file_type": "code",
-      "id": "possessionitems_usererrorfromsessionitemfailure",
-      "label": "userErrorFromSessionItemFailure()",
-      "norm_label": "usererrorfromsessionitemfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 422,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "label": "productUtil.ts",
-      "norm_label": "productutil.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 422,
-      "file_type": "code",
-      "id": "productutil_buildallproductscachekey",
-      "label": "buildAllProductsCacheKey()",
-      "norm_label": "buildallproductscachekey()",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 423,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 423,
-      "file_type": "code",
-      "id": "stores_tov2onlyconfig",
-      "label": "toV2OnlyConfig()",
-      "norm_label": "tov2onlyconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 424,
-      "file_type": "code",
-      "id": "commandresultvalidators_commandresultvalidator",
-      "label": "commandResultValidator()",
-      "norm_label": "commandresultvalidator()",
-      "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 424,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
-      "label": "commandResultValidators.ts",
-      "norm_label": "commandresultvalidators.ts",
-      "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 425,
-      "file_type": "code",
-      "id": "callllmprovider_callllmprovider",
-      "label": "callLlmProvider()",
-      "norm_label": "callllmprovider()",
-      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 425,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
-      "label": "callLlmProvider.ts",
-      "norm_label": "callllmprovider.ts",
-      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 426,
-      "file_type": "code",
-      "id": "anthropic_callanthropic",
-      "label": "callAnthropic()",
-      "norm_label": "callanthropic()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 426,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
-      "label": "anthropic.ts",
-      "norm_label": "anthropic.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "openai_callopenai",
-      "label": "callOpenAi()",
-      "norm_label": "callopenai()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
-      "label": "openai.ts",
-      "norm_label": "openai.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "foundation_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
-      "label": "foundation.test.ts",
-      "norm_label": "foundation.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "approvalrequesthelpers_buildapprovalrequest",
-      "label": "buildApprovalRequest()",
-      "norm_label": "buildapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
-      "label": "approvalRequestHelpers.ts",
-      "norm_label": "approvalrequesthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
-      "label": "RegisterSessionView.tsx",
-      "norm_label": "registersessionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L248"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_builddepositsubmissionkey",
-      "label": "buildDepositSubmissionKey()",
-      "norm_label": "builddepositsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L616"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L152"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_handlerecorddeposit",
-      "label": "handleRecordDeposit()",
-      "norm_label": "handlerecorddeposit()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "registersessionview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 430,
-      "file_type": "code",
-      "id": "approvalrequests_test_createapprovalrequestmutationctx",
-      "label": "createApprovalRequestMutationCtx()",
-      "norm_label": "createapprovalrequestmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 430,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
-      "label": "approvalRequests.test.ts",
-      "norm_label": "approvalrequests.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 431,
-      "file_type": "code",
-      "id": "eventbuilders_buildoperationaleventmessage",
-      "label": "buildOperationalEventMessage()",
-      "norm_label": "buildoperationaleventmessage()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 431,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
-      "label": "eventBuilders.ts",
-      "norm_label": "eventbuilders.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 432,
-      "file_type": "code",
-      "id": "emailotp_formatvalidtime",
-      "label": "formatValidTime()",
-      "norm_label": "formatvalidtime()",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 432,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
-      "label": "EmailOTP.ts",
-      "norm_label": "emailotp.ts",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 433,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
-      "label": "quickAddCatalogItem.test.ts",
-      "norm_label": "quickaddcatalogitem.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 433,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_test_createquickaddctx",
-      "label": "createQuickAddCtx()",
-      "norm_label": "createquickaddctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 434,
-      "file_type": "code",
-      "id": "inventoryholdgateway_createinventoryholdgateway",
-      "label": "createInventoryHoldGateway()",
-      "norm_label": "createinventoryholdgateway()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 434,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "label": "inventoryHoldGateway.ts",
-      "norm_label": "inventoryholdgateway.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 435,
-      "file_type": "code",
-      "id": "cashierrepository_getcashierforregisterstate",
-      "label": "getCashierForRegisterState()",
-      "norm_label": "getcashierforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 435,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
-      "label": "cashierRepository.ts",
-      "norm_label": "cashierrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 436,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
-      "label": "sessionRepository.test.ts",
-      "norm_label": "sessionrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 436,
-      "file_type": "code",
-      "id": "sessionrepository_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "catalog_buildservicecatalogitem",
-      "label": "buildServiceCatalogItem()",
-      "norm_label": "buildservicecatalogitem()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "modulewiring_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
-      "label": "moduleWiring.test.ts",
-      "norm_label": "modulewiring.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "access_test_createstockopsaccessqueryctx",
-      "label": "createStockOpsAccessQueryCtx()",
-      "norm_label": "createstockopsaccessqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
-      "label": "access.test.ts",
-      "norm_label": "access.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 440,
-      "file_type": "code",
-      "id": "access_requirestorefulladminaccess",
-      "label": "requireStoreFullAdminAccess()",
-      "norm_label": "requirestorefulladminaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 440,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_ts",
-      "label": "access.ts",
-      "norm_label": "access.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 441,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
-      "label": "purchaseOrders.test.ts",
-      "norm_label": "purchaseorders.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 441,
-      "file_type": "code",
-      "id": "purchaseorders_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 442,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
-      "label": "vendors.test.ts",
-      "norm_label": "vendors.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 442,
-      "file_type": "code",
-      "id": "vendors_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 443,
-      "file_type": "code",
-      "id": "auth_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 443,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 444,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_test_createqueryctx",
-      "label": "createQueryCtx()",
-      "norm_label": "createqueryctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 444,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
-      "label": "customerBehaviorTimeline.test.ts",
-      "norm_label": "customerbehaviortimeline.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 445,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 445,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
-      "label": "customerObservabilityTimeline.test.ts",
-      "norm_label": "customerobservabilitytimeline.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 446,
-      "file_type": "code",
-      "id": "helperorchestration_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 446,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
-      "label": "helperOrchestration.test.ts",
-      "norm_label": "helperorchestration.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "customerengagementevents_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
-      "label": "customerEngagementEvents.test.ts",
-      "norm_label": "customerengagementevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "onlineorderitem_updateonlineorderitem",
-      "label": "updateOnlineOrderItem()",
-      "norm_label": "updateonlineorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "reviews_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 450,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 450,
-      "file_type": "code",
-      "id": "rewards_formatpointslabel",
-      "label": "formatPointsLabel()",
-      "norm_label": "formatpointslabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 451,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 451,
-      "file_type": "code",
-      "id": "savedbag_listsavedbagitems",
-      "label": "listSavedBagItems()",
-      "norm_label": "listsavedbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 452,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "label": "storefrontObservabilityReport.test.ts",
-      "norm_label": "storefrontobservabilityreport.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 452,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 453,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
-      "label": "syntheticMonitor.ts",
-      "norm_label": "syntheticmonitor.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 453,
-      "file_type": "code",
-      "id": "syntheticmonitor_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
-      "label": "timeQueryRefactors.test.ts",
-      "norm_label": "timequeryrefactors.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "timequeryrefactors_test_readsource",
-      "label": "readSource()",
-      "norm_label": "readsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 455,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 455,
-      "file_type": "code",
-      "id": "user_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 456,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 456,
-      "file_type": "code",
-      "id": "useroffers_determineoffereligibility",
-      "label": "determineOfferEligibility()",
-      "norm_label": "determineoffereligibility()",
-      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "possession_buildpossessiontraceseed",
-      "label": "buildPosSessionTraceSeed()",
-      "norm_label": "buildpossessiontraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
-      "label": "presentation.ts",
-      "norm_label": "presentation.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "presentation_buildworkflowtraceviewmodel",
-      "label": "buildWorkflowTraceViewModel()",
-      "norm_label": "buildworkflowtraceviewmodel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
-      "label": "schemaIndexes.test.ts",
-      "norm_label": "schemaindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "schemaindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 46,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_utils_ts",
       "label": "utils.ts",
@@ -63958,7 +62887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_ts",
       "label": "utils.ts",
@@ -63967,7 +62896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
       "label": "utils.ts",
@@ -63976,7 +62905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_formatdeliveryaddress",
       "label": "formatDeliveryAddress()",
@@ -63985,7 +62914,7 @@
       "source_location": "L74"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_getamountpaidfororder",
       "label": "getAmountPaidForOrder()",
@@ -63994,7 +62923,7 @@
       "source_location": "L128"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_getdiscountvalue",
       "label": "getDiscountValue()",
@@ -64003,7 +62932,7 @@
       "source_location": "L17"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_getorderamount",
       "label": "getOrderAmount()",
@@ -64012,7 +62941,7 @@
       "source_location": "L51"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_getorderstate",
       "label": "getOrderState()",
@@ -64021,7 +62950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_getpickupactionstate",
       "label": "getPickupActionState()",
@@ -64030,7 +62959,7 @@
       "source_location": "L61"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_getpotentialpoints",
       "label": "getPotentialPoints()",
@@ -64039,7 +62968,7 @@
       "source_location": "L107"
     },
     {
-      "community": 46,
+      "community": 42,
       "file_type": "code",
       "id": "utils_getproductdiscountvalue",
       "label": "getProductDiscountValue()",
@@ -64048,7 +62977,1159 @@
       "source_location": "L75"
     },
     {
+      "community": 420,
+      "file_type": "code",
+      "id": "auth_mapathenaauthsyncerror",
+      "label": "mapAthenaAuthSyncError()",
+      "norm_label": "mapathenaauthsyncerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
+      "label": "posQueryCleanup.test.ts",
+      "norm_label": "posquerycleanup.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "posquerycleanup_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
+      "label": "posSessionItems.ts",
+      "norm_label": "possessionitems.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "possessionitems_usererrorfromsessionitemfailure",
+      "label": "userErrorFromSessionItemFailure()",
+      "norm_label": "usererrorfromsessionitemfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 423,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
+      "label": "productUtil.ts",
+      "norm_label": "productutil.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 423,
+      "file_type": "code",
+      "id": "productutil_buildallproductscachekey",
+      "label": "buildAllProductsCacheKey()",
+      "norm_label": "buildallproductscachekey()",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 424,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 424,
+      "file_type": "code",
+      "id": "stores_tov2onlyconfig",
+      "label": "toV2OnlyConfig()",
+      "norm_label": "tov2onlyconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 425,
+      "file_type": "code",
+      "id": "commandresultvalidators_commandresultvalidator",
+      "label": "commandResultValidator()",
+      "norm_label": "commandresultvalidator()",
+      "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 425,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
+      "label": "commandResultValidators.ts",
+      "norm_label": "commandresultvalidators.ts",
+      "source_file": "packages/athena-webapp/convex/lib/commandResultValidators.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 426,
+      "file_type": "code",
+      "id": "callllmprovider_callllmprovider",
+      "label": "callLlmProvider()",
+      "norm_label": "callllmprovider()",
+      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 426,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
+      "label": "callLlmProvider.ts",
+      "norm_label": "callllmprovider.ts",
+      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 427,
+      "file_type": "code",
+      "id": "anthropic_callanthropic",
+      "label": "callAnthropic()",
+      "norm_label": "callanthropic()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 427,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
+      "label": "anthropic.ts",
+      "norm_label": "anthropic.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 428,
+      "file_type": "code",
+      "id": "openai_callopenai",
+      "label": "callOpenAi()",
+      "norm_label": "callopenai()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 428,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
+      "label": "openai.ts",
+      "norm_label": "openai.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 429,
+      "file_type": "code",
+      "id": "foundation_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 429,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
+      "label": "foundation.test.ts",
+      "norm_label": "foundation.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "approvalrequesthelpers_buildapprovalrequest",
+      "label": "buildApprovalRequest()",
+      "norm_label": "buildapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
+      "label": "approvalRequestHelpers.ts",
+      "norm_label": "approvalrequesthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "approvalrequests_test_createapprovalrequestmutationctx",
+      "label": "createApprovalRequestMutationCtx()",
+      "norm_label": "createapprovalrequestmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
+      "label": "approvalRequests.test.ts",
+      "norm_label": "approvalrequests.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "eventbuilders_buildoperationaleventmessage",
+      "label": "buildOperationalEventMessage()",
+      "norm_label": "buildoperationaleventmessage()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
+      "label": "eventBuilders.ts",
+      "norm_label": "eventbuilders.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 433,
+      "file_type": "code",
+      "id": "emailotp_formatvalidtime",
+      "label": "formatValidTime()",
+      "norm_label": "formatvalidtime()",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 433,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
+      "label": "EmailOTP.ts",
+      "norm_label": "emailotp.ts",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 434,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
+      "label": "quickAddCatalogItem.test.ts",
+      "norm_label": "quickaddcatalogitem.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 434,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_test_createquickaddctx",
+      "label": "createQuickAddCtx()",
+      "norm_label": "createquickaddctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 435,
+      "file_type": "code",
+      "id": "completetransaction_test_expectnocompletionsideeffects",
+      "label": "expectNoCompletionSideEffects()",
+      "norm_label": "expectnocompletionsideeffects()",
+      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 435,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
+      "label": "completeTransaction.test.ts",
+      "norm_label": "completetransaction.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 436,
+      "file_type": "code",
+      "id": "inventoryholdgateway_createinventoryholdgateway",
+      "label": "createInventoryHoldGateway()",
+      "norm_label": "createinventoryholdgateway()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 436,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
+      "label": "inventoryHoldGateway.ts",
+      "norm_label": "inventoryholdgateway.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "cashierrepository_getcashierforregisterstate",
+      "label": "getCashierForRegisterState()",
+      "norm_label": "getcashierforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
+      "label": "cashierRepository.ts",
+      "norm_label": "cashierrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 438,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
+      "label": "sessionRepository.test.ts",
+      "norm_label": "sessionrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 438,
+      "file_type": "code",
+      "id": "sessionrepository_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.test.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 439,
+      "file_type": "code",
+      "id": "catalog_buildservicecatalogitem",
+      "label": "buildServiceCatalogItem()",
+      "norm_label": "buildservicecatalogitem()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 439,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "label": "RegisterSessionView.tsx",
+      "norm_label": "registersessionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L248"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_builddepositsubmissionkey",
+      "label": "buildDepositSubmissionKey()",
+      "norm_label": "builddepositsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L616"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L159"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L152"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L168"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_handlerecorddeposit",
+      "label": "handleRecordDeposit()",
+      "norm_label": "handlerecorddeposit()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L258"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registersessionview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "modulewiring_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
+      "label": "moduleWiring.test.ts",
+      "norm_label": "modulewiring.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "access_test_createstockopsaccessqueryctx",
+      "label": "createStockOpsAccessQueryCtx()",
+      "norm_label": "createstockopsaccessqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
+      "label": "access.test.ts",
+      "norm_label": "access.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "access_requirestorefulladminaccess",
+      "label": "requireStoreFullAdminAccess()",
+      "norm_label": "requirestorefulladminaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_ts",
+      "label": "access.ts",
+      "norm_label": "access.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 443,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
+      "label": "purchaseOrders.test.ts",
+      "norm_label": "purchaseorders.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 443,
+      "file_type": "code",
+      "id": "purchaseorders_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 444,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
+      "label": "vendors.test.ts",
+      "norm_label": "vendors.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 444,
+      "file_type": "code",
+      "id": "vendors_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 445,
+      "file_type": "code",
+      "id": "auth_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 445,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 446,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_test_createqueryctx",
+      "label": "createQueryCtx()",
+      "norm_label": "createqueryctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 446,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
+      "label": "customerBehaviorTimeline.test.ts",
+      "norm_label": "customerbehaviortimeline.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 447,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 447,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
+      "label": "customerObservabilityTimeline.test.ts",
+      "norm_label": "customerobservabilitytimeline.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 448,
+      "file_type": "code",
+      "id": "helperorchestration_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 448,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
+      "label": "helperOrchestration.test.ts",
+      "norm_label": "helperorchestration.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 449,
+      "file_type": "code",
+      "id": "customerengagementevents_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 449,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
+      "label": "customerEngagementEvents.test.ts",
+      "norm_label": "customerengagementevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "onlineorderitem_updateonlineorderitem",
+      "label": "updateOnlineOrderItem()",
+      "norm_label": "updateonlineorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "reviews_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "rewards_formatpointslabel",
+      "label": "formatPointsLabel()",
+      "norm_label": "formatpointslabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 453,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 453,
+      "file_type": "code",
+      "id": "savedbag_listsavedbagitems",
+      "label": "listSavedBagItems()",
+      "norm_label": "listsavedbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 454,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
+      "label": "storefrontObservabilityReport.test.ts",
+      "norm_label": "storefrontobservabilityreport.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 454,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 455,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
+      "label": "syntheticMonitor.ts",
+      "norm_label": "syntheticmonitor.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 455,
+      "file_type": "code",
+      "id": "syntheticmonitor_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 456,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
+      "label": "timeQueryRefactors.test.ts",
+      "norm_label": "timequeryrefactors.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 456,
+      "file_type": "code",
+      "id": "timequeryrefactors_test_readsource",
+      "label": "readSource()",
+      "norm_label": "readsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 457,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 457,
+      "file_type": "code",
+      "id": "user_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 458,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 458,
+      "file_type": "code",
+      "id": "useroffers_determineoffereligibility",
+      "label": "determineOfferEligibility()",
+      "norm_label": "determineoffereligibility()",
+      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 459,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 459,
+      "file_type": "code",
+      "id": "possession_buildpossessiontraceseed",
+      "label": "buildPosSessionTraceSeed()",
+      "norm_label": "buildpossessiontraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L1"
+    },
+    {
       "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "label": "presentation.ts",
+      "norm_label": "presentation.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "presentation_buildworkflowtraceviewmodel",
+      "label": "buildWorkflowTraceViewModel()",
+      "norm_label": "buildworkflowtraceviewmodel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
+      "label": "schemaIndexes.test.ts",
+      "norm_label": "schemaindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "schemaindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -64057,7 +64138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -64066,7 +64147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -64075,7 +64156,7 @@
       "source_location": "L7"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -64084,7 +64165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -64093,7 +64174,7 @@
       "source_location": "L12"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -64102,7 +64183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -64111,7 +64192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -64120,7 +64201,7 @@
       "source_location": "L11"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -64129,7 +64210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -64138,7 +64219,7 @@
       "source_location": "L11"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -64147,7 +64228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -64156,7 +64237,7 @@
       "source_location": "L3"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -64165,7 +64246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -64174,7 +64255,7 @@
       "source_location": "L12"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -64183,48 +64264,12 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
       "norm_label": "storedropdown()",
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
-      "label": "StoresDropdown.tsx",
-      "norm_label": "storesdropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "storesdropdown_storesdropdown",
-      "label": "StoresDropdown()",
-      "norm_label": "storesdropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L42"
     },
     {
@@ -64329,6 +64374,42 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
+      "label": "StoresDropdown.tsx",
+      "norm_label": "storesdropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "storesdropdown_storesdropdown",
+      "label": "StoresDropdown()",
+      "norm_label": "storesdropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
       "norm_label": "handleprint()",
@@ -64336,7 +64417,7 @@
       "source_location": "L31"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -64345,7 +64426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -64354,7 +64435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -64363,7 +64444,7 @@
       "source_location": "L10"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -64372,7 +64453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -64381,7 +64462,7 @@
       "source_location": "L14"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -64390,7 +64471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -64399,7 +64480,7 @@
       "source_location": "L5"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -64408,7 +64489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -64417,7 +64498,7 @@
       "source_location": "L10"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -64426,7 +64507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -64435,7 +64516,7 @@
       "source_location": "L15"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -64444,7 +64525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -64453,7 +64534,7 @@
       "source_location": "L13"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -64462,48 +64543,12 @@
       "source_location": "L116"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
       "norm_label": "copyimagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "activitytimeline_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L151"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
-      "label": "ActivityTimeline.tsx",
-      "norm_label": "activitytimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1"
     },
     {
@@ -64599,6 +64644,42 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "activitytimeline_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L151"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
+      "label": "ActivityTimeline.tsx",
+      "norm_label": "activitytimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
       "norm_label": "analyticsitems()",
@@ -64606,7 +64687,7 @@
       "source_location": "L6"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -64615,7 +64696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -64624,7 +64705,7 @@
       "source_location": "L19"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -64633,7 +64714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -64642,7 +64723,7 @@
       "source_location": "L7"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -64651,7 +64732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -64660,7 +64741,7 @@
       "source_location": "L42"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -64669,7 +64750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -64678,7 +64759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -64687,7 +64768,7 @@
       "source_location": "L66"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -64696,7 +64777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -64705,7 +64786,7 @@
       "source_location": "L18"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -64714,7 +64795,7 @@
       "source_location": "L6"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -64723,7 +64804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -64732,49 +64813,13 @@
       "source_location": "L10"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
-      "label": "useLoadLogItems.ts",
-      "norm_label": "useloadlogitems.ts",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "useloadlogitems_useloadlogitems",
-      "label": "useLoadLogItems()",
-      "norm_label": "useloadlogitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L12"
     },
     {
       "community": 49,
@@ -64869,6 +64914,42 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
+      "label": "useLoadLogItems.ts",
+      "norm_label": "useloadlogitems.ts",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "useloadlogitems_useloadlogitems",
+      "label": "useLoadLogItems()",
+      "norm_label": "useloadlogitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
       "norm_label": "auth()",
@@ -64876,7 +64957,7 @@
       "source_location": "L3"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -64885,7 +64966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -64894,7 +64975,7 @@
       "source_location": "L5"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -64903,7 +64984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -64912,7 +64993,7 @@
       "source_location": "L49"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -64921,7 +65002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -64930,7 +65011,7 @@
       "source_location": "L23"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -64939,7 +65020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -64948,7 +65029,7 @@
       "source_location": "L50"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -64957,7 +65038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -64966,7 +65047,7 @@
       "source_location": "L13"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -64975,7 +65056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -64984,7 +65065,7 @@
       "source_location": "L11"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -64993,7 +65074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -65002,48 +65083,12 @@
       "source_location": "L31"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
       "norm_label": "expensecompletion.tsx",
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "expenseview_expenseview",
-      "label": "ExpenseView()",
-      "norm_label": "expenseview()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
-      "label": "ExpenseView.tsx",
-      "norm_label": "expenseview.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "bestsellersdialog_handleaddbestseller",
-      "label": "handleAddBestSeller()",
-      "norm_label": "handleaddbestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "label": "BestSellersDialog.tsx",
-      "norm_label": "bestsellersdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L1"
     },
     {
@@ -65391,6 +65436,42 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "expenseview_expenseview",
+      "label": "ExpenseView()",
+      "norm_label": "expenseview()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
+      "label": "ExpenseView.tsx",
+      "norm_label": "expenseview.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "bestsellersdialog_handleaddbestseller",
+      "label": "handleAddBestSeller()",
+      "norm_label": "handleaddbestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
+      "label": "BestSellersDialog.tsx",
+      "norm_label": "bestsellersdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
       "norm_label": "handleaddfeatureditem()",
@@ -65398,7 +65479,7 @@
       "source_location": "L37"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -65407,7 +65488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -65416,7 +65497,7 @@
       "source_location": "L25"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -65425,7 +65506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -65434,7 +65515,7 @@
       "source_location": "L83"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -65443,7 +65524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -65452,7 +65533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -65461,7 +65542,7 @@
       "source_location": "L35"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -65470,7 +65551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -65479,7 +65560,7 @@
       "source_location": "L28"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -65488,7 +65569,7 @@
       "source_location": "L12"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -65497,7 +65578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -65506,7 +65587,7 @@
       "source_location": "L13"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -65515,7 +65596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -65524,48 +65605,12 @@
       "source_location": "L43"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
       "norm_label": "emailstatusview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
     },
     {
@@ -65661,6 +65706,42 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
       "norm_label": "refundsview.tsx",
@@ -65668,7 +65749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -65677,7 +65758,7 @@
       "source_location": "L81"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -65686,7 +65767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -65695,7 +65776,7 @@
       "source_location": "L6"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -65704,7 +65785,7 @@
       "source_location": "L34"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -65713,7 +65794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -65722,7 +65803,7 @@
       "source_location": "L89"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -65731,7 +65812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -65740,7 +65821,7 @@
       "source_location": "L215"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -65749,7 +65830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -65758,7 +65839,7 @@
       "source_location": "L5"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -65767,7 +65848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -65776,7 +65857,7 @@
       "source_location": "L7"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -65785,7 +65866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -65794,49 +65875,13 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
       "norm_label": "pininput()",
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
     },
     {
       "community": 52,
@@ -65931,6 +65976,42 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
       "norm_label": "productcard.tsx",
@@ -65938,7 +66019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -65947,7 +66028,7 @@
       "source_location": "L14"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -65956,7 +66037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -65965,7 +66046,7 @@
       "source_location": "L15"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -65974,7 +66055,7 @@
       "source_location": "L18"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -65983,7 +66064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -65992,7 +66073,7 @@
       "source_location": "L9"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -66001,7 +66082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -66010,7 +66091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -66019,7 +66100,7 @@
       "source_location": "L28"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -66028,7 +66109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -66037,7 +66118,7 @@
       "source_location": "L9"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -66046,7 +66127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -66055,7 +66136,7 @@
       "source_location": "L9"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -66064,49 +66145,13 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
       "norm_label": "rendertransactioncell()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
       "source_location": "L31"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "barcodeview_barcodeview",
-      "label": "BarcodeView()",
-      "norm_label": "barcodeview()",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "label": "BarcodeView.tsx",
-      "norm_label": "barcodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 53,
@@ -66201,6 +66246,42 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "barcodeview_barcodeview",
+      "label": "BarcodeView()",
+      "norm_label": "barcodeview()",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
+      "label": "BarcodeView.tsx",
+      "norm_label": "barcodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
       "norm_label": "categorizationview()",
@@ -66208,7 +66289,7 @@
       "source_location": "L6"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -66217,7 +66298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -66226,7 +66307,7 @@
       "source_location": "L37"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -66235,7 +66316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -66244,7 +66325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -66253,7 +66334,7 @@
       "source_location": "L11"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -66262,7 +66343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -66271,7 +66352,7 @@
       "source_location": "L10"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -66280,7 +66361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -66289,7 +66370,7 @@
       "source_location": "L6"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -66298,7 +66379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -66307,7 +66388,7 @@
       "source_location": "L5"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -66316,7 +66397,7 @@
       "source_location": "L17"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -66325,7 +66406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -66334,49 +66415,13 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
       "norm_label": "products()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
-      "label": "PromoCodeForm.tsx",
-      "norm_label": "promocodeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "promocodeform_togglediscounttype",
-      "label": "toggleDiscountType()",
-      "norm_label": "togglediscounttype()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L84"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L23"
     },
     {
       "community": 54,
@@ -66471,6 +66516,42 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
+      "label": "PromoCodeForm.tsx",
+      "norm_label": "promocodeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "promocodeform_togglediscounttype",
+      "label": "toggleDiscountType()",
+      "norm_label": "togglediscounttype()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
       "norm_label": "promocodepreview.tsx",
@@ -66478,7 +66559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -66487,7 +66568,7 @@
       "source_location": "L37"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -66496,7 +66577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -66505,7 +66586,7 @@
       "source_location": "L9"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -66514,7 +66595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -66523,7 +66604,7 @@
       "source_location": "L23"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -66532,7 +66613,7 @@
       "source_location": "L5"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -66541,7 +66622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -66550,7 +66631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -66559,7 +66640,7 @@
       "source_location": "L4"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -66568,7 +66649,7 @@
       "source_location": "L13"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -66577,7 +66658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -66586,7 +66667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -66595,7 +66676,7 @@
       "source_location": "L29"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -66604,49 +66685,13 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
       "norm_label": "reviewactions()",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
-      "label": "ServiceCasesView.test.tsx",
-      "norm_label": "servicecasesview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "servicecasesview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
-      "label": "ServiceCatalogView.test.tsx",
-      "norm_label": "servicecatalogview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "servicecatalogview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L30"
     },
     {
       "community": 55,
@@ -66741,6 +66786,42 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
+      "label": "ServiceCasesView.test.tsx",
+      "norm_label": "servicecasesview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "servicecasesview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "label": "ServiceCatalogView.test.tsx",
+      "norm_label": "servicecatalogview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "servicecatalogview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
       "norm_label": "serviceintakeform.tsx",
@@ -66748,7 +66829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -66757,7 +66838,7 @@
       "source_location": "L59"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -66766,7 +66847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -66775,7 +66856,7 @@
       "source_location": "L45"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -66784,7 +66865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -66793,7 +66874,7 @@
       "source_location": "L47"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -66802,7 +66883,7 @@
       "source_location": "L29"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -66811,7 +66892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -66820,7 +66901,7 @@
       "source_location": "L3"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -66829,7 +66910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -66838,7 +66919,7 @@
       "source_location": "L4"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -66847,7 +66928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -66856,7 +66937,7 @@
       "source_location": "L4"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -66865,7 +66946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -66874,49 +66955,13 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
       "norm_label": "protectedadminsigninview()",
       "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "contactview_contactview",
-      "label": "ContactView()",
-      "norm_label": "contactview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "label": "ContactView.tsx",
-      "norm_label": "contactview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -67011,6 +67056,42 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "contactview_contactview",
+      "label": "ContactView()",
+      "norm_label": "contactview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
+      "label": "ContactView.tsx",
+      "norm_label": "contactview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
       "norm_label": "maintenanceview()",
@@ -67018,7 +67099,7 @@
       "source_location": "L11"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -67027,7 +67108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -67036,7 +67117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -67045,7 +67126,7 @@
       "source_location": "L25"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -67054,7 +67135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -67063,7 +67144,7 @@
       "source_location": "L21"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -67072,7 +67153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -67081,7 +67162,7 @@
       "source_location": "L63"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -67090,7 +67171,7 @@
       "source_location": "L7"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -67099,7 +67180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -67108,7 +67189,7 @@
       "source_location": "L25"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -67117,7 +67198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -67126,7 +67207,7 @@
       "source_location": "L15"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -67135,7 +67216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -67144,48 +67225,12 @@
       "source_location": "L21"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
       "norm_label": "copy-wrapper.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "label_label",
-      "label": "Label()",
-      "norm_label": "label()",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -67281,6 +67326,42 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "label_label",
+      "label": "Label()",
+      "norm_label": "label()",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
@@ -67288,7 +67369,7 @@
       "source_location": "L49"
     },
     {
-      "community": 570,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -67297,7 +67378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -67306,7 +67387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -67315,7 +67396,7 @@
       "source_location": "L63"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -67324,7 +67405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -67333,7 +67414,7 @@
       "source_location": "L5"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -67342,7 +67423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -67351,7 +67432,7 @@
       "source_location": "L12"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -67360,7 +67441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -67369,7 +67450,7 @@
       "source_location": "L15"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -67378,7 +67459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -67387,7 +67468,7 @@
       "source_location": "L3"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -67396,7 +67477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -67405,7 +67486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -67414,48 +67495,12 @@
       "source_location": "L5"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
       "norm_label": "bagitems.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "bagitemsview_bagitemsview",
-      "label": "BagItemsView()",
-      "norm_label": "bagitemsview()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "label": "BagItemsView.tsx",
-      "norm_label": "bagitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1"
     },
     {
@@ -67542,6 +67587,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "bagitemsview_bagitemsview",
+      "label": "BagItemsView()",
+      "norm_label": "bagitemsview()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
+      "label": "BagItemsView.tsx",
+      "norm_label": "bagitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
       "norm_label": "string()",
@@ -67549,7 +67630,7 @@
       "source_location": "L102"
     },
     {
-      "community": 580,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -67558,7 +67639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -67567,7 +67648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -67576,7 +67657,7 @@
       "source_location": "L13"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -67585,7 +67666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -67594,7 +67675,7 @@
       "source_location": "L7"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -67603,7 +67684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -67612,7 +67693,7 @@
       "source_location": "L11"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -67621,7 +67702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -67630,7 +67711,7 @@
       "source_location": "L7"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -67639,7 +67720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -67648,7 +67729,7 @@
       "source_location": "L45"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -67657,7 +67738,7 @@
       "source_location": "L13"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -67666,7 +67747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -67675,49 +67756,13 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
       "norm_label": "useimageupload()",
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "label": "use-mobile.tsx",
-      "norm_label": "use-mobile.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "use_mobile_useismobile",
-      "label": "useIsMobile()",
-      "norm_label": "useismobile()",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L5"
     },
     {
       "community": 59,
@@ -67803,6 +67848,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
+      "label": "use-mobile.tsx",
+      "norm_label": "use-mobile.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "use_mobile_useismobile",
+      "label": "useIsMobile()",
+      "norm_label": "useismobile()",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
       "norm_label": "use-navigation-keyboard-shortcuts.ts",
@@ -67810,7 +67891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 592,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -67819,7 +67900,7 @@
       "source_location": "L7"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -67828,7 +67909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -67837,7 +67918,7 @@
       "source_location": "L9"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -67846,7 +67927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -67855,7 +67936,7 @@
       "source_location": "L6"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -67864,7 +67945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -67873,7 +67954,7 @@
       "source_location": "L168"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -67882,7 +67963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -67891,7 +67972,7 @@
       "source_location": "L5"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -67900,7 +67981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -67909,7 +67990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -67918,7 +67999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -67927,7 +68008,7 @@
       "source_location": "L6"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -67936,49 +68017,13 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
       "norm_label": "usedebounce()",
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 6,
@@ -68298,6 +68343,42 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
       "norm_label": "usegetautheduser.ts",
@@ -68305,7 +68386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 602,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -68314,7 +68395,7 @@
       "source_location": "L4"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -68323,7 +68404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -68332,7 +68413,7 @@
       "source_location": "L5"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -68341,7 +68422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -68350,7 +68431,7 @@
       "source_location": "L5"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -68359,7 +68440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -68368,7 +68449,7 @@
       "source_location": "L4"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -68377,7 +68458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -68386,7 +68467,7 @@
       "source_location": "L5"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -68395,7 +68476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -68404,7 +68485,7 @@
       "source_location": "L5"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -68413,7 +68494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -68422,7 +68503,7 @@
       "source_location": "L8"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -68431,49 +68512,13 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
       "norm_label": "usepermissions()",
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L13"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprint_ts",
-      "label": "usePrint.ts",
-      "norm_label": "useprint.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "useprint_useprint",
-      "label": "usePrint()",
-      "norm_label": "useprint()",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L27"
     },
     {
       "community": 61,
@@ -68559,6 +68604,42 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprint_ts",
+      "label": "usePrint.ts",
+      "norm_label": "useprint.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "useprint_useprint",
+      "label": "usePrint()",
+      "norm_label": "useprint()",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
       "norm_label": "useproductwithnoimagesnotification.tsx",
@@ -68566,7 +68647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 612,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -68575,7 +68656,7 @@
       "source_location": "L7"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -68584,7 +68665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -68593,7 +68674,7 @@
       "source_location": "L5"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -68602,7 +68683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -68611,7 +68692,7 @@
       "source_location": "L12"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -68620,7 +68701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -68629,7 +68710,7 @@
       "source_location": "L12"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -68638,7 +68719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -68647,7 +68728,7 @@
       "source_location": "L5"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -68656,7 +68737,7 @@
       "source_location": "L44"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -68665,7 +68746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -68674,7 +68755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -68683,7 +68764,7 @@
       "source_location": "L6"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -68692,49 +68773,13 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
       "norm_label": "presentunexpectederrortoast()",
       "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "navigationutils_getorigin",
-      "label": "getOrigin()",
-      "norm_label": "getorigin()",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
-      "label": "navigationUtils.ts",
-      "norm_label": "navigationutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "additem_additem",
-      "label": "addItem()",
-      "norm_label": "additem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
-      "label": "addItem.ts",
-      "norm_label": "additem.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L1"
     },
     {
       "community": 62,
@@ -68820,6 +68865,42 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "navigationutils_getorigin",
+      "label": "getOrigin()",
+      "norm_label": "getorigin()",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
+      "label": "navigationUtils.ts",
+      "norm_label": "navigationutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "additem_additem",
+      "label": "addItem()",
+      "norm_label": "additem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
+      "label": "addItem.ts",
+      "norm_label": "additem.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
       "norm_label": "bootstrapregister()",
@@ -68827,7 +68908,7 @@
       "source_location": "L6"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -68836,7 +68917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -68845,7 +68926,7 @@
       "source_location": "L5"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -68854,7 +68935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -68863,7 +68944,7 @@
       "source_location": "L5"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -68872,7 +68953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -68881,7 +68962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -68890,7 +68971,7 @@
       "source_location": "L5"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -68899,7 +68980,7 @@
       "source_location": "L10"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -68908,7 +68989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -68917,7 +68998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "useregisterviewmodel_test_deferred",
       "label": "deferred()",
@@ -68926,7 +69007,7 @@
       "source_location": "L165"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -68935,7 +69016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -68944,7 +69025,7 @@
       "source_location": "L12"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -68953,49 +69034,13 @@
       "source_location": "L9"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
       "norm_label": "closeouts.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/closeouts.index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "index_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
-      "label": "$sessionId.tsx",
-      "norm_label": "$sessionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "sessionid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
-      "source_location": "L6"
     },
     {
       "community": 63,
@@ -69081,6 +69126,42 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "index_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
+      "label": "$sessionId.tsx",
+      "norm_label": "$sessionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "sessionid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
       "norm_label": "storerootredirect()",
@@ -69088,7 +69169,7 @@
       "source_location": "L13"
     },
     {
-      "community": 630,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -69097,7 +69178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -69106,7 +69187,7 @@
       "source_location": "L6"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -69115,7 +69196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -69124,7 +69205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -69133,7 +69214,7 @@
       "source_location": "L9"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -69142,7 +69223,7 @@
       "source_location": "L13"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -69151,7 +69232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -69160,7 +69241,7 @@
       "source_location": "L4"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -69169,7 +69250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -69178,7 +69259,7 @@
       "source_location": "L13"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -69187,7 +69268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -69196,7 +69277,7 @@
       "source_location": "L5"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -69205,7 +69286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -69214,48 +69295,12 @@
       "source_location": "L17"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
       "norm_label": "controls.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "dialog_stories_dialogshowcase",
-      "label": "DialogShowcase()",
-      "norm_label": "dialogshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
-      "label": "Dialog.stories.tsx",
-      "norm_label": "dialog.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "feedback_stories_feedbackshowcase",
-      "label": "FeedbackShowcase()",
-      "norm_label": "feedbackshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
-      "label": "Feedback.stories.tsx",
-      "norm_label": "feedback.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -69342,6 +69387,42 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "dialog_stories_dialogshowcase",
+      "label": "DialogShowcase()",
+      "norm_label": "dialogshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
+      "label": "Dialog.stories.tsx",
+      "norm_label": "dialog.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "feedback_stories_feedbackshowcase",
+      "label": "FeedbackShowcase()",
+      "norm_label": "feedbackshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
+      "label": "Feedback.stories.tsx",
+      "norm_label": "feedback.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
       "norm_label": "primitivesoverview()",
@@ -69349,7 +69430,7 @@
       "source_location": "L5"
     },
     {
-      "community": 640,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -69358,7 +69439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -69367,7 +69448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -69376,7 +69457,7 @@
       "source_location": "L13"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -69385,7 +69466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -69394,7 +69475,7 @@
       "source_location": "L14"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -69403,7 +69484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -69412,7 +69493,7 @@
       "source_location": "L13"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -69421,7 +69502,7 @@
       "source_location": "L5"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -69430,7 +69511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -69439,7 +69520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -69448,7 +69529,7 @@
       "source_location": "L17"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -69457,7 +69538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -69466,7 +69547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -69475,48 +69556,12 @@
       "source_location": "L4"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "checkoutsession_test_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
-      "label": "checkoutSession.test.ts",
-      "norm_label": "checkoutsession.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "guest_updateguest",
-      "label": "updateGuest()",
-      "norm_label": "updateguest()",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1"
     },
     {
@@ -69594,6 +69639,42 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "checkoutsession_test_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
+      "label": "checkoutSession.test.ts",
+      "norm_label": "checkoutsession.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "guest_updateguest",
+      "label": "updateGuest()",
+      "norm_label": "updateguest()",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
@@ -69601,7 +69682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 652,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -69610,7 +69691,7 @@
       "source_location": "L5"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -69619,7 +69700,7 @@
       "source_location": "L10"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -69628,7 +69709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -69637,7 +69718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -69646,7 +69727,7 @@
       "source_location": "L10"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -69655,7 +69736,7 @@
       "source_location": "L4"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -69664,7 +69745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -69673,7 +69754,7 @@
       "source_location": "L39"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -69682,7 +69763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -69691,7 +69772,7 @@
       "source_location": "L18"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -69700,7 +69781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -69709,7 +69790,7 @@
       "source_location": "L71"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -69718,7 +69799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -69727,49 +69808,13 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
       "norm_label": "iswithinrestrictiontime()",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
-      "label": "EnteredBillingAddressDetails.tsx",
-      "norm_label": "enteredbillingaddressdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "ordersummary_ordersummary",
-      "label": "OrderSummary()",
-      "norm_label": "ordersummary()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
-      "source_location": "L1"
     },
     {
       "community": 66,
@@ -69846,6 +69891,42 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
+      "label": "EnteredBillingAddressDetails.tsx",
+      "norm_label": "enteredbillingaddressdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "ordersummary_ordersummary",
+      "label": "OrderSummary()",
+      "norm_label": "ordersummary()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
       "norm_label": "pickupdetails()",
@@ -69853,7 +69934,7 @@
       "source_location": "L10"
     },
     {
-      "community": 660,
+      "community": 662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -69862,7 +69943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -69871,7 +69952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -69880,7 +69961,7 @@
       "source_location": "L8"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -69889,7 +69970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -69898,7 +69979,7 @@
       "source_location": "L27"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -69907,7 +69988,7 @@
       "source_location": "L40"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -69916,7 +69997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -69925,7 +70006,7 @@
       "source_location": "L3"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -69934,7 +70015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -69943,7 +70024,7 @@
       "source_location": "L8"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -69952,7 +70033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -69961,7 +70042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -69970,7 +70051,7 @@
       "source_location": "L12"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -69979,48 +70060,12 @@
       "source_location": "L77"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
       "norm_label": "customerdetailsform.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "deliverydetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "label": "DeliveryDetailsForm.tsx",
-      "norm_label": "deliverydetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "hooks_usecountdown",
-      "label": "useCountdown()",
-      "norm_label": "usecountdown()",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -70098,6 +70143,42 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "deliverydetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
+      "label": "DeliveryDetailsForm.tsx",
+      "norm_label": "deliverydetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "hooks_usecountdown",
+      "label": "useCountdown()",
+      "norm_label": "usecountdown()",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
       "norm_label": "trustsignals.tsx",
@@ -70105,7 +70186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 672,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -70114,7 +70195,7 @@
       "source_location": "L4"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -70123,7 +70204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -70132,7 +70213,7 @@
       "source_location": "L14"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -70141,7 +70222,7 @@
       "source_location": "L27"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -70150,7 +70231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -70159,7 +70240,7 @@
       "source_location": "L17"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -70168,7 +70249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -70177,7 +70258,7 @@
       "source_location": "L13"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -70186,7 +70267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -70195,7 +70276,7 @@
       "source_location": "L47"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -70204,7 +70285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -70213,7 +70294,7 @@
       "source_location": "L7"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -70222,7 +70303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -70231,49 +70312,13 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
       "norm_label": "sitebanner()",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "dimensionbar_mapvaluetolabelindex",
-      "label": "mapValueToLabelIndex()",
-      "norm_label": "mapvaluetolabelindex()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "label": "DimensionBar.tsx",
-      "norm_label": "dimensionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L1"
     },
     {
       "community": 68,
@@ -70350,6 +70395,42 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "dimensionbar_mapvaluetolabelindex",
+      "label": "mapValueToLabelIndex()",
+      "norm_label": "mapvaluetolabelindex()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
+      "label": "DimensionBar.tsx",
+      "norm_label": "dimensionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
       "norm_label": "discountbadge()",
@@ -70357,7 +70438,7 @@
       "source_location": "L7"
     },
     {
-      "community": 680,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -70366,7 +70447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -70375,7 +70456,7 @@
       "source_location": "L45"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -70384,7 +70465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -70393,7 +70474,7 @@
       "source_location": "L5"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -70402,7 +70483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -70411,7 +70492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -70420,7 +70501,7 @@
       "source_location": "L17"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -70429,7 +70510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -70438,7 +70519,7 @@
       "source_location": "L3"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -70447,7 +70528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -70456,7 +70537,7 @@
       "source_location": "L37"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -70465,7 +70546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -70474,7 +70555,7 @@
       "source_location": "L79"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -70483,49 +70564,13 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
       "norm_label": "handlehelpful()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "label": "ReviewSummary.tsx",
-      "norm_label": "reviewsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "reviewsummary_reviewsummary",
-      "label": "ReviewSummary()",
-      "norm_label": "reviewsummary()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 69,
@@ -70602,6 +70647,42 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
+      "label": "ReviewSummary.tsx",
+      "norm_label": "reviewsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "reviewsummary_reviewsummary",
+      "label": "ReviewSummary()",
+      "norm_label": "reviewsummary()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
       "norm_label": "ratingselector.tsx",
@@ -70609,7 +70690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 690,
+      "community": 692,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -70618,7 +70699,7 @@
       "source_location": "L18"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -70627,7 +70708,7 @@
       "source_location": "L10"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -70636,7 +70717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -70645,7 +70726,7 @@
       "source_location": "L11"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -70654,7 +70735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -70663,7 +70744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -70672,7 +70753,7 @@
       "source_location": "L59"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -70681,7 +70762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -70690,7 +70771,7 @@
       "source_location": "L33"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -70699,7 +70780,7 @@
       "source_location": "L19"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -70708,7 +70789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -70717,7 +70798,7 @@
       "source_location": "L4"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -70726,7 +70807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -70735,48 +70816,12 @@
       "source_location": "L22"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
       "norm_label": "errorboundary.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
-      "label": "ScrollDownButton.tsx",
-      "norm_label": "scrolldownbutton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "scrolldownbutton_scrolldownbutton",
-      "label": "ScrollDownButton()",
-      "norm_label": "scrolldownbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "country_select_countryselect",
-      "label": "CountrySelect()",
-      "norm_label": "countryselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
-      "label": "country-select.tsx",
-      "norm_label": "country-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L1"
     },
     {
@@ -71020,7 +71065,7 @@
       "label": "buildItem()",
       "norm_label": "builditem()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1499"
+      "source_location": "L2348"
     },
     {
       "community": 70,
@@ -71029,7 +71074,7 @@
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1493"
+      "source_location": "L2342"
     },
     {
       "community": 70,
@@ -71038,7 +71083,7 @@
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1489"
+      "source_location": "L2338"
     },
     {
       "community": 70,
@@ -71047,7 +71092,7 @@
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1509"
+      "source_location": "L2358"
     },
     {
       "community": 70,
@@ -71056,7 +71101,7 @@
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1278"
+      "source_location": "L2104"
     },
     {
       "community": 70,
@@ -71065,7 +71110,7 @@
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1355"
+      "source_location": "L2194"
     },
     {
       "community": 70,
@@ -71074,10 +71119,46 @@
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1260"
+      "source_location": "L2086"
     },
     {
       "community": 700,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
+      "label": "ScrollDownButton.tsx",
+      "norm_label": "scrolldownbutton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "scrolldownbutton_scrolldownbutton",
+      "label": "ScrollDownButton()",
+      "norm_label": "scrolldownbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "country_select_countryselect",
+      "label": "CountrySelect()",
+      "norm_label": "countryselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
+      "label": "country-select.tsx",
+      "norm_label": "country-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -71086,7 +71167,7 @@
       "source_location": "L3"
     },
     {
-      "community": 700,
+      "community": 702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -71095,7 +71176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -71104,7 +71185,7 @@
       "source_location": "L9"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -71113,7 +71194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -71122,7 +71203,7 @@
       "source_location": "L66"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -71131,7 +71212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -71140,7 +71221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -71149,7 +71230,7 @@
       "source_location": "L19"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -71158,7 +71239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -71167,7 +71248,7 @@
       "source_location": "L13"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -71176,7 +71257,7 @@
       "source_location": "L46"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -71185,7 +71266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -71194,7 +71275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -71203,7 +71284,7 @@
       "source_location": "L46"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -71212,49 +71293,13 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "formsubmissionprovider_useformsubmission",
-      "label": "useFormSubmission()",
-      "norm_label": "useformsubmission()",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
-      "label": "FormSubmissionProvider.tsx",
-      "norm_label": "formsubmissionprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
-      "label": "useCheckout.ts",
-      "norm_label": "usecheckout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "usecheckout_usecheckout",
-      "label": "useCheckout()",
-      "norm_label": "usecheckout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L5"
     },
     {
       "community": 71,
@@ -71331,6 +71376,42 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "formsubmissionprovider_useformsubmission",
+      "label": "useFormSubmission()",
+      "norm_label": "useformsubmission()",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
+      "label": "FormSubmissionProvider.tsx",
+      "norm_label": "formsubmissionprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
+      "label": "useCheckout.ts",
+      "norm_label": "usecheckout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "usecheckout_usecheckout",
+      "label": "useCheckout()",
+      "norm_label": "usecheckout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
       "norm_label": "usediscountcodealert.tsx",
@@ -71338,7 +71419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 712,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -71347,7 +71428,7 @@
       "source_location": "L14"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -71356,7 +71437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -71365,7 +71446,7 @@
       "source_location": "L29"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -71374,7 +71455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -71383,7 +71464,7 @@
       "source_location": "L5"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -71392,7 +71473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -71401,7 +71482,7 @@
       "source_location": "L5"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -71410,7 +71491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -71419,7 +71500,7 @@
       "source_location": "L3"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -71428,7 +71509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -71437,7 +71518,7 @@
       "source_location": "L4"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -71446,7 +71527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -71455,7 +71536,7 @@
       "source_location": "L4"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -71464,49 +71545,13 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
       "norm_label": "useinventorystatus()",
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
-      "label": "useLeaveAReviewModal.tsx",
-      "norm_label": "useleaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "label": "useLeaveAReviewModal()",
-      "norm_label": "useleaveareviewmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
-      "label": "useLogout.ts",
-      "norm_label": "uselogout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "uselogout_uselogout",
-      "label": "useLogout()",
-      "norm_label": "uselogout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L5"
     },
     {
       "community": 72,
@@ -71583,6 +71628,42 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
+      "label": "useLeaveAReviewModal.tsx",
+      "norm_label": "useleaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "useleaveareviewmodal_useleaveareviewmodal",
+      "label": "useLeaveAReviewModal()",
+      "norm_label": "useleaveareviewmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
+      "label": "useLogout.ts",
+      "norm_label": "uselogout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "uselogout_uselogout",
+      "label": "useLogout()",
+      "norm_label": "uselogout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
       "norm_label": "usemodalstate.tsx",
@@ -71590,7 +71671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 720,
+      "community": 722,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -71599,7 +71680,7 @@
       "source_location": "L15"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -71608,7 +71689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -71617,7 +71698,7 @@
       "source_location": "L18"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -71626,7 +71707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -71635,7 +71716,7 @@
       "source_location": "L9"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -71644,7 +71725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -71653,7 +71734,7 @@
       "source_location": "L16"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -71662,7 +71743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -71671,7 +71752,7 @@
       "source_location": "L4"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -71680,7 +71761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -71689,7 +71770,7 @@
       "source_location": "L11"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -71698,7 +71779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -71707,7 +71788,7 @@
       "source_location": "L3"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -71716,49 +71797,13 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
       "norm_label": "usetrackaction()",
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
-      "label": "useTrackEvent.ts",
-      "norm_label": "usetrackevent.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "usetrackevent_usetrackevent",
-      "label": "useTrackEvent()",
-      "norm_label": "usetrackevent()",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
-      "label": "useUpsellModal.tsx",
-      "norm_label": "useupsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "useupsellmodal_useupsellmodal",
-      "label": "useUpsellModal()",
-      "norm_label": "useupsellmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L14"
     },
     {
       "community": 73,
@@ -71835,6 +71880,42 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
+      "label": "useTrackEvent.ts",
+      "norm_label": "usetrackevent.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "usetrackevent_usetrackevent",
+      "label": "useTrackEvent()",
+      "norm_label": "usetrackevent()",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
+      "label": "useUpsellModal.tsx",
+      "norm_label": "useupsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "useupsellmodal_useupsellmodal",
+      "label": "useUpsellModal()",
+      "norm_label": "useupsellmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
       "norm_label": "usepostanalytics()",
@@ -71842,7 +71923,7 @@
       "source_location": "L4"
     },
     {
-      "community": 730,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -71851,7 +71932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -71860,7 +71941,7 @@
       "source_location": "L7"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -71869,7 +71950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -71878,7 +71959,7 @@
       "source_location": "L6"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71887,7 +71968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -71896,7 +71977,7 @@
       "source_location": "L10"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -71905,7 +71986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -71914,7 +71995,7 @@
       "source_location": "L6"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -71923,7 +72004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -71932,7 +72013,7 @@
       "source_location": "L5"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -71941,7 +72022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -71950,7 +72031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -71959,7 +72040,7 @@
       "source_location": "L5"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -71968,49 +72049,13 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
       "norm_label": "useproductqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "promocode_usepromocodesqueries",
-      "label": "usePromoCodesQueries()",
-      "norm_label": "usepromocodesqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "reviews_usereviewqueries",
-      "label": "useReviewQueries()",
-      "norm_label": "usereviewqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L10"
     },
     {
       "community": 74,
@@ -72087,6 +72132,42 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "promocode_usepromocodesqueries",
+      "label": "usePromoCodesQueries()",
+      "norm_label": "usepromocodesqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "reviews_usereviewqueries",
+      "label": "useReviewQueries()",
+      "norm_label": "usereviewqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -72094,7 +72175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 742,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -72103,7 +72184,7 @@
       "source_location": "L11"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -72112,7 +72193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -72121,7 +72202,7 @@
       "source_location": "L6"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -72130,7 +72211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -72139,7 +72220,7 @@
       "source_location": "L5"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -72148,7 +72229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -72157,7 +72238,7 @@
       "source_location": "L6"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -72166,7 +72247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -72175,7 +72256,7 @@
       "source_location": "L10"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -72184,7 +72265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -72193,7 +72274,7 @@
       "source_location": "L15"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -72202,7 +72283,7 @@
       "source_location": "L14"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -72211,7 +72292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -72220,49 +72301,13 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
       "norm_label": "createrouter()",
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "homepageloader_loadhomepagedata",
-      "label": "loadHomePageData()",
-      "norm_label": "loadhomepagedata()",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
-      "label": "-homePageLoader.ts",
-      "norm_label": "-homepageloader.ts",
-      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "orderslayout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
-      "label": "_ordersLayout.tsx",
-      "norm_label": "_orderslayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L1"
     },
     {
       "community": 75,
@@ -72339,6 +72384,42 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "homepageloader_loadhomepagedata",
+      "label": "loadHomePageData()",
+      "norm_label": "loadhomepagedata()",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
+      "label": "-homePageLoader.ts",
+      "norm_label": "-homepageloader.ts",
+      "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "orderslayout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
+      "label": "_ordersLayout.tsx",
+      "norm_label": "_orderslayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
       "norm_label": "contactus()",
@@ -72346,7 +72427,7 @@
       "source_location": "L14"
     },
     {
-      "community": 750,
+      "community": 752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -72355,7 +72436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -72364,7 +72445,7 @@
       "source_location": "L13"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -72373,7 +72454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -72382,7 +72463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -72391,7 +72472,7 @@
       "source_location": "L9"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -72400,7 +72481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -72409,7 +72490,7 @@
       "source_location": "L15"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -72418,7 +72499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -72427,7 +72508,7 @@
       "source_location": "L16"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -72436,7 +72517,7 @@
       "source_location": "L6"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -72445,7 +72526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -72454,7 +72535,7 @@
       "source_location": "L10"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -72463,7 +72544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -72472,49 +72553,13 @@
       "source_location": "L21"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
       "norm_label": "canceled.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "complete_index_checkoutcomplete",
-      "label": "CheckoutComplete()",
-      "norm_label": "checkoutcomplete()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
-      "label": "complete.index.tsx",
-      "norm_label": "complete.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
-      "label": "pod-confirmation.tsx",
-      "norm_label": "pod-confirmation.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "pod_confirmation_completepodcheckoutsession",
-      "label": "completePODCheckoutSession()",
-      "norm_label": "completepodcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
-      "source_location": "L193"
     },
     {
       "community": 76,
@@ -72591,6 +72636,42 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "complete_index_checkoutcomplete",
+      "label": "CheckoutComplete()",
+      "norm_label": "checkoutcomplete()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
+      "label": "complete.index.tsx",
+      "norm_label": "complete.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
+      "label": "pod-confirmation.tsx",
+      "norm_label": "pod-confirmation.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "pod_confirmation_completepodcheckoutsession",
+      "label": "completePODCheckoutSession()",
+      "norm_label": "completepodcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
+      "source_location": "L193"
+    },
+    {
+      "community": 762,
+      "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
       "norm_label": "test-connection.js",
@@ -72598,7 +72679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 762,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -72607,7 +72688,7 @@
       "source_location": "L7"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -72616,7 +72697,7 @@
       "source_location": "L10"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -72625,7 +72706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -72634,7 +72715,7 @@
       "source_location": "L32"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -72643,7 +72724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -72652,7 +72733,7 @@
       "source_location": "L211"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -72661,7 +72742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -72670,7 +72751,7 @@
       "source_location": "L85"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -72679,7 +72760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -72688,7 +72769,7 @@
       "source_location": "L15"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -72697,7 +72778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -72706,30 +72787,12 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
       "norm_label": "api.js",
       "source_file": "packages/athena-webapp/convex/_generated/api.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
-      "label": "dataModel.d.ts",
-      "norm_label": "datamodel.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_server_d_ts",
-      "label": "server.d.ts",
-      "norm_label": "server.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
       "source_location": "L1"
     },
     {
@@ -72807,6 +72870,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
+      "label": "dataModel.d.ts",
+      "norm_label": "datamodel.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_server_d_ts",
+      "label": "server.d.ts",
+      "norm_label": "server.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 772,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
       "norm_label": "server.js",
@@ -72814,7 +72895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -72823,7 +72904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -72832,7 +72913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -72841,7 +72922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -72850,7 +72931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -72859,7 +72940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -72868,30 +72949,12 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
       "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_crons_ts",
-      "label": "crons.ts",
-      "norm_label": "crons.ts",
-      "source_file": "packages/athena-webapp/convex/crons.ts",
       "source_location": "L1"
     },
     {
@@ -72969,6 +73032,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_crons_ts",
+      "label": "crons.ts",
+      "norm_label": "crons.ts",
+      "source_file": "packages/athena-webapp/convex/crons.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
       "norm_label": "feedbackrequest.tsx",
@@ -72976,7 +73057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -72985,7 +73066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -72994,7 +73075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -73003,7 +73084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -73012,7 +73093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -73021,7 +73102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -73030,30 +73111,12 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
-      "label": "colors.ts",
-      "norm_label": "colors.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
       "source_location": "L1"
     },
     {
@@ -73131,6 +73194,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
+      "label": "colors.ts",
+      "norm_label": "colors.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/colors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 792,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
@@ -73138,7 +73219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -73147,7 +73228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -73156,7 +73237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -73165,7 +73246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -73174,7 +73255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -73183,7 +73264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -73192,30 +73273,12 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
-      "label": "me.ts",
-      "norm_label": "me.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
       "source_location": "L1"
     },
     {
@@ -73491,6 +73554,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
+      "label": "me.ts",
+      "norm_label": "me.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
@@ -73498,7 +73579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -73507,7 +73588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -73516,7 +73597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -73525,7 +73606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -73534,7 +73615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -73543,7 +73624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -73552,30 +73633,12 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts",
       "source_location": "L1"
     },
     {
@@ -73653,6 +73716,24 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 812,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -73660,7 +73741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -73669,7 +73750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -73678,7 +73759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -73687,7 +73768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -73696,7 +73777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -73705,7 +73786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -73714,30 +73795,12 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
       "source_location": "L1"
     },
     {
@@ -73815,6 +73878,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
       "norm_label": "invitecode.ts",
@@ -73822,7 +73903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -73831,7 +73912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -73840,7 +73921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -73849,7 +73930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -73858,7 +73939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -73867,7 +73948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -73876,30 +73957,12 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
       "norm_label": "productutil.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1"
     },
     {
@@ -73968,6 +74031,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
       "norm_label": "storeconfigv2.test.ts",
@@ -73975,7 +74056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -73984,7 +74065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -73993,7 +74074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -74002,7 +74083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -74011,7 +74092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -74020,7 +74101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -74029,30 +74110,12 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "label": "normalize.test.ts",
-      "norm_label": "normalize.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
       "source_location": "L1"
     },
     {
@@ -74121,6 +74184,24 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
+      "label": "normalize.test.ts",
+      "norm_label": "normalize.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
       "norm_label": "customerprofiles.test.ts",
@@ -74128,7 +74209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -74137,7 +74218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -74146,7 +74227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -74155,16 +74236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
-      "label": "completeTransaction.test.ts",
-      "norm_label": "completetransaction.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -74173,7 +74245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -74182,7 +74254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -74191,21 +74263,12 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
       "norm_label": "opendrawer.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
-      "label": "posSessionTracing.test.ts",
-      "norm_label": "possessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
       "source_location": "L1"
     },
     {
@@ -74274,6 +74337,15 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
+      "label": "posSessionTracing.test.ts",
+      "norm_label": "possessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
       "norm_label": "terminals.test.ts",
@@ -74281,7 +74353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -74290,7 +74362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -74299,7 +74371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -74308,7 +74380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -74317,7 +74389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -74326,7 +74398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -74335,7 +74407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -74344,21 +74416,12 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
       "norm_label": "transactions.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/athena-webapp/convex/schema.ts",
       "source_location": "L1"
     },
     {
@@ -74427,6 +74490,15 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/athena-webapp/convex/schema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
       "norm_label": "appverificationcode.ts",
@@ -74434,7 +74506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -74443,7 +74515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -74452,7 +74524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -74461,7 +74533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -74470,7 +74542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -74479,7 +74551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -74488,7 +74560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -74497,21 +74569,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
       "source_location": "L1"
     },
     {
@@ -74580,6 +74643,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
@@ -74587,7 +74659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -74596,7 +74668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -74605,7 +74677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -74614,7 +74686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -74623,7 +74695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -74632,7 +74704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -74641,7 +74713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -74650,21 +74722,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
       "norm_label": "workflowtrace.ts",
       "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
-      "label": "workflowTraceEvent.ts",
-      "norm_label": "workflowtraceevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
       "source_location": "L1"
     },
     {
@@ -74733,6 +74796,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
+      "label": "workflowTraceEvent.ts",
+      "norm_label": "workflowtraceevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
       "norm_label": "workflowtracelookup.ts",
@@ -74740,7 +74812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -74749,7 +74821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -74758,7 +74830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -74767,7 +74839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -74776,7 +74848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -74785,7 +74857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -74794,7 +74866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -74803,21 +74875,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
       "norm_label": "registersession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
-      "label": "staffCredential.ts",
-      "norm_label": "staffcredential.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
       "source_location": "L1"
     },
     {
@@ -74886,6 +74949,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
+      "label": "staffCredential.ts",
+      "norm_label": "staffcredential.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
       "norm_label": "staffprofile.ts",
@@ -74893,7 +74965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -74902,7 +74974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -74911,7 +74983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -74920,7 +74992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -74929,7 +75001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -74938,7 +75010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -74947,7 +75019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -74956,21 +75028,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1"
     },
     {
@@ -74989,7 +75052,7 @@
       "label": "buildNextSessionNumber()",
       "norm_label": "buildnextsessionnumber()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L747"
+      "source_location": "L754"
     },
     {
       "community": 9,
@@ -74998,7 +75061,7 @@
       "label": "createDefaultSessionCommandService()",
       "norm_label": "createdefaultsessioncommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L702"
+      "source_location": "L709"
     },
     {
       "community": 9,
@@ -75016,7 +75079,7 @@
       "label": "failure()",
       "norm_label": "failure()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L940"
+      "source_location": "L947"
     },
     {
       "community": 9,
@@ -75025,7 +75088,7 @@
       "label": "isActiveRegisterSession()",
       "norm_label": "isactiveregistersession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L758"
+      "source_location": "L765"
     },
     {
       "community": 9,
@@ -75034,7 +75097,7 @@
       "label": "isSessionExpired()",
       "norm_label": "issessionexpired()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L849"
+      "source_location": "L856"
     },
     {
       "community": 9,
@@ -75052,7 +75115,7 @@
       "label": "recordSessionLifecycleBestEffort()",
       "norm_label": "recordsessionlifecyclebesteffort()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L714"
+      "source_location": "L721"
     },
     {
       "community": 9,
@@ -75061,7 +75124,7 @@
       "label": "registerSessionMatchesIdentity()",
       "norm_label": "registersessionmatchesidentity()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L764"
+      "source_location": "L771"
     },
     {
       "community": 9,
@@ -75070,7 +75133,7 @@
       "label": "resolveRegisterSessionBinding()",
       "norm_label": "resolveregistersessionbinding()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L793"
+      "source_location": "L800"
     },
     {
       "community": 9,
@@ -75079,7 +75142,7 @@
       "label": "runBindSessionToRegisterSessionCommand()",
       "norm_label": "runbindsessiontoregistersessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L679"
+      "source_location": "L686"
     },
     {
       "community": 9,
@@ -75088,7 +75151,7 @@
       "label": "runHoldSessionCommand()",
       "norm_label": "runholdsessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L668"
+      "source_location": "L675"
     },
     {
       "community": 9,
@@ -75097,7 +75160,7 @@
       "label": "runRemoveSessionItemCommand()",
       "norm_label": "runremovesessionitemcommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L695"
+      "source_location": "L702"
     },
     {
       "community": 9,
@@ -75106,7 +75169,7 @@
       "label": "runResumeSessionCommand()",
       "norm_label": "runresumesessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L672"
+      "source_location": "L679"
     },
     {
       "community": 9,
@@ -75115,7 +75178,7 @@
       "label": "runStartSessionCommand()",
       "norm_label": "runstartsessioncommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L651"
+      "source_location": "L658"
     },
     {
       "community": 9,
@@ -75124,7 +75187,7 @@
       "label": "runUpsertSessionItemCommand()",
       "norm_label": "runupsertsessionitemcommand()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L688"
+      "source_location": "L695"
     },
     {
       "community": 9,
@@ -75133,7 +75196,7 @@
       "label": "success()",
       "norm_label": "success()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L933"
+      "source_location": "L940"
     },
     {
       "community": 9,
@@ -75142,7 +75205,7 @@
       "label": "validateActiveSession()",
       "norm_label": "validateactivesession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L856"
+      "source_location": "L863"
     },
     {
       "community": 9,
@@ -75151,7 +75214,7 @@
       "label": "validateActiveSessionRegisterBinding()",
       "norm_label": "validateactivesessionregisterbinding()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L829"
+      "source_location": "L836"
     },
     {
       "community": 9,
@@ -75160,7 +75223,7 @@
       "label": "validateModifiableSession()",
       "norm_label": "validatemodifiablesession()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L900"
+      "source_location": "L907"
     },
     {
       "community": 90,
@@ -75228,6 +75291,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
       "norm_label": "possessionitem.ts",
@@ -75235,7 +75307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -75244,7 +75316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -75253,7 +75325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -75262,7 +75334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -75271,7 +75343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -75280,7 +75352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -75289,7 +75361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -75298,21 +75370,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
       "norm_label": "servicecatalog.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
-      "label": "serviceInventoryUsage.ts",
-      "norm_label": "serviceinventoryusage.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
       "source_location": "L1"
     },
     {
@@ -75381,6 +75444,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
+      "label": "serviceInventoryUsage.ts",
+      "norm_label": "serviceinventoryusage.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -75388,7 +75460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -75397,7 +75469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -75406,7 +75478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -75415,7 +75487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -75424,7 +75496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -75433,7 +75505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -75442,7 +75514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -75451,21 +75523,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -75534,6 +75597,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
       "norm_label": "checkoutsessionitem.ts",
@@ -75541,7 +75613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -75550,7 +75622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -75559,7 +75631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -75568,7 +75640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -75577,7 +75649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -75586,7 +75658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -75595,7 +75667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -75604,21 +75676,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
       "source_location": "L1"
     },
     {
@@ -75687,6 +75750,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
       "norm_label": "storefrontsession.ts",
@@ -75694,7 +75766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -75703,7 +75775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -75712,7 +75784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -75721,7 +75793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -75730,7 +75802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -75739,7 +75811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -75748,7 +75820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -75757,21 +75829,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1"
     },
     {
@@ -75840,6 +75903,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
       "norm_label": "orderoperations.test.ts",
@@ -75847,7 +75919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -75856,7 +75928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -75865,7 +75937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -75874,7 +75946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -75883,7 +75955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -75892,7 +75964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -75901,7 +75973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -75910,21 +75982,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
       "norm_label": "registersession.test.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
-      "label": "presentation.test.ts",
-      "norm_label": "presentation.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
       "source_location": "L1"
     },
     {
@@ -75993,6 +76056,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
+      "label": "presentation.test.ts",
+      "norm_label": "presentation.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
@@ -76000,7 +76072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -76009,7 +76081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -76018,7 +76090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -76027,7 +76099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -76036,7 +76108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -76045,7 +76117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -76054,7 +76126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -76063,21 +76135,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
       "norm_label": "storesaccordion.tsx",
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
-      "label": "ThemeToggle.tsx",
-      "norm_label": "themetoggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
       "source_location": "L1"
     },
     {
@@ -76146,6 +76209,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
+      "label": "ThemeToggle.tsx",
+      "norm_label": "themetoggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
       "norm_label": "defaultattributestogglegroup.tsx",
@@ -76153,7 +76225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -76162,7 +76234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -76171,7 +76243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -76180,7 +76252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76189,7 +76261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76198,7 +76270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -76207,7 +76279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -76216,21 +76288,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
       "norm_label": "revenuechart.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1"
     },
     {
@@ -76299,6 +76362,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
@@ -76306,7 +76378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -76315,7 +76387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76324,7 +76396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -76333,7 +76405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76342,7 +76414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -76351,7 +76423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -76360,7 +76432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76369,21 +76441,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -76452,6 +76515,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -76459,7 +76531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76468,7 +76540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76477,7 +76549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -76486,7 +76558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -76495,7 +76567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76504,7 +76576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76513,7 +76585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -76522,21 +76594,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -76605,6 +76668,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -76612,7 +76684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76621,7 +76693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -76630,7 +76702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -76639,7 +76711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -76648,7 +76720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -76657,7 +76729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -76666,7 +76738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -76675,21 +76747,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1521
-- Graph nodes: 3906
-- Graph edges: 3461
+- Graph nodes: 3909
+- Graph edges: 3464
 - Communities: 1436
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.trace.test.ts
@@ -45,6 +45,7 @@ type SessionRecord = {
   expiresAt: number;
   staffProfileId?: string;
   customerId?: string;
+  customerProfileId?: string;
   registerSessionId?: string;
   customerInfo?: {
     name?: string;
@@ -219,6 +220,7 @@ function createMutationCtx(seed?: {
   return {
     db,
     sessions,
+    items,
   };
 }
 
@@ -275,6 +277,7 @@ describe("pos session lifecycle trace handlers", () => {
 
     const result = await getHandler(completeSession)(ctx as never, {
       sessionId: "session-1",
+      staffProfileId: "cashier-1",
       payments: [{ method: "cash", amount: 115, timestamp: 1_000 }],
       notes: "Completed in test",
       subtotal: 100,
@@ -293,6 +296,7 @@ describe("pos session lifecycle trace handlers", () => {
       ctx,
       expect.objectContaining({
         sessionId: "session-1",
+        staffProfileId: "cashier-1",
         recordRegisterSale: false,
       }),
     );
@@ -319,6 +323,43 @@ describe("pos session lifecycle trace handlers", () => {
     expect(ctx.db.patch).toHaveBeenCalledWith("posSession", "session-1", {
       workflowTraceId: "pos_session:ses-001",
     });
+  });
+
+  it("refuses to complete a session for a different cashier before transaction side effects", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "session-1",
+          staffProfileId: "cashier-1",
+          registerSessionId: "drawer-1",
+          subtotal: 100,
+          tax: 15,
+          total: 115,
+        }),
+      ],
+    });
+
+    const result = await getHandler(completeSession)(ctx as never, {
+      sessionId: "session-1",
+      staffProfileId: "cashier-2",
+      payments: [{ method: "cash", amount: 115, timestamp: 1_000 }],
+      subtotal: 100,
+      tax: 15,
+      total: 115,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "precondition_failed",
+          message: "This session is not associated with your cashier.",
+        }),
+      }),
+    );
+    expect(mocks.createTransactionFromSessionHandler).not.toHaveBeenCalled();
+    expect(mocks.traceRecord).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
   it("records a voided lifecycle trace when voiding a session", async () => {
@@ -365,6 +406,87 @@ describe("pos session lifecycle trace handlers", () => {
     );
   });
 
+  it("voids an empty session without deleting audit items", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "session-empty-void",
+        }),
+      ],
+    });
+
+    const result = await getHandler(voidSession)(ctx as never, {
+      sessionId: "session-empty-void",
+      voidReason: "No items added",
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        sessionId: "session-empty-void",
+      },
+    });
+    expect(mocks.releaseInventoryHoldsBatch).toHaveBeenCalledWith(ctx.db, []);
+    expect(ctx.db.delete).not.toHaveBeenCalled();
+    expect(ctx.sessions[0]).toEqual(
+      expect.objectContaining({
+        status: "void",
+        notes: "No items added",
+      }),
+    );
+    expect(mocks.traceRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "voided",
+        session: expect.objectContaining({
+          _id: "session-empty-void",
+          status: "void",
+        }),
+      }),
+    );
+  });
+
+  it("aggregates SKU quantities before releasing holds while voiding a session", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "session-aggregate-void",
+        }),
+      ],
+      items: [
+        {
+          _id: "item-1",
+          sessionId: "session-aggregate-void",
+          productSkuId: "sku-1",
+          quantity: 2,
+        },
+        {
+          _id: "item-2",
+          sessionId: "session-aggregate-void",
+          productSkuId: "sku-1",
+          quantity: 3,
+        },
+        {
+          _id: "item-3",
+          sessionId: "session-aggregate-void",
+          productSkuId: "sku-2",
+          quantity: 1,
+        },
+      ],
+    });
+
+    await getHandler(voidSession)(ctx as never, {
+      sessionId: "session-aggregate-void",
+      voidReason: "Duplicate SKU lines",
+    });
+
+    expect(mocks.releaseInventoryHoldsBatch).toHaveBeenCalledWith(ctx.db, [
+      { skuId: "sku-1", quantity: 5 },
+      { skuId: "sku-2", quantity: 1 },
+    ]);
+    expect(ctx.items).toHaveLength(3);
+    expect(ctx.db.delete).not.toHaveBeenCalled();
+  });
+
   it("records customer milestones when session metadata links a customer", async () => {
     const ctx = createMutationCtx({
       sessions: [
@@ -407,6 +529,102 @@ describe("pos session lifecycle trace handlers", () => {
             name: "Ama Serwa",
             email: "ama@example.com",
           }),
+        }),
+      }),
+    );
+  });
+
+  it("preserves customerProfileId and records customer profile metadata milestones", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "session-customer-profile",
+          customerProfileId: undefined,
+          customerInfo: undefined,
+        }),
+      ],
+    });
+
+    await getHandler(updateSession)(ctx as never, {
+      sessionId: "session-customer-profile",
+      staffProfileId: "cashier-1",
+      customerProfileId: "profile-1",
+      customerInfo: {
+        name: "Ama Serwa",
+        email: "ama@example.com",
+      },
+      subtotal: 100,
+      tax: 15,
+      total: 115,
+    });
+
+    expect(
+      ctx.sessions.find((session) => session._id === "session-customer-profile"),
+    ).toEqual(
+      expect.objectContaining({
+        customerProfileId: "profile-1",
+        customerInfo: expect.objectContaining({
+          name: "Ama Serwa",
+          email: "ama@example.com",
+        }),
+      }),
+    );
+    expect(mocks.traceRecord).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: "customerLinked",
+        customerName: "Ama Serwa",
+        session: expect.objectContaining({
+          _id: "session-customer-profile",
+          customerProfileId: "profile-1",
+        }),
+      }),
+    );
+
+    await getHandler(updateSession)(ctx as never, {
+      sessionId: "session-customer-profile",
+      staffProfileId: "cashier-1",
+      customerProfileId: "profile-1",
+      customerInfo: {
+        name: "Ama Serwa Mensah",
+        email: "ama@example.com",
+      },
+      subtotal: 100,
+      tax: 15,
+      total: 115,
+    });
+
+    expect(mocks.traceRecord).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: "customerUpdated",
+        customerName: "Ama Serwa Mensah",
+        session: expect.objectContaining({
+          _id: "session-customer-profile",
+          customerProfileId: "profile-1",
+          customerInfo: expect.objectContaining({
+            name: "Ama Serwa Mensah",
+          }),
+        }),
+      }),
+    );
+
+    await getHandler(updateSession)(ctx as never, {
+      sessionId: "session-customer-profile",
+      staffProfileId: "cashier-1",
+      customerProfileId: undefined,
+      customerInfo: undefined,
+      subtotal: 100,
+      tax: 15,
+      total: 115,
+    });
+
+    expect(mocks.traceRecord).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: "customerCleared",
+        customerName: "Ama Serwa Mensah",
+        session: expect.objectContaining({
+          _id: "session-customer-profile",
+          customerProfileId: undefined,
+          customerInfo: undefined,
         }),
       }),
     );
@@ -492,6 +710,57 @@ describe("pos session lifecycle trace handlers", () => {
     );
     expect(mocks.traceRecord).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["voided", "void", 4_102_444_800_000],
+    ["expired", "active", 500],
+  ] as const)(
+    "treats stale %s sessions owned by the cashier as a no-op metadata update",
+    async (_label, status, expiresAt) => {
+      const ctx = createMutationCtx({
+        sessions: [
+          buildSession({
+            _id: `session-${_label}`,
+            status,
+            expiresAt,
+            customerProfileId: "profile-original",
+          }),
+        ],
+      });
+
+      const result = await getHandler(updateSession)(ctx as never, {
+        sessionId: `session-${_label}`,
+        staffProfileId: "cashier-1",
+        customerProfileId: "profile-new",
+        customerInfo: {
+          name: "Ama Serwa",
+        },
+        subtotal: 100,
+        tax: 15,
+        total: 115,
+      });
+
+      expect(result).toEqual({
+        kind: "ok",
+        data: {
+          sessionId: `session-${_label}`,
+          expiresAt,
+        },
+      });
+      expect(ctx.sessions[0]).toEqual(
+        expect.objectContaining({
+          customerProfileId: "profile-original",
+          expiresAt,
+        }),
+      );
+      expect(ctx.db.patch).not.toHaveBeenCalledWith(
+        "posSession",
+        `session-${_label}`,
+        expect.anything(),
+      );
+      expect(mocks.traceRecord).not.toHaveBeenCalled();
+    },
+  );
 
   it("records a cart-cleared milestone and clears pending payments", async () => {
     const ctx = createMutationCtx({
@@ -688,6 +957,75 @@ describe("pos session lifecycle trace handlers", () => {
     expect(ctx.db.delete).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      "closing",
+      {
+        _id: "drawer-1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        status: "closing",
+      },
+    ],
+    [
+      "mismatched-store",
+      {
+        _id: "drawer-1",
+        storeId: "store-2",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        status: "open",
+      },
+    ],
+  ] as const)(
+    "refuses to clear the cart when the bound drawer is %s and preserves items and holds",
+    async (label, drawer) => {
+      const ctx = createMutationCtx({
+        sessions: [
+          buildSession({
+            _id: `session-clear-${label}`,
+            checkoutStateVersion: 2,
+          }),
+        ],
+        registerSessions: [drawer],
+        items: [
+          {
+            _id: "item-1",
+            sessionId: `session-clear-${label}`,
+            productSkuId: "sku-1",
+            quantity: 1,
+          },
+        ],
+      });
+
+      const result = await getHandler(releaseSessionInventoryHoldsAndDeleteItems)(
+        ctx as never,
+        {
+          sessionId: `session-clear-${label}`,
+          staffProfileId: "cashier-1",
+          checkoutStateVersion: 4,
+        },
+      );
+
+      expect(result).toEqual({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "validation_failed",
+          message: "Open the cash drawer before modifying this sale.",
+        }),
+      });
+      expect(mocks.releaseInventoryHoldsBatch).not.toHaveBeenCalled();
+      expect(ctx.db.delete).not.toHaveBeenCalled();
+      expect(ctx.items).toEqual([
+        expect.objectContaining({
+          _id: "item-1",
+          sessionId: `session-clear-${label}`,
+        }),
+      ]);
+    },
+  );
+
   it("keeps cleared carts fenced off from older payment-sync writes", async () => {
     const ctx = createMutationCtx({
       sessions: [
@@ -857,6 +1195,136 @@ describe("pos session lifecycle trace handlers", () => {
       "posSession",
       "session-checkout-no-drawer",
       expect.anything(),
+    );
+  });
+
+  it.each([
+    [
+      "closed",
+      {
+        _id: "drawer-1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        status: "closed",
+      },
+    ],
+    [
+      "closing",
+      {
+        _id: "drawer-1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        status: "closing",
+      },
+    ],
+    [
+      "mismatched-store",
+      {
+        _id: "drawer-1",
+        storeId: "store-2",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        status: "open",
+      },
+    ],
+    [
+      "mismatched-terminal",
+      {
+        _id: "drawer-1",
+        storeId: "store-1",
+        terminalId: "terminal-9",
+        registerNumber: "1",
+        status: "open",
+      },
+    ],
+  ] as const)(
+    "refuses to sync checkout payments when the bound drawer is %s before patching",
+    async (label, drawer) => {
+      const ctx = createMutationCtx({
+        sessions: [
+          buildSession({
+            _id: `session-checkout-${label}`,
+            payments: [{ method: "cash", amount: 60, timestamp: 1_000 }],
+            checkoutStateVersion: 2,
+          }),
+        ],
+        registerSessions: [drawer],
+      });
+
+      const result = await getHandler(syncSessionCheckoutState)(ctx as never, {
+        sessionId: `session-checkout-${label}`,
+        staffProfileId: "cashier-1",
+        checkoutStateVersion: 3,
+        payments: [{ method: "cash", amount: 120, timestamp: 1_000 }],
+        stage: "paymentUpdated",
+        paymentMethod: "cash",
+        amount: 120,
+        previousAmount: 60,
+      });
+
+      expect(result).toEqual({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "validation_failed",
+          message: "Open the cash drawer before modifying this sale.",
+        }),
+      });
+      expect(ctx.db.patch).not.toHaveBeenCalledWith(
+        "posSession",
+        `session-checkout-${label}`,
+        expect.anything(),
+      );
+      expect(mocks.traceRecord).not.toHaveBeenCalled();
+      expect(ctx.sessions[0]).toEqual(
+        expect.objectContaining({
+          payments: [{ method: "cash", amount: 60, timestamp: 1_000 }],
+          checkoutStateVersion: 2,
+        }),
+      );
+    },
+  );
+
+  it("ignores stale checkout-state sync writes without patching or tracing", async () => {
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "session-stale-checkout-only",
+          checkoutStateVersion: 5,
+          payments: [{ method: "card", amount: 80, timestamp: 2_000 }],
+        }),
+      ],
+    });
+
+    const result = await getHandler(syncSessionCheckoutState)(ctx as never, {
+      sessionId: "session-stale-checkout-only",
+      staffProfileId: "cashier-1",
+      checkoutStateVersion: 4,
+      payments: [{ method: "cash", amount: 80, timestamp: 1_000 }],
+      stage: "paymentAdded",
+      paymentMethod: "cash",
+      amount: 80,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        sessionId: "session-stale-checkout-only",
+        expiresAt: 4_102_444_800_000,
+      },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "posSession",
+      "session-stale-checkout-only",
+      expect.anything(),
+    );
+    expect(mocks.traceRecord).not.toHaveBeenCalled();
+    expect(ctx.sessions[0]).toEqual(
+      expect.objectContaining({
+        payments: [{ method: "card", amount: 80, timestamp: 2_000 }],
+        checkoutStateVersion: 5,
+      }),
     );
   });
 

--- a/packages/athena-webapp/convex/inventory/posSessions.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.ts
@@ -702,6 +702,7 @@ export const resumeSession = mutation({
 export const completeSession = mutation({
   args: {
     sessionId: v.id("posSession"),
+    staffProfileId: v.id("staffProfile"),
     payments: v.array(
       v.object({
         method: v.string(), // "cash", "card", "mobile_money"
@@ -741,8 +742,16 @@ export const completeSession = mutation({
       });
     }
 
+    if (session.staffProfileId !== args.staffProfileId) {
+      return userError({
+        code: "precondition_failed",
+        message: "This session is not associated with your cashier.",
+      });
+    }
+
     const transactionResult = await createTransactionFromSessionHandler(ctx, {
       sessionId: args.sessionId,
+      staffProfileId: args.staffProfileId,
       payments: args.payments,
       recordRegisterSale: false,
       notes: args.notes,

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -481,6 +481,7 @@ export async function createTransactionFromSessionHandler(
   ctx: MutationCtx,
   args: {
     sessionId: Id<"posSession">;
+    staffProfileId: Id<"staffProfile">;
     payments: PosPaymentInput[];
     registerSessionId?: Id<"registerSession">;
     recordRegisterSale?: boolean;
@@ -498,6 +499,13 @@ export async function createTransactionFromSessionHandler(
     return userError({
       code: "not_found",
       message: "Session not found.",
+    });
+  }
+
+  if (session.staffProfileId !== args.staffProfileId) {
+    return userError({
+      code: "precondition_failed",
+      message: "This session is not associated with your cashier.",
     });
   }
 

--- a/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
@@ -619,10 +619,17 @@ export function createPosSessionCommandService(
         );
       }
 
-      await dependencies.inventory.releaseHold(
+      const releaseResult = await dependencies.inventory.releaseHold(
         item.productSkuId,
         item.quantity,
       );
+      if (!releaseResult.success) {
+        return failure(
+          "inventoryUnavailable",
+          releaseResult.message || "Failed to release inventory hold",
+        );
+      }
+
       await dependencies.repository.deleteSessionItem(args.itemId);
 
       const expiresAt = dependencies.calculateExpiration(now);

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -60,6 +60,19 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+function expectNoCompletionSideEffects() {
+  expect(createPosTransaction).not.toHaveBeenCalled();
+  expect(createPosTransactionItem).not.toHaveBeenCalled();
+  expect(patchProductSku).not.toHaveBeenCalled();
+  expect(patchPosSession).not.toHaveBeenCalled();
+  expect(patchPosTransaction).not.toHaveBeenCalled();
+  expect(recordRetailSalePaymentAllocations).not.toHaveBeenCalled();
+  expect(updateCustomerStats).not.toHaveBeenCalled();
+  expect(createWorkflowTraceWithCtx).not.toHaveBeenCalled();
+  expect(registerWorkflowTraceLookupWithCtx).not.toHaveBeenCalled();
+  expect(appendWorkflowTraceEventWithCtx).not.toHaveBeenCalled();
+}
+
 describe("buildCompleteTransactionResult", () => {
   it("returns ok with transaction data when completion succeeds", () => {
     const result = buildCompleteTransactionResult({
@@ -93,6 +106,281 @@ describe("buildCompleteTransactionResult", () => {
     });
 
     expect(result.status).toBe("validationFailed");
+  });
+});
+
+describe("completeTransaction checkout side effects", () => {
+  it("requires a terminal before recording a direct register sale", async () => {
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-1",
+      images: [],
+      inventoryCount: 10,
+      productId: "product-1",
+      quantityAvailable: 10,
+      sku: "SKU-1",
+    } as never);
+
+    await expect(
+      completeTransaction({ runMutation: vi.fn() } as never, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-1" as Id<"productSku">,
+            quantity: 1,
+            price: 10,
+            name: "Sneaker",
+            sku: "SKU-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+        subtotal: 10,
+        tax: 0,
+        total: 10,
+        registerSessionId: "register-1" as Id<"registerSession">,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "precondition_failed",
+          message: "Register session transactions must include a terminal.",
+        }),
+      }),
+    );
+
+    expectNoCompletionSideEffects();
+  });
+
+  it("records register sale and payment allocation for a direct register sale", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      runMutation,
+    } as never;
+
+    vi.mocked(getStoreById).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-1",
+      images: [],
+      inventoryCount: 10,
+      productId: "product-1",
+      quantityAvailable: 10,
+      sku: "SKU-1",
+    } as never);
+    vi.mocked(createPosTransaction).mockResolvedValue("txn-1" as never);
+    vi.mocked(recordRetailSalePaymentAllocations).mockResolvedValue(true);
+    vi.mocked(createPosTransactionItem).mockResolvedValue(
+      "txn-item-1" as never,
+    );
+    vi.mocked(patchProductSku).mockResolvedValue(undefined as never);
+
+    await expect(
+      completeTransaction(ctx, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-1" as Id<"productSku">,
+            quantity: 1,
+            price: 10,
+            name: "Sneaker",
+            sku: "SKU-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 12, timestamp: 1 }],
+        subtotal: 10,
+        tax: 0,
+        total: 10,
+        registerNumber: "1",
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        registerSessionId: "register-1" as Id<"registerSession">,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "ok",
+        data: expect.objectContaining({
+          transactionId: "txn-1",
+          transactionItems: ["txn-item-1"],
+        }),
+      }),
+    );
+
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        adjustmentKind: "sale",
+        changeGiven: 2,
+        registerSessionId: "register-1",
+        registerNumber: "1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    );
+    expect(recordRetailSalePaymentAllocations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        changeGiven: 2,
+        organizationId: "org-1",
+        posTransactionId: "txn-1",
+        registerSessionId: "register-1",
+        storeId: "store-1",
+      }),
+    );
+  });
+
+  it("does not create side effects when payments are empty", async () => {
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-1",
+      images: [],
+      inventoryCount: 10,
+      productId: "product-1",
+      quantityAvailable: 10,
+      sku: "SKU-1",
+    } as never);
+
+    await expect(
+      completeTransaction({} as never, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-1" as Id<"productSku">,
+            quantity: 1,
+            price: 10,
+            name: "Sneaker",
+            sku: "SKU-1",
+          },
+        ],
+        payments: [],
+        subtotal: 10,
+        tax: 0,
+        total: 10,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "At least one payment is required.",
+      },
+    });
+
+    expectNoCompletionSideEffects();
+  });
+
+  it("does not create side effects when payment is insufficient", async () => {
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-1",
+      images: [],
+      inventoryCount: 10,
+      productId: "product-1",
+      quantityAvailable: 10,
+      sku: "SKU-1",
+    } as never);
+
+    await expect(
+      completeTransaction({} as never, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-1" as Id<"productSku">,
+            quantity: 1,
+            price: 10,
+            name: "Sneaker",
+            sku: "SKU-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 9, timestamp: 1 }],
+        subtotal: 10,
+        tax: 0,
+        total: 10,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Insufficient payment. Total: 10.00, Paid: 9.00",
+      },
+    });
+
+    expectNoCompletionSideEffects();
+  });
+
+  it("does not create side effects when a direct sale SKU is missing", async () => {
+    vi.mocked(getProductSkuById).mockResolvedValue(null as never);
+
+    await expect(
+      completeTransaction({} as never, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-missing" as Id<"productSku">,
+            quantity: 1,
+            price: 10,
+            name: "Sneaker",
+            sku: "SKU-MISSING",
+          },
+        ],
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+        subtotal: 10,
+        tax: 0,
+        total: 10,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "not_found",
+        message: "Product SKU sku-missing not found.",
+      },
+    });
+
+    expectNoCompletionSideEffects();
+  });
+
+  it("aggregates duplicate SKU quantities before availability checks", async () => {
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-1",
+      images: [],
+      inventoryCount: 3,
+      productId: "product-1",
+      quantityAvailable: 3,
+      sku: "SKU-1",
+    } as never);
+
+    await expect(
+      completeTransaction({} as never, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-1" as Id<"productSku">,
+            quantity: 2,
+            price: 10,
+            name: "sneaker",
+            sku: "SKU-1",
+          },
+          {
+            skuId: "sku-1" as Id<"productSku">,
+            quantity: 2,
+            price: 10,
+            name: "sneaker",
+            sku: "SKU-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 40, timestamp: 1 }],
+        subtotal: 40,
+        tax: 0,
+        total: 40,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "conflict",
+        message:
+          "Insufficient inventory for Sneaker (SKU-1). Available: 3, Total Requested: 4",
+      },
+    });
+
+    expect(getProductSkuById).toHaveBeenCalledTimes(1);
+    expectNoCompletionSideEffects();
   });
 });
 
@@ -160,8 +448,9 @@ describe("completeTransaction trace ordering", () => {
   });
 
   it("does not write a POS sale trace for session-based checkout", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
     const ctx = {
-      runMutation: vi.fn().mockResolvedValue(undefined),
+      runMutation,
     } as never;
 
     vi.mocked(getStoreById).mockResolvedValue({
@@ -238,6 +527,7 @@ describe("completeTransaction trace ordering", () => {
     await expect(
       createTransactionFromSessionHandler(ctx, {
         sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
         payments: [{ method: "cash", amount: 10, timestamp: 1 }],
       }),
     ).rejects.toThrow("session patch unavailable");
@@ -324,6 +614,7 @@ describe("completeTransaction trace ordering", () => {
     await expect(
       createTransactionFromSessionHandler(ctx, {
         sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
         payments: [{ method: "cash", amount: 10, timestamp: 1 }],
       }),
     ).resolves.toEqual(
@@ -354,6 +645,41 @@ describe("completeTransaction trace ordering", () => {
         registerSessionId: "register-1",
       }),
     );
+  });
+
+  it("fails before transaction side effects when the checkout cashier does not own the session", async () => {
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerId: undefined,
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      subtotal: 10,
+      tax: 0,
+      total: 10,
+      terminalId: "terminal-1",
+      customerInfo: undefined,
+    } as never);
+
+    await expect(
+      createTransactionFromSessionHandler({} as never, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-2" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "precondition_failed",
+          message: "This session is not associated with your cashier.",
+        }),
+      }),
+    );
+
+    expect(listSessionItems).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
   });
 
   it("fails when a session sale is not bound to an open drawer", async () => {
@@ -387,6 +713,7 @@ describe("completeTransaction trace ordering", () => {
     await expect(
       createTransactionFromSessionHandler({} as never, {
         sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
         payments: [{ method: "cash", amount: 10, timestamp: 1 }],
       }),
     ).resolves.toEqual(
@@ -439,6 +766,7 @@ describe("completeTransaction trace ordering", () => {
     await expect(
       createTransactionFromSessionHandler({} as never, {
         sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
         payments: [{ method: "cash", amount: 10, timestamp: 1 }],
       }),
     ).resolves.toEqual(
@@ -452,6 +780,184 @@ describe("completeTransaction trace ordering", () => {
     );
 
     expect(createPosTransaction).not.toHaveBeenCalled();
+  });
+
+  it("fails safely when a session sale is bound to a closing drawer", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      runMutation,
+    } as never;
+
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerId: undefined,
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      subtotal: 10,
+      tax: 0,
+      total: 10,
+      terminalId: "terminal-1",
+      customerInfo: undefined,
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "closing",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productSku: "SKU-1",
+        productName: "Sneaker",
+        price: 10,
+        quantity: 1,
+        image: undefined,
+      },
+    ] as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "precondition_failed",
+          message: "Open the cash drawer before completing this sale.",
+        }),
+      }),
+    );
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
+  });
+
+  it("fails safely when a session sale drawer belongs to another store", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      runMutation,
+    } as never;
+
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerId: undefined,
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      subtotal: 10,
+      tax: 0,
+      total: 10,
+      terminalId: "terminal-1",
+      customerInfo: undefined,
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-2",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productSku: "SKU-1",
+        productName: "Sneaker",
+        price: 10,
+        quantity: 1,
+        image: undefined,
+      },
+    ] as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "precondition_failed",
+          message: "Open the cash drawer before completing this sale.",
+        }),
+      }),
+    );
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
+  });
+
+  it("fails safely when a provided drawer conflicts with the session drawer", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      runMutation,
+    } as never;
+
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerId: undefined,
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      subtotal: 10,
+      tax: 0,
+      total: 10,
+      terminalId: "terminal-1",
+      customerInfo: undefined,
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productSku: "SKU-1",
+        productName: "Sneaker",
+        price: 10,
+        quantity: 1,
+        image: undefined,
+      },
+    ] as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+        registerSessionId: "register-2" as Id<"registerSession">,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "user_error",
+        error: expect.objectContaining({
+          code: "precondition_failed",
+          message: "Open the cash drawer before completing this sale.",
+        }),
+      }),
+    );
+
+    expect(getRegisterSessionById).not.toHaveBeenCalled();
+    expect(runMutation).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
   });
 
   it("fails safely when a session sale is bound to a mismatched drawer", async () => {
@@ -493,6 +999,7 @@ describe("completeTransaction trace ordering", () => {
     await expect(
       createTransactionFromSessionHandler({} as never, {
         sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
         payments: [{ method: "cash", amount: 10, timestamp: 1 }],
       }),
     ).resolves.toEqual(

--- a/packages/athena-webapp/convex/pos/application/getRegisterState.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getRegisterState.test.ts
@@ -78,4 +78,45 @@ describe("buildRegisterState", () => {
 
     expect(result.phase).toBe("readyToStart");
   });
+
+  it("keeps the visible drawer in readyToStart state", () => {
+    const result = buildRegisterState({
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "cashier-1", firstName: "Ama", lastName: "K" },
+      activeRegisterSession: {
+        _id: "drawer-1" as Id<"registerSession">,
+        expectedCash: 5000,
+        openedAt: 1710000000000,
+        openingFloat: 5000,
+        registerNumber: "A1",
+        status: "open",
+      },
+      activeSession: null,
+      heldSessions: [],
+    });
+
+    expect(result.phase).toBe("readyToStart");
+    expect(result.activeRegisterSession?._id).toBe("drawer-1");
+  });
+
+  it("keeps a closing drawer visible without changing resumable phase selection", () => {
+    const result = buildRegisterState({
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "cashier-1", firstName: "Ama", lastName: "K" },
+      activeRegisterSession: {
+        _id: "drawer-1" as Id<"registerSession">,
+        expectedCash: 5000,
+        openedAt: 1710000000000,
+        openingFloat: 5000,
+        registerNumber: "A1",
+        status: "closing",
+      },
+      activeSession: null,
+      heldSessions: [{ _id: "session-2", sessionNumber: "POS-002" }],
+    });
+
+    expect(result.phase).toBe("resumable");
+    expect(result.activeRegisterSession?.status).toBe("closing");
+    expect(result.resumableSession?._id).toBe("session-2");
+  });
 });

--- a/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
@@ -123,6 +123,84 @@ describe("createPosSessionCommandService", () => {
     ]);
   });
 
+  it("trims register identity before resolving and persisting a new session", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).startSession({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      staffProfileId: "cashier-1",
+      registerNumber: " 1 ",
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        sessionId: "session-1",
+        expiresAt: 61_000,
+      },
+    });
+    expect(repository.getSession("session-1")).toEqual(
+      expect.objectContaining({
+        registerNumber: "1",
+        registerSessionId: "drawer-1",
+      }),
+    );
+  });
+
+  it("rejects an explicit drawer from a different store before creating a session", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-2",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).startSession({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      staffProfileId: "cashier-1",
+      registerNumber: "1",
+      registerSessionId: "drawer-1",
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message: "Open the cash drawer before starting a sale.",
+    });
+    expect(repository.sessions).toHaveLength(0);
+    expect(repository.sessionPatches).toEqual([]);
+  });
+
   it("refuses to start a new session when the cashier is already active on another terminal", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
@@ -240,6 +318,146 @@ describe("createPosSessionCommandService", () => {
         holdReason: "Auto-held when new session started",
       },
     ]);
+  });
+
+  it("reuses an empty active same-terminal session without holding or tracing it", async () => {
+    const commandService = await loadCommandService();
+    const traceCalls: TraceCall[] = [];
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      sessions: [
+        buildSession({
+          _id: "session-4",
+          sessionNumber: "SES-004",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          status: "active",
+          workflowTraceId: "pos_session:session-4",
+          expiresAt: 12_000,
+          updatedAt: 950,
+        }),
+      ],
+    });
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        traceCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).startSession({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      staffProfileId: "cashier-1",
+      registerNumber: "1",
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        sessionId: "session-4",
+        expiresAt: 12_000,
+      },
+    });
+    expect(repository.getSession("session-4")).toEqual(
+      expect.objectContaining({
+        status: "active",
+        updatedAt: 950,
+        expiresAt: 12_000,
+        workflowTraceId: "pos_session:session-4",
+      }),
+    );
+    expect(repository.sessionPatches).toEqual([]);
+    expect(traceCalls).toEqual([]);
+  });
+
+  it("auto-holds a non-empty same-terminal session while preserving existing metadata", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      sessions: [
+        buildSession({
+          _id: "session-16",
+          sessionNumber: "SES-016",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          status: "active",
+          workflowTraceId: "trace-existing",
+          expiresAt: 12_000,
+          updatedAt: 950,
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-16",
+          sessionId: "session-16",
+          storeId: "store-1",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          productSku: "SKU-1",
+          productName: "Sneaker",
+          price: 120,
+          quantity: 1,
+        }),
+      ],
+    });
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).startSession({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      staffProfileId: "cashier-1",
+      registerNumber: "1",
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        sessionId: "session-16",
+        expiresAt: 12_000,
+      },
+    });
+    expect(repository.getSession("session-16")).toEqual(
+      expect.objectContaining({
+        status: "held",
+        registerNumber: "1",
+        registerSessionId: "drawer-1",
+        staffProfileId: "cashier-1",
+        workflowTraceId: "trace-existing",
+        expiresAt: 12_000,
+        heldAt: 1_000,
+        updatedAt: 1_000,
+      }),
+    );
+    expect(repository.items).toHaveLength(1);
   });
 
   it("holds a modifiable session without refreshing its expiration", async () => {
@@ -608,6 +826,87 @@ describe("createPosSessionCommandService", () => {
     );
   });
 
+  it("rejects rebinding an already recovered session to a different drawer without touching sale state", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-2",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+        buildRegisterSession({
+          _id: "drawer-3",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      sessions: [
+        buildSession({
+          _id: "session-1",
+          sessionNumber: "SES-001",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          expiresAt: 8_000,
+          updatedAt: 500,
+          registerNumber: "1",
+          registerSessionId: "drawer-2",
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-1",
+          sessionId: "session-1",
+          storeId: "store-1",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          productSku: "SKU-1",
+          productName: "Sneaker",
+          price: 120,
+          quantity: 2,
+        }),
+      ],
+    });
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).bindSessionToRegisterSession({
+      sessionId: "session-1",
+      staffProfileId: "cashier-1",
+      registerSessionId: "drawer-3",
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message: "This sale is already assigned to a different cash drawer.",
+    });
+    expect(repository.getSession("session-1")).toEqual(
+      expect.objectContaining({
+        registerSessionId: "drawer-2",
+        updatedAt: 500,
+        expiresAt: 8_000,
+      }),
+    );
+    expect(repository.items).toEqual([
+      expect.objectContaining({
+        _id: "item-1",
+        quantity: 2,
+      }),
+    ]);
+    expect(repository.sessionPatches).toEqual([]);
+    expect(repository.itemPatches).toEqual([]);
+  });
+
   it("refuses to resume an expired held session", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
@@ -641,6 +940,73 @@ describe("createPosSessionCommandService", () => {
       status: "sessionExpired",
       message: "This session has expired. Start a new one to proceed.",
     });
+  });
+
+  it("rejects resume when the cashier is active on another terminal before mutating the held session", async () => {
+    const commandService = await loadCommandService();
+    const traceCalls: TraceCall[] = [];
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-3",
+          sessionNumber: "SES-003",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          status: "held",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+        buildSession({
+          _id: "session-8",
+          sessionNumber: "SES-008",
+          storeId: "store-1",
+          terminalId: "terminal-9",
+          staffProfileId: "cashier-1",
+          status: "active",
+          expiresAt: 8_000,
+          updatedAt: 700,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        traceCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).resumeSession({
+      sessionId: "session-3",
+      staffProfileId: "cashier-1",
+      terminalId: "terminal-1",
+    });
+
+    expect(result).toEqual({
+      status: "terminalUnavailable",
+      message: "This cashier has an active session on another terminal",
+    });
+    expect(repository.getSession("session-3")).toEqual(
+      expect.objectContaining({
+        status: "held",
+        updatedAt: 500,
+        expiresAt: 8_000,
+      }),
+    );
+    expect(repository.sessionPatches).toEqual([]);
+    expect(traceCalls).toEqual([]);
   });
 
   it("acquires a new inventory hold when adding a new cart line and refreshes session expiration", async () => {
@@ -723,6 +1089,76 @@ describe("createPosSessionCommandService", () => {
         previousQuantity: undefined,
       },
     ]);
+  });
+
+  it("does not create a cart line, patch the session, or trace when inventory acquire fails", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+    const traceCalls: TraceCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        traceCalls,
+        inventoryFailures: {
+          acquire: "inventory unavailable",
+        },
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      productSku: "SKU-1",
+      productName: "Sneaker",
+      price: 120,
+      quantity: 2,
+    });
+
+    expect(result).toEqual({
+      status: "inventoryUnavailable",
+      message: "inventory unavailable",
+    });
+    expect(inventoryCalls).toEqual([
+      { kind: "acquire", skuId: "sku-1", quantity: 2 },
+    ]);
+    expect(repository.items).toEqual([]);
+    expect(repository.getSession("session-5")).toEqual(
+      expect.objectContaining({
+        updatedAt: 500,
+        expiresAt: 8_000,
+      }),
+    );
+    expect(repository.sessionPatches).toEqual([]);
+    expect(traceCalls).toEqual([]);
   });
 
   it("adjusts the existing inventory hold when updating a cart line quantity", async () => {
@@ -820,6 +1256,100 @@ describe("createPosSessionCommandService", () => {
         previousQuantity: 2,
       },
     ]);
+  });
+
+  it("does not patch a cart line, patch the session, or trace when inventory adjust fails", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-6",
+          sessionNumber: "SES-006",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-9",
+          sessionId: "session-6",
+          storeId: "store-1",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          productSku: "SKU-1",
+          productName: "Sneaker",
+          price: 120,
+          quantity: 2,
+        }),
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+    const traceCalls: TraceCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        traceCalls,
+        inventoryFailures: {
+          adjust: "inventory unavailable",
+        },
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-6",
+      staffProfileId: "cashier-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      productSku: "SKU-1",
+      productName: "Sneaker",
+      price: 125,
+      quantity: 5,
+    });
+
+    expect(result).toEqual({
+      status: "inventoryUnavailable",
+      message: "inventory unavailable",
+    });
+    expect(inventoryCalls).toEqual([
+      {
+        kind: "adjust",
+        skuId: "sku-1",
+        oldQuantity: 2,
+        newQuantity: 5,
+      },
+    ]);
+    expect(repository.getItem("item-9")).toEqual(
+      expect.objectContaining({
+        quantity: 2,
+        price: 120,
+      }),
+    );
+    expect(repository.getSession("session-6")).toEqual(
+      expect.objectContaining({
+        updatedAt: 500,
+        expiresAt: 8_000,
+      }),
+    );
+    expect(repository.itemPatches).toEqual([]);
+    expect(repository.sessionPatches).toEqual([]);
+    expect(traceCalls).toEqual([]);
   });
 
   it("refuses to add a cart line when the active session has no drawer binding", async () => {
@@ -920,6 +1450,137 @@ describe("createPosSessionCommandService", () => {
     });
     expect(inventoryCalls).toEqual([]);
     expect(repository.items).toEqual([]);
+  });
+
+  it("refuses to add a cart line when the bound drawer is closing before inventory is called", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-17",
+          sessionNumber: "SES-017",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "closing",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-17",
+      staffProfileId: "cashier-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      productSku: "SKU-1",
+      productName: "Sneaker",
+      price: 120,
+      quantity: 2,
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message: "Open the cash drawer before modifying this sale.",
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.items).toEqual([]);
+    expect(repository.sessionPatches).toEqual([]);
+  });
+
+  it("refuses to update a cart line when the bound drawer belongs to another store before inventory is called", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-18",
+          sessionNumber: "SES-018",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-2",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-18",
+          sessionId: "session-18",
+          storeId: "store-1",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          productSku: "SKU-1",
+          productName: "Sneaker",
+          price: 120,
+          quantity: 2,
+        }),
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-18",
+      staffProfileId: "cashier-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      productSku: "SKU-1",
+      productName: "Sneaker",
+      price: 125,
+      quantity: 5,
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message: "Open the cash drawer before modifying this sale.",
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.getItem("item-18")).toEqual(
+      expect.objectContaining({
+        quantity: 2,
+        price: 120,
+      }),
+    );
+    expect(repository.itemPatches).toEqual([]);
+    expect(repository.sessionPatches).toEqual([]);
   });
 
   it("refuses to update a cart line when the bound drawer identity is mismatched", async () => {
@@ -1077,6 +1738,84 @@ describe("createPosSessionCommandService", () => {
     ]);
   });
 
+  it("does not delete a cart line, patch the session, or trace when inventory release fails", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-7",
+          sessionNumber: "SES-007",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-3",
+          sessionId: "session-7",
+          storeId: "store-1",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          productSku: "SKU-1",
+          productName: "Sneaker",
+          price: 120,
+          quantity: 3,
+        }),
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+    const traceCalls: TraceCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        traceCalls,
+        inventoryFailures: {
+          release: "inventory unavailable",
+        },
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).removeSessionItem({
+      sessionId: "session-7",
+      staffProfileId: "cashier-1",
+      itemId: "item-3",
+    });
+
+    expect(result).toEqual({
+      status: "inventoryUnavailable",
+      message: "inventory unavailable",
+    });
+    expect(inventoryCalls).toEqual([
+      { kind: "release", skuId: "sku-1", quantity: 3 },
+    ]);
+    expect(repository.getItem("item-3")).not.toBeNull();
+    expect(repository.getSession("session-7")).toEqual(
+      expect.objectContaining({
+        updatedAt: 500,
+        expiresAt: 8_000,
+      }),
+    );
+    expect(repository.sessionPatches).toEqual([]);
+    expect(traceCalls).toEqual([]);
+  });
+
   it("refuses to remove a cart line when the active session has no drawer binding", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
@@ -1193,6 +1932,93 @@ describe("createPosSessionCommandService", () => {
     expect(repository.getItem("item-14")).not.toBeNull();
   });
 
+  it.each([
+    {
+      label: "closing",
+      sessionId: "session-16",
+      itemId: "item-16",
+      drawer: buildRegisterSession({
+        _id: "drawer-1",
+        storeId: "store-1",
+        status: "closing",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+      }),
+    },
+    {
+      label: "wrong-store",
+      sessionId: "session-17",
+      itemId: "item-17",
+      drawer: buildRegisterSession({
+        _id: "drawer-1",
+        storeId: "store-2",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+      }),
+    },
+  ])(
+    "refuses to remove a cart line when the bound drawer is $label",
+    async ({ sessionId, itemId, drawer }) => {
+      const commandService = await loadCommandService();
+      const repository = createFakeRepository({
+        sessions: [
+          buildSession({
+            _id: sessionId,
+            sessionNumber: "SES-REMOVE",
+            storeId: "store-1",
+            terminalId: "terminal-1",
+            staffProfileId: "cashier-1",
+            status: "active",
+            registerNumber: "1",
+            registerSessionId: "drawer-1",
+            expiresAt: 8_000,
+            updatedAt: 500,
+          }),
+        ],
+        registerSessions: [drawer],
+        items: [
+          buildItem({
+            _id: itemId,
+            sessionId,
+            storeId: "store-1",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            productSku: "SKU-1",
+            productName: "Sneaker",
+            price: 120,
+            quantity: 3,
+          }),
+        ],
+      });
+      const inventoryCalls: InventoryCall[] = [];
+      const traceCalls: TraceCall[] = [];
+
+      const result = await commandService(
+        createDependencies({
+          repository,
+          inventoryCalls,
+          traceCalls,
+          now: 1_000,
+          nextExpiration: 61_000,
+        }),
+      ).removeSessionItem({
+        sessionId,
+        staffProfileId: "cashier-1",
+        itemId,
+      });
+
+      expect(result).toEqual({
+        status: "validationFailed",
+        message: "Open the cash drawer before modifying this sale.",
+      });
+      expect(inventoryCalls).toEqual([]);
+      expect(repository.getItem(itemId)).not.toBeNull();
+      expect(repository.sessionPatches).toEqual([]);
+      expect(traceCalls).toEqual([]);
+    },
+  );
+
   it("refuses to remove a cart line when the bound drawer identity is mismatched", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
@@ -1286,6 +2112,7 @@ function createDependencies(options: {
     traceCreated: boolean;
     traceId: string;
   };
+  inventoryFailures?: Partial<Record<InventoryCall["kind"], string>>;
 }) {
   return {
     now: () => options.now,
@@ -1294,6 +2121,10 @@ function createDependencies(options: {
     inventory: {
       acquireHold: async (skuId: string, quantity: number) => {
         options.inventoryCalls?.push({ kind: "acquire", skuId, quantity });
+        if (options.inventoryFailures?.acquire) {
+          return { success: false, message: options.inventoryFailures.acquire };
+        }
+
         return { success: true };
       },
       adjustHold: async (
@@ -1307,10 +2138,18 @@ function createDependencies(options: {
           oldQuantity,
           newQuantity,
         });
+        if (options.inventoryFailures?.adjust) {
+          return { success: false, message: options.inventoryFailures.adjust };
+        }
+
         return { success: true };
       },
       releaseHold: async (skuId: string, quantity: number) => {
         options.inventoryCalls?.push({ kind: "release", skuId, quantity });
+        if (options.inventoryFailures?.release) {
+          return { success: false, message: options.inventoryFailures.release };
+        }
+
         return { success: true };
       },
     },
@@ -1361,6 +2200,14 @@ function createFakeRepository(seed?: {
     sessions: [...(seed?.sessions ?? [])],
     items: [...(seed?.items ?? [])],
     registerSessions: [...(seed?.registerSessions ?? [])],
+    sessionPatches: [] as Array<{
+      sessionId: string;
+      patch: Partial<SessionRecord>;
+    }>,
+    itemPatches: [] as Array<{
+      itemId: string;
+      patch: Partial<SessionItemRecord>;
+    }>,
     getSession(sessionId: string) {
       return (
         repository.sessions.find((session) => session._id === sessionId) ?? null
@@ -1453,6 +2300,7 @@ function createFakeRepository(seed?: {
       return sessionId;
     },
     async patchSession(sessionId: string, patch: Partial<SessionRecord>) {
+      repository.sessionPatches.push({ sessionId, patch });
       const session = repository.getSession(sessionId);
       if (!session) {
         return;
@@ -1471,6 +2319,7 @@ function createFakeRepository(seed?: {
       return itemId;
     },
     async patchSessionItem(itemId: string, patch: Partial<SessionItemRecord>) {
+      repository.itemPatches.push({ itemId, patch });
       const item = repository.getItem(itemId);
       if (!item) {
         return;

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -185,6 +185,7 @@ export const voidTransaction = mutation({
 export const createTransactionFromSession = mutation({
   args: {
     sessionId: v.id("posSession"),
+    staffProfileId: v.id("staffProfile"),
     payments: v.array(paymentValidator),
     registerSessionId: v.optional(v.id("registerSession")),
     notes: v.optional(v.string()),

--- a/packages/athena-webapp/src/components/pos/SessionManager.test.tsx
+++ b/packages/athena-webapp/src/components/pos/SessionManager.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { SessionManager } from "./SessionManager";
@@ -107,5 +108,69 @@ describe("SessionManager", () => {
     expect(
       screen.queryByRole("link", { name: "View trace" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("disables hold and new-sale actions from panel state", async () => {
+    const onHoldCurrentSession = vi.fn();
+    const onStartNewSession = vi.fn();
+
+    render(
+      <SessionManager
+        sessionPanel={{
+          activeSessionNumber: "SES-001",
+          activeSessionTraceId: null,
+          hasExpiredSession: false,
+          canHoldSession: false,
+          disableNewSession: true,
+          heldSessions: [],
+          onHoldCurrentSession,
+          onVoidCurrentSession: vi.fn(),
+          onResumeSession: vi.fn(),
+          onVoidHeldSession: vi.fn(),
+          onStartNewSession,
+        }}
+      />,
+    );
+
+    const holdButton = screen.getByRole("button", { name: /hold/i });
+    const newSaleButton = screen.getByRole("button", { name: /new sale/i });
+
+    expect(holdButton).toBeDisabled();
+    expect(newSaleButton).toBeDisabled();
+
+    await userEvent.click(holdButton);
+    await userEvent.click(newSaleButton);
+
+    expect(onHoldCurrentSession).not.toHaveBeenCalled();
+    expect(onStartNewSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps held-sale resume controls hidden when no held sessions exist", () => {
+    render(
+      <SessionManager
+        sessionPanel={{
+          activeSessionNumber: null,
+          activeSessionTraceId: null,
+          hasExpiredSession: false,
+          canHoldSession: false,
+          disableNewSession: false,
+          heldSessions: [],
+          onHoldCurrentSession: vi.fn(),
+          onVoidCurrentSession: vi.fn(),
+          onResumeSession: vi.fn(),
+          onVoidHeldSession: vi.fn(),
+          onStartNewSession: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /hold/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /clear sale/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /resume sale/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /new sale/i })).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -146,7 +146,7 @@ describe("POSRegisterView", () => {
       sessionPanel: {},
       cashierCard: {},
       authDialog: {
-        open: true,
+        open: false,
       },
       drawerGate: null,
       onNavigateBack: vi.fn(),
@@ -161,7 +161,52 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
     expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
+    expect(screen.queryByText("cashier-auth-dialog")).not.toBeInTheDocument();
+  });
+
+  it("hides selling controls while cashier authentication is missing", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        customerName: undefined,
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: true,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: null,
+      cashierCard: null,
+      authDialog: {
+        open: true,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
     expect(screen.getByText("cashier-auth-dialog")).toBeInTheDocument();
+    expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
+    expect(screen.queryByText("register-customer-panel")).not.toBeInTheDocument();
+    expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
+    expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
+    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
   });
 
   it("renders expense completion UI in expense workflow without POS checkout controls", async () => {

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -113,15 +113,20 @@ export function POSRegisterView({
   );
   const hasProductSearchIntent =
     (viewModel.productEntry?.productSearchQuery ?? "").trim().length > 0;
+  const isAwaitingCashierAuth = Boolean(viewModel.authDialog?.open);
   const shouldShowPaymentWorkspace =
     isPosWorkflow && isPaymentInputActive && !hasProductSearchIntent;
   const canSearchProducts =
-    !viewModel.checkout.isTransactionCompleted && !viewModel.drawerGate;
+    !viewModel.checkout.isTransactionCompleted &&
+    !viewModel.drawerGate &&
+    !isAwaitingCashierAuth;
   const isHeaderProductSearchSupported =
     isSessionActive && canSearchProducts && !viewModel.productEntry.disabled;
-  const shouldRenderSaleSurface = !viewModel.checkout.isTransactionCompleted;
+  const shouldRenderSaleSurface =
+    !viewModel.checkout.isTransactionCompleted && !isAwaitingCashierAuth;
   const shouldRenderCheckoutPanel =
-    isPosWorkflow || !viewModel.checkout.isTransactionCompleted;
+    !isAwaitingCashierAuth &&
+    (isPosWorkflow || !viewModel.checkout.isTransactionCompleted);
 
   useEffect(() => {
     if (hasProductSearchIntent && isPaymentInputActive) {

--- a/packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx
+++ b/packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { HeldSessionsList } from "./HeldSessionsList";
@@ -40,6 +41,18 @@ vi.mock("~/src/hooks/useGetCurrencyFormatter", () => ({
 }));
 
 describe("HeldSessionsList", () => {
+  it("renders an empty held-sales state", () => {
+    render(
+      <HeldSessionsList
+        sessions={[]}
+        onResumeSession={vi.fn()}
+        onVoidSession={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No held sales")).toBeInTheDocument();
+  });
+
   it("renders a held-session trace link when the workflow trace id is present", () => {
     render(
       <HeldSessionsList
@@ -81,5 +94,91 @@ describe("HeldSessionsList", () => {
     );
 
     expect(screen.queryByRole("link", { name: "View trace" })).not.toBeInTheDocument();
+  });
+
+  it("renders customer, totals, hold reason, and action callbacks for held sales", async () => {
+    const onResumeSession = vi.fn();
+    const onVoidSession = vi.fn();
+
+    render(
+      <HeldSessionsList
+        sessions={[
+          {
+            _id: "session-3" as never,
+            cartItems: [
+              {
+                id: "item-1",
+                name: "Body Wave",
+                price: 125,
+                quantity: 2,
+              } as never,
+            ],
+            customer: {
+              name: "Ama Serwa",
+              email: "ama@example.com",
+              phone: "555-0100",
+            },
+            expiresAt: Date.now() + 10_000,
+            heldAt: Date.now(),
+            holdReason: "Customer checking another item",
+            sessionNumber: "SES-003",
+            total: 12_500,
+            updatedAt: Date.now(),
+            workflowTraceId: "pos_session:ses-003",
+          },
+        ]}
+        onResumeSession={onResumeSession}
+        onVoidSession={onVoidSession}
+      />,
+    );
+
+    expect(screen.getByText("Held sales")).toBeInTheDocument();
+    expect(screen.getByText("SES-003")).toBeInTheDocument();
+    expect(screen.getByText("Ama Serwa")).toBeInTheDocument();
+    expect(screen.getByText("2 items")).toBeInTheDocument();
+    expect(screen.getByText("$125.00")).toBeInTheDocument();
+    expect(
+      screen.getByText('"Customer checking another item"'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View trace" })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTitle("Resume sale"));
+    await userEvent.click(screen.getByTitle("Clear sale"));
+
+    expect(onResumeSession).toHaveBeenCalledWith("session-3");
+    expect(onVoidSession).toHaveBeenCalledWith("session-3");
+  });
+
+  it("marks expired held sales and disables resume without blocking clear", async () => {
+    const onResumeSession = vi.fn();
+    const onVoidSession = vi.fn();
+
+    render(
+      <HeldSessionsList
+        sessions={[
+          {
+            _id: "session-4" as never,
+            cartItems: [],
+            expiresAt: Date.now() - 10_000,
+            heldAt: Date.now() - 20_000,
+            sessionNumber: "SES-004",
+            updatedAt: Date.now() - 20_000,
+          },
+        ]}
+        onResumeSession={onResumeSession}
+        onVoidSession={onVoidSession}
+      />,
+    );
+
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+
+    const resumeButton = screen.getByTitle("Resume sale");
+    expect(resumeButton).toBeDisabled();
+
+    await userEvent.click(resumeButton);
+    await userEvent.click(screen.getByTitle("Clear sale"));
+
+    expect(onResumeSession).not.toHaveBeenCalled();
+    expect(onVoidSession).toHaveBeenCalledWith("session-4");
   });
 });

--- a/packages/athena-webapp/src/lib/errors/operatorMessages.test.ts
+++ b/packages/athena-webapp/src/lib/errors/operatorMessages.test.ts
@@ -14,4 +14,39 @@ describe("toOperatorMessage", () => {
       toOperatorMessage("Barcode not found. Scan again or search by name."),
     ).toBe("Barcode not found. Scan again or search by name.");
   });
+
+  it.each([
+    [
+      "Open the cash drawer before starting a sale.",
+      "Drawer closed. Open the drawer before starting a sale.",
+    ],
+    [
+      "Open the cash drawer before resuming this sale.",
+      "Drawer closed. Open the drawer before resuming this sale.",
+    ],
+    [
+      "Open the cash drawer before recovering this sale.",
+      "Drawer closed. Open the drawer before continuing this sale.",
+    ],
+    [
+      "Open the cash drawer before modifying this sale.",
+      "Drawer closed. Open the drawer before updating this sale.",
+    ],
+    [
+      "Open the cash drawer before completing this sale.",
+      "Drawer closed. Open the drawer before completing this sale.",
+    ],
+    [
+      "This sale is already assigned to a different cash drawer.",
+      "Sale assigned to a different drawer. Open that drawer before continuing.",
+    ],
+  ])("normalizes POS drawer command copy: %s", (backendMessage, operatorCopy) => {
+    expect(toOperatorMessage(backendMessage)).toBe(operatorCopy);
+  });
+
+  it("normalizes backend phrasing despite case and whitespace drift", () => {
+    expect(
+      toOperatorMessage("  open the cash drawer before completing this sale  "),
+    ).toBe("Drawer closed. Open the drawer before completing this sale.");
+  });
 });

--- a/packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts
+++ b/packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, it } from "vitest";
 
 import { bootstrapRegister } from "./useCases/bootstrapRegister";
+import type { PosCashDrawerDto, PosRegisterStateDto } from "./dto";
+
+const terminal = { _id: "terminal-1", displayName: "Front Counter" };
+const cashier = { _id: "cashier-1", firstName: "Ama", lastName: "K" };
+
+function drawer(
+  overrides: Partial<PosCashDrawerDto> = {},
+): PosCashDrawerDto {
+  return {
+    _id: "drawer-1" as PosCashDrawerDto["_id"],
+    status: "open",
+    openingFloat: 5000,
+    expectedCash: 5000,
+    openedAt: 1710000000000,
+    registerNumber: "A1",
+    ...overrides,
+  };
+}
+
+function state(
+  overrides: Partial<PosRegisterStateDto>,
+): PosRegisterStateDto {
+  return {
+    phase: "readyToStart",
+    terminal,
+    cashier,
+    activeRegisterSession: null,
+    activeSession: null,
+    resumableSession: null,
+    ...overrides,
+  };
+}
 
 describe("bootstrapRegister", () => {
   it("returns requiresCashier when terminal exists but no cashier is authenticated", () => {
@@ -16,8 +48,85 @@ describe("bootstrapRegister", () => {
     });
 
     expect(state).toBeDefined();
-    expect(
-      state?.phase,
-    ).toBe("requiresCashier");
+    expect(state?.phase).toBe("requiresCashier");
+    expect(state?.canStartSession).toBe(false);
+    expect(state?.canResumeSession).toBe(false);
+  });
+
+  it.each([
+    {
+      phase: "readyToStart" as const,
+      activeRegisterSession: drawer(),
+      expected: { canStartSession: true, canResumeSession: false },
+    },
+    {
+      phase: "readyToStart" as const,
+      activeRegisterSession: null,
+      expected: { canStartSession: false, canResumeSession: false },
+    },
+    {
+      phase: "resumable" as const,
+      activeRegisterSession: drawer(),
+      resumableSession: { _id: "session-1", sessionNumber: "POS-001" },
+      expected: { canStartSession: false, canResumeSession: true },
+    },
+    {
+      phase: "resumable" as const,
+      activeRegisterSession: null,
+      resumableSession: { _id: "session-1", sessionNumber: "POS-001" },
+      expected: { canStartSession: false, canResumeSession: false },
+    },
+  ])(
+    "derives start/resume permissions for $phase with active drawer $activeRegisterSession",
+    ({ expected, ...registerState }) => {
+      const result = bootstrapRegister({
+        registerState: state(registerState),
+      });
+
+      expect(result).toMatchObject(expected);
+    },
+  );
+
+  it.each([
+    { phase: "requiresCashier" as const },
+    {
+      phase: "active" as const,
+      activeSession: { _id: "session-1", sessionNumber: "POS-001" },
+    },
+  ])("does not enable session actions while phase is $phase", (overrides) => {
+    const result = bootstrapRegister({
+      registerState: state({
+        activeRegisterSession: drawer(),
+        ...overrides,
+      }),
+    });
+
+    expect(result?.canStartSession).toBe(false);
+    expect(result?.canResumeSession).toBe(false);
+  });
+
+  it.each([
+    { phase: "readyToStart" as const, expected: "canStartSession" as const },
+    {
+      phase: "resumable" as const,
+      resumableSession: { _id: "session-1", sessionNumber: "POS-001" },
+      expected: "canResumeSession" as const,
+    },
+  ])(
+    "does not treat a closing drawer as available for $phase",
+    ({ expected, ...registerState }) => {
+      const result = bootstrapRegister({
+        registerState: state({
+          activeRegisterSession: drawer({ status: "closing" }),
+          ...registerState,
+        }),
+      });
+
+      expect(result?.[expected]).toBe(false);
+    },
+  );
+
+  it("returns undefined while register state is still loading", () => {
+    expect(bootstrapRegister({ registerState: undefined })).toBeUndefined();
   });
 });

--- a/packages/athena-webapp/src/lib/pos/application/dto.ts
+++ b/packages/athena-webapp/src/lib/pos/application/dto.ts
@@ -193,6 +193,7 @@ export interface PosPaymentDto {
 
 export interface PosCompleteTransactionInput {
   sessionId: Id<"posSession">;
+  staffProfileId: Id<"staffProfile">;
   payments: PosPaymentDto[];
   notes?: string;
   subtotal: number;

--- a/packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts
+++ b/packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts
@@ -12,14 +12,16 @@ export function bootstrapRegister(input: {
     return undefined;
   }
 
+  const hasUsableRegisterSession =
+    registerState.activeRegisterSession?.status === "open" ||
+    registerState.activeRegisterSession?.status === "active";
+
   return {
     phase: registerState.phase,
     canStartSession:
-      registerState.phase === "readyToStart" &&
-      Boolean(registerState.activeRegisterSession),
+      registerState.phase === "readyToStart" && hasUsableRegisterSession,
     canResumeSession:
-      registerState.phase === "resumable" &&
-      Boolean(registerState.activeRegisterSession),
+      registerState.phase === "resumable" && hasUsableRegisterSession,
     terminal: registerState.terminal,
     cashier: registerState.cashier,
     activeRegisterSession: registerState.activeRegisterSession,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts
@@ -46,6 +46,7 @@ export function useConvexCommandGateway(): PosCommandGateway {
     ): Promise<PosCompleteTransactionResultDto> {
       return completeSessionMutation({
         sessionId: input.sessionId,
+        staffProfileId: input.staffProfileId,
         payments: input.payments,
         notes: input.notes,
         subtotal: input.subtotal,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts
@@ -16,4 +16,39 @@ describe("mapRegisterStateDto", () => {
     expect(state.phase).toBe("readyToStart");
     expect(state.terminal?.displayName).toBe("Front Counter");
   });
+
+  it("preserves active drawer visibility and resumable session identity", () => {
+    const state = mapRegisterStateDto({
+      phase: "resumable",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "cashier-1", firstName: "Ama", lastName: "K" },
+      activeRegisterSession: {
+        _id: "drawer-1" as never,
+        status: "closing",
+        registerNumber: "A1",
+        openingFloat: 5000,
+        expectedCash: 5000,
+        openedAt: 1710000000000,
+      },
+      activeSession: null,
+      resumableSession: {
+        _id: "session-1",
+        sessionNumber: "POS-001",
+        registerSessionId: "drawer-1",
+      },
+    });
+
+    expect(state.activeRegisterSession).toEqual(
+      expect.objectContaining({
+        _id: "drawer-1",
+        status: "closing",
+      }),
+    );
+    expect(state.resumableSession).toEqual(
+      expect.objectContaining({
+        _id: "session-1",
+        registerSessionId: "drawer-1",
+      }),
+    );
+  });
 });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts
@@ -1,11 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ok, userError } from "~/shared/commandResult";
 import {
   mapActiveSessionDto,
   mapHeldSessionsDto,
 } from "./sessionGateway.mapper";
+import { useConvexSessionActions } from "./sessionGateway";
+
+const { mockUseMutation } = vi.hoisted(() => ({
+  mockUseMutation: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: (...args: unknown[]) => mockUseMutation(...args),
+  useQuery: vi.fn(),
+}));
 
 describe("mapActiveSessionDto", () => {
+  beforeEach(() => {
+    mockUseMutation.mockReset();
+  });
+
   it("normalizes raw session cart items into the shared cart item shape", () => {
     const session = mapActiveSessionDto({
       _id: "session-1",
@@ -65,6 +80,53 @@ describe("mapActiveSessionDto", () => {
         quantity: 1,
       }),
     ]);
+  });
+
+  it("carries drawer, customer profile, payment, and checkout state fields", () => {
+    const session = mapActiveSessionDto({
+      _id: "session-1",
+      _creationTime: 1,
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      staffProfileId: "staff-1",
+      status: "active",
+      registerNumber: "REG-1",
+      registerSessionId: "drawer-1",
+      sessionNumber: "SES-001",
+      customerId: "customer-1",
+      customerProfileId: "profile-1",
+      subtotal: 120,
+      tax: 0,
+      total: 120,
+      payments: [{ method: "cash", amount: 120, timestamp: 1_000 }],
+      checkoutStateVersion: 3,
+      holdReason: undefined,
+      expiresAt: 10_000,
+      completedAt: undefined,
+      transactionId: undefined,
+      heldAt: undefined,
+      holdExpiresAt: undefined,
+      notes: undefined,
+      createdAt: 1,
+      updatedAt: 2,
+      customer: {
+        name: "Ama K",
+        customerProfileId: "profile-1",
+      },
+      cartItems: [],
+    } as never);
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        registerSessionId: "drawer-1",
+        customerProfileId: "profile-1",
+        payments: [{ method: "cash", amount: 120, timestamp: 1_000 }],
+        checkoutStateVersion: 3,
+        customer: expect.objectContaining({
+          customerProfileId: "profile-1",
+        }),
+      }),
+    );
   });
 });
 
@@ -127,5 +189,136 @@ describe("mapHeldSessionsDto", () => {
         barcode: "",
       }),
     ]);
+  });
+});
+
+describe("useConvexSessionActions", () => {
+  beforeEach(() => {
+    mockUseMutation.mockReset();
+  });
+
+  it("normalizes resume command results while preserving register session payloads", async () => {
+    const resumeSessionMutation = vi.fn().mockResolvedValue(
+      ok({
+        sessionId: "session-1",
+        registerSessionId: "drawer-1",
+        expiresAt: 10_000,
+      }),
+    );
+    mockUseMutation.mockReturnValue(vi.fn());
+    mockUseMutation.mockReturnValueOnce(resumeSessionMutation);
+
+    const actions = useConvexSessionActions();
+    const result = await actions.resumeSession({
+      sessionId: "session-1",
+      staffProfileId: "staff-1",
+      registerSessionId: "drawer-1",
+    } as never);
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        sessionId: "session-1",
+        registerSessionId: "drawer-1",
+        expiresAt: 10_000,
+      },
+    });
+    expect(resumeSessionMutation).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      staffProfileId: "staff-1",
+      registerSessionId: "drawer-1",
+    });
+  });
+
+  it("normalizes recover/bind command failures without throwing", async () => {
+    const bindSessionMutation = vi.fn().mockResolvedValue(
+      userError({
+        code: "precondition_failed",
+        message: "Open the cash drawer before recovering this sale.",
+      }),
+    );
+    mockUseMutation.mockReturnValue(vi.fn());
+    mockUseMutation
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(bindSessionMutation);
+
+    const actions = useConvexSessionActions();
+    const result = await actions.bindSessionToRegisterSession({
+      sessionId: "session-1",
+      staffProfileId: "staff-1",
+      registerSessionId: "drawer-1",
+    } as never);
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Open the cash drawer before recovering this sale.",
+      },
+    });
+  });
+
+  it("preserves checkout sync payload fields from modify command results", async () => {
+    const syncSessionCheckoutStateMutation = vi.fn().mockResolvedValue(
+      ok({
+        sessionId: "session-1",
+        payments: [{ method: "card", amount: 120, timestamp: 1_000 }],
+        checkoutStateVersion: 4,
+        customerProfileId: "profile-1",
+        expiresAt: 10_000,
+      }),
+    );
+    mockUseMutation.mockReturnValue(vi.fn());
+    mockUseMutation
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(syncSessionCheckoutStateMutation);
+
+    const actions = useConvexSessionActions();
+    const result = await actions.syncSessionCheckoutState({
+      sessionId: "session-1",
+      staffProfileId: "staff-1",
+      payments: [{ method: "card", amount: 120, timestamp: 1_000 }],
+      checkoutStateVersion: 4,
+    } as never);
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        sessionId: "session-1",
+        payments: [{ method: "card", amount: 120, timestamp: 1_000 }],
+        checkoutStateVersion: 4,
+        customerProfileId: "profile-1",
+        expiresAt: 10_000,
+      },
+    });
+  });
+
+  it("normalizes thrown command faults to unexpected errors", async () => {
+    const removeItemMutation = vi.fn().mockRejectedValue(new Error("boom"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockUseMutation.mockReturnValue(vi.fn());
+    mockUseMutation
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(removeItemMutation);
+
+    const actions = useConvexSessionActions();
+    const result = await actions.removeItem({ itemId: "item-1" } as never);
+
+    expect(result).toEqual({
+      kind: "unexpected_error",
+      error: {
+        title: "Something went wrong",
+        message: "Please try again.",
+        traceId: undefined,
+      },
+    });
   });
 });

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -751,6 +751,68 @@ describe("useRegisterViewModel", () => {
     expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
   });
 
+  it("keeps a preserved sale gated when drawer recovery binding fails", async () => {
+    mockRegisterState = {
+      phase: "active",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: { _id: "session-1", sessionNumber: "POS-0001" },
+      resumableSession: null,
+    };
+    mockActiveSession = {
+      ...mockActiveSession!,
+      registerSessionId: undefined,
+      payments: [{ method: "cash", amount: 120, timestamp: 1_000 }],
+    };
+    mockBindSessionToRegisterSession.mockResolvedValueOnce(
+      userError({
+        code: "conflict",
+        message: "This sale is already bound to another drawer.",
+      }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result, rerender } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    mockRegisterState = {
+      ...mockRegisterState,
+      activeRegisterSession: {
+        _id: "drawer-2",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+    };
+
+    await act(async () => {
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(result.current.drawerGate?.errorMessage).toBe(
+        "This sale is already bound to another drawer.",
+      );
+    });
+    expect(result.current.drawerGate?.mode).toBe("recovery");
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(result.current.checkout.payments).toEqual([
+      expect.objectContaining({ method: "cash", amount: 120 }),
+    ]);
+    expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
   it("keeps the operator on the drawer gate when opening the drawer fails", async () => {
     mockRegisterState = {
       phase: "readyToStart",
@@ -790,6 +852,37 @@ describe("useRegisterViewModel", () => {
       "Drawer already open for this register. Return to the active sale or review it in Cash Controls.",
     );
     expect(toast.error).not.toHaveBeenCalled();
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
+  it("validates the drawer opening float before sending an open-drawer command", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+
+    expect(result.current.drawerGate?.errorMessage).toBe(
+      "Opening float required. Enter an amount greater than 0.",
+    );
+    expect(mockOpenDrawer).not.toHaveBeenCalled();
     expect(mockStartSession).not.toHaveBeenCalled();
   });
 
@@ -976,6 +1069,81 @@ describe("useRegisterViewModel", () => {
     );
   });
 
+  it("keeps local payment draft state but skips payment sync while drawer recovery is required", async () => {
+    mockRegisterState = {
+      phase: "active",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: { _id: "session-1", sessionNumber: "POS-0001" },
+      resumableSession: null,
+    };
+    mockActiveSession = {
+      ...mockActiveSession!,
+      registerSessionId: undefined,
+    };
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.checkout.onAddPayment("cash", 120);
+    });
+
+    expect(result.current.checkout.payments).toEqual([
+      expect.objectContaining({ method: "cash", amount: 120 }),
+    ]);
+    expect(mockSyncSessionCheckoutState).not.toHaveBeenCalled();
+  });
+
+  it("blocks cart mutation handlers while drawer recovery is required", async () => {
+    mockRegisterState = {
+      phase: "active",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: { _id: "session-1", sessionNumber: "POS-0001" },
+      resumableSession: null,
+    };
+    mockActiveSession = {
+      ...mockActiveSession!,
+      registerSessionId: undefined,
+    };
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.cart.onUpdateQuantity(
+        "item-1" as Id<"posSessionItem">,
+        2,
+      );
+      await result.current.cart.onRemoveItem(
+        "item-1" as Id<"posSessionItem">,
+      );
+      await result.current.cart.onClearCart();
+    });
+
+    expect(mockAddItem).not.toHaveBeenCalled();
+    expect(mockRemoveItem).not.toHaveBeenCalled();
+    expect(mockReleaseSessionInventoryHoldsAndDeleteItems).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Drawer closed. Open the drawer before updating this sale.",
+    );
+  });
+
   it("keeps back-to-back payment additions in sync with the latest checkout state", async () => {
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -1074,6 +1242,150 @@ describe("useRegisterViewModel", () => {
       }),
     );
     expect(mockCompleteTransaction).toHaveBeenCalled();
+  });
+
+  it("keeps the sale editable when completion fails", async () => {
+    mockCompleteTransaction.mockResolvedValueOnce(
+      userError({
+        code: "conflict",
+        message: "Open the cash drawer before completing this sale.",
+      }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.checkout.onAddPayment("cash", 120);
+    });
+
+    let completed = true;
+    await act(async () => {
+      completed = await result.current.checkout.onCompleteTransaction();
+    });
+
+    expect(completed).toBe(false);
+    expect(result.current.checkout.isTransactionCompleted).toBe(false);
+    expect(result.current.checkout.completedOrderNumber).toBeNull();
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(result.current.checkout.payments).toEqual([
+      expect.objectContaining({ method: "cash", amount: 120 }),
+    ]);
+    expect(result.current.productEntry.disabled).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith(
+      "Drawer closed. Open the drawer before completing this sale.",
+    );
+  });
+
+  it("keeps draft state when holding the current sale fails", async () => {
+    mockActiveSession = {
+      ...mockActiveSession!,
+      payments: [{ method: "card", amount: 120, timestamp: 1_000 }],
+    };
+    mockHoldSession.mockResolvedValueOnce(
+      userError({
+        code: "conflict",
+        message: "Unable to hold this sale right now.",
+      }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.productEntry.setProductSearchQuery("body wave");
+    });
+
+    await act(async () => {
+      await result.current.sessionPanel?.onHoldCurrentSession();
+    });
+
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(result.current.checkout.payments).toEqual([
+      expect.objectContaining({ method: "card", amount: 120 }),
+    ]);
+    expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
+    expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
+    expect(result.current.productEntry.productSearchQuery).toBe("body wave");
+    expect(toast.success).not.toHaveBeenCalledWith("Sale placed on hold.");
+  });
+
+  it("keeps draft state and does not start a new sale when auto-hold fails", async () => {
+    mockHoldSession.mockResolvedValueOnce(
+      userError({
+        code: "conflict",
+        message: "Unable to hold this sale right now.",
+      }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.sessionPanel?.onStartNewSession();
+    });
+
+    expect(mockStartSession).not.toHaveBeenCalled();
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
+    expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
+  });
+
+  it("keeps draft state and does not resume another sale when auto-hold fails", async () => {
+    mockHeldSessions = [
+      {
+        _id: "session-2" as Id<"posSession">,
+        expiresAt: Date.now() + 60_000,
+        sessionNumber: "POS-0002",
+        updatedAt: Date.now(),
+        cartItems: [],
+        customer: null,
+      },
+    ];
+    mockHoldSession.mockResolvedValueOnce(
+      userError({
+        code: "conflict",
+        message: "Unable to hold this sale right now.",
+      }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.sessionPanel?.onResumeSession(
+        "session-2" as Id<"posSession">,
+      );
+    });
+
+    expect(mockResumeSession).not.toHaveBeenCalled();
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
+    expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
   });
 
   it("commits customer changes through the session update path", async () => {
@@ -1285,6 +1597,95 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(mockUpdateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply queued customer attribution commits to the previous active session", async () => {
+    const firstUpdate = deferred<ReturnType<typeof ok>>();
+    mockUpdateSession
+      .mockReset()
+      .mockImplementationOnce(() => firstUpdate.promise)
+      .mockResolvedValue(
+        ok({
+          sessionId: "session-2" as Id<"posSession">,
+          expiresAt: Date.now() + 60_000,
+        }),
+      );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result, rerender } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    let firstCommit!: Promise<void>;
+    await act(async () => {
+      firstCommit = result.current.customerPanel.onCustomerCommitted({
+        customerProfileId: "profile-2" as Id<"customerProfile">,
+        name: "Efua Mensah",
+        email: "efua@example.com",
+        phone: "555-2222",
+      });
+      await Promise.resolve();
+    });
+
+    expect(mockUpdateSession).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSession).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sessionId: "session-1",
+        customerProfileId: "profile-2",
+      }),
+    );
+
+    mockActiveSession = {
+      ...mockActiveSession!,
+      _id: "session-2" as Id<"posSession">,
+      sessionNumber: "SES-002",
+    };
+
+    await act(async () => {
+      rerender();
+    });
+
+    let secondCommit!: Promise<void>;
+    await act(async () => {
+      secondCommit = result.current.customerPanel.onCustomerCommitted({
+        customerProfileId: "profile-3" as Id<"customerProfile">,
+        name: "Kofi Boateng",
+        email: "kofi@example.com",
+        phone: "555-3333",
+      });
+      await Promise.resolve();
+    });
+
+    firstUpdate.resolve(
+      ok({
+        sessionId: "session-1" as Id<"posSession">,
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.all([firstCommit, secondCommit]);
+    });
+
+    expect(mockUpdateSession).toHaveBeenCalledTimes(2);
+    expect(mockUpdateSession).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sessionId: "session-2",
+        customerProfileId: "profile-3",
+      }),
+    );
+    expect(mockUpdateSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        customerProfileId: "profile-3",
+      }),
+    );
   });
 
   it("commits name-only attribution as sale-only customer info without customer ids", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1421,7 +1421,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleCompleteTransaction = useCallback(async () => {
-    if (!activeSession) {
+    if (!activeSession || !staffProfileId) {
       toast.error("No sale in progress. Start a sale before taking payment.");
       return false;
     }
@@ -1439,6 +1439,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       },
       command: {
         sessionId: activeSession._id as Id<"posSession">,
+        staffProfileId,
         payments: currentPayments.map((payment) => ({
           method: payment.method,
           amount: payment.amount,


### PR DESCRIPTION
## Summary
- Adds the POS session workflow hardening spec and implements the full V26-399 through V26-406 test batch.
- Expands command, Convex mutation, register bootstrap, gateway, view-model, shell, held-session, and checkout-completion coverage.
- Fixes production issues exposed by the new tests/review: failed inventory hold releases now stop item removal, closing drawers no longer enable register start/resume, auth dialogs hard-gate the sale surface, and session checkout now requires the owning cashier before transaction side effects.
- Refreshes graphify outputs after code changes.

## Why
POS session state sits across cashier auth, drawer state, held sessions, inventory holds, checkout sync, and trace emission. This hardens the workflow before production by pinning the race boundaries, side-effect ordering, cashier ownership checks, and operator-facing error normalization that would otherwise be easy to regress.

## Validation
- `bun run --filter '@athena/webapp' test -- convex/pos/application/sessionCommands.test.ts convex/inventory/posSessions.trace.test.ts convex/pos/application/completeTransaction.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx`
- `bun run --filter '@athena/webapp' test -- convex/pos/application/sessionCommands.test.ts convex/inventory/posSessions.trace.test.ts convex/pos/application/completeTransaction.test.ts convex/pos/application/getRegisterState.test.ts convex/operations/registerSessions.trace.test.ts shared/registerSessionStatus.test.ts src/lib/pos/application/bootstrapRegister.test.ts src/lib/pos/infrastructure/convex/sessionGateway.test.ts src/lib/pos/infrastructure/convex/registerGateway.test.ts src/lib/errors/operatorMessages.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx src/components/pos/SessionManager.test.tsx src/components/pos/session/HeldSessionsList.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild`
- `bun run harness:check`
- `bun run harness:review`

Linear: https://linear.app/yaegars/issue/V26-399, https://linear.app/yaegars/issue/V26-400, https://linear.app/yaegars/issue/V26-401, https://linear.app/yaegars/issue/V26-402, https://linear.app/yaegars/issue/V26-403, https://linear.app/yaegars/issue/V26-404, https://linear.app/yaegars/issue/V26-405, https://linear.app/yaegars/issue/V26-406
