### PR TITLE
fix(webapp): polish cash controls and POS receipts

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1536 files · ~0 words
+- 1540 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3975 nodes · 3544 edges · 1451 communities detected
+- 3985 nodes · 3553 edges · 1455 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1461,6 +1461,10 @@
 - [[_COMMUNITY_Community 1448|Community 1448]]
 - [[_COMMUNITY_Community 1449|Community 1449]]
 - [[_COMMUNITY_Community 1450|Community 1450]]
+- [[_COMMUNITY_Community 1451|Community 1451]]
+- [[_COMMUNITY_Community 1452|Community 1452]]
+- [[_COMMUNITY_Community 1453|Community 1453]]
+- [[_COMMUNITY_Community 1454|Community 1454]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1561,36 +1565,36 @@ Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
 ### Community 18 - "Community 18"
+Cohesion: 0.16
+Nodes (12): applyCommandResult(), buildDepositSubmissionKey(), buildLifecycleRows(), canOpenTransaction(), formatCurrency(), formatRegisterHeaderName(), formatRegisterName(), formatStaffByline() (+4 more)
+
+### Community 19 - "Community 19"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.26
 Nodes (15): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername(), getStaffCredentialByStaffProfileIdWithCtx() (+7 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.21
 Nodes (12): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionTransactionPatch() (+4 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
-
-### Community 25 - "Community 25"
-Cohesion: 0.17
-Nodes (8): applyCommandResult(), buildDepositSubmissionKey(), canOpenTransaction(), formatRegisterHeaderName(), formatRegisterName(), handleRecordDeposit(), openTransaction(), trimOptional()
 
 ### Community 26 - "Community 26"
 Cohesion: 0.21
@@ -1609,16 +1613,16 @@ Cohesion: 0.13
 Nodes (1): DataTableColumnHeader()
 
 ### Community 30 - "Community 30"
-Cohesion: 0.18
-Nodes (5): applyCommandResult(), formatStoredAmountForInput(), handleReviewCloseout(), handleSubmitCloseout(), trimOptional()
-
-### Community 31 - "Community 31"
 Cohesion: 0.28
 Nodes (12): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix() (+4 more)
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.2
+Nodes (5): applyCommandResult(), formatStoredAmountForInput(), handleReviewCloseout(), handleSubmitCloseout(), trimOptional()
 
 ### Community 33 - "Community 33"
 Cohesion: 0.18
@@ -1737,68 +1741,68 @@ Cohesion: 0.28
 Nodes (3): modifyProduct(), onSubmit(), saveProduct()
 
 ### Community 62 - "Community 62"
+Cohesion: 0.25
+Nodes (2): formatCurrency(), SummaryStrip()
+
+### Community 63 - "Community 63"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.33
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
-
-### Community 72 - "Community 72"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 73 - "Community 73"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 74 - "Community 74"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 75 - "Community 75"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.36
 Nodes (4): buildPendingSkuContextById(), listPurchaseOrderLineItems(), listReplenishmentRecommendationsWithCtx(), listStoreProductSkus()
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
-
-### Community 77 - "Community 77"
-Cohesion: 0.29
-Nodes (2): formatCurrency(), SummaryStrip()
 
 ### Community 78 - "Community 78"
 Cohesion: 0.32
@@ -1909,16 +1913,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 105 - "Community 105"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 106 - "Community 106"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 107 - "Community 107"
+### Community 106 - "Community 106"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 107 - "Community 107"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 108 - "Community 108"
 Cohesion: 0.52
@@ -1981,16 +1985,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 123 - "Community 123"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 124 - "Community 124"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 125 - "Community 125"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 126 - "Community 126"
 Cohesion: 0.33
@@ -2005,16 +2009,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 129 - "Community 129"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 130 - "Community 130"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 131 - "Community 131"
+### Community 130 - "Community 130"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
+
+### Community 131 - "Community 131"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 132 - "Community 132"
 Cohesion: 0.33
@@ -2025,36 +2029,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 134 - "Community 134"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 135 - "Community 135"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 136 - "Community 136"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 141 - "Community 141"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 142 - "Community 142"
 Cohesion: 0.53
@@ -2134,7 +2138,7 @@ Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 162 - "Community 162"
 Cohesion: 0.4
@@ -2145,12 +2149,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 164 - "Community 164"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 165 - "Community 165"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 165 - "Community 165"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 166 - "Community 166"
 Cohesion: 0.4
@@ -2162,7 +2166,7 @@ Nodes (0):
 
 ### Community 168 - "Community 168"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 169 - "Community 169"
 Cohesion: 0.6
@@ -2429,24 +2433,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 235 - "Community 235"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 236 - "Community 236"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 238 - "Community 238"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 239 - "Community 239"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 239 - "Community 239"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 240 - "Community 240"
 Cohesion: 0.5
@@ -2457,40 +2461,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 242 - "Community 242"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 243 - "Community 243"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 250 - "Community 250"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 0.5
@@ -2517,51 +2521,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 257 - "Community 257"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 258 - "Community 258"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 263 - "Community 263"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 264 - "Community 264"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 265 - "Community 265"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 266 - "Community 266"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 267 - "Community 267"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 268 - "Community 268"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 269 - "Community 269"
@@ -2605,44 +2609,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 279 - "Community 279"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 280 - "Community 280"
 Cohesion: 1.0
 Nodes (2): buildRegisterState(), getRegisterState()
 
-### Community 280 - "Community 280"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 281 - "Community 281"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 282 - "Community 282"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 284 - "Community 284"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 285 - "Community 285"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 285 - "Community 285"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 287 - "Community 287"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 288 - "Community 288"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 288 - "Community 288"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.67
@@ -2653,32 +2657,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 291 - "Community 291"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 294 - "Community 294"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 295 - "Community 295"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 296 - "Community 296"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 297 - "Community 297"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
@@ -2693,16 +2697,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 303 - "Community 303"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.67
@@ -2710,11 +2714,11 @@ Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 306 - "Community 306"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.67
@@ -2722,19 +2726,19 @@ Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 310 - "Community 310"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 311 - "Community 311"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 311 - "Community 311"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
@@ -7292,6 +7296,22 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1451 - "Community 1451"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1452 - "Community 1452"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1453 - "Community 1453"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1454 - "Community 1454"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **Thin community `Community 416`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -7403,1053 +7423,1053 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 470`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 471`** (2 nodes): `currencyFormatter()`, `currencyFormatter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 472`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 473`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 474`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 475`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 476`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 477`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 478`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 479`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 480`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 481`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 482`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 483`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 484`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 485`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 486`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 487`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 488`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 489`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 490`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 491`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 492`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 493`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 494`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 495`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 496`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 497`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 498`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 499`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 500`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 501`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 502`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 503`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 504`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 505`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 506`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 507`** (2 nodes): `CashControlsWorkspaceHeader()`, `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 508`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 509`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 510`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 511`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 512`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 513`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 514`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 515`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 516`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 517`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 518`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 519`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 520`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 521`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 522`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 523`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 524`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 525`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 526`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 527`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 528`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 529`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 530`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 531`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 532`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 533`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 534`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 535`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 536`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 537`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 538`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 539`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 540`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 541`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 542`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 543`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 544`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 545`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 546`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 547`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 548`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 549`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 550`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 551`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 552`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 553`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 554`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 555`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 556`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 557`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 558`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 559`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 560`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 561`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 562`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 563`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 564`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 565`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 566`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 567`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 568`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 569`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 570`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 571`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 572`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 573`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 574`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 575`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 576`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 577`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 578`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 579`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 580`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 581`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 582`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 583`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 584`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 585`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 586`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 587`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 588`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 589`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 590`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 591`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 592`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 593`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 594`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 595`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 596`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 597`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 598`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 599`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 600`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 601`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 602`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 603`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 604`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 605`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 606`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 607`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 608`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 609`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 610`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 611`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 612`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 613`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 614`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 615`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 616`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 617`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 618`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 619`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 620`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 621`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 622`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 623`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 624`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 625`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 626`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
+- **Thin community `Community 627`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 628`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 629`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 630`** (2 nodes): `presentCommandToast.ts`, `presentCommandToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 631`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 632`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 633`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 634`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 635`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
+- **Thin community `Community 636`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 637`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 638`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 639`** (2 nodes): `useRegisterViewModel.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 640`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 641`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 642`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 643`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 644`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 645`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 646`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 647`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 648`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 649`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 650`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 651`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 652`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 653`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 654`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 655`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 656`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 657`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 658`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 659`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 660`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 661`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 662`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 663`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 664`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 665`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 666`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 667`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 668`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 669`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 670`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 671`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 672`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 673`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 674`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 675`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 676`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 677`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 678`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 679`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 680`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 681`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 682`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 683`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 684`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 685`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 686`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 687`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 688`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 689`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 690`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 691`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 692`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 693`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 694`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 695`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 696`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 697`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 698`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 699`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 700`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 701`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 702`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 703`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 704`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 705`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 706`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 707`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 708`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 709`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 710`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 711`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 712`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 713`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 714`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 715`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 716`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 717`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 718`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 719`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 720`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 721`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 722`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 723`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 724`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 725`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 726`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 727`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 728`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 729`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 730`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 731`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 732`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 733`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 734`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 735`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 736`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 737`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 738`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 739`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 740`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 741`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 742`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 743`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 744`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 745`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 746`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 747`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 748`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 749`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 750`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 751`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 752`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 753`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 754`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 755`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 756`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 757`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 758`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 759`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 760`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 761`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 762`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 763`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 764`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 765`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 766`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 767`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 768`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 769`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 770`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 771`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 772`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 773`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 774`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 775`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `api.d.ts`
+- **Thin community `Community 776`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `api.js`
+- **Thin community `Community 777`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 778`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `server.d.ts`
+- **Thin community `Community 779`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `server.js`
+- **Thin community `Community 780`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `app.ts`
+- **Thin community `Community 781`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `auth.config.js`
+- **Thin community `Community 782`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `auth.ts`
+- **Thin community `Community 783`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 784`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 785`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `countries.ts`
+- **Thin community `Community 786`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `email.ts`
+- **Thin community `Community 787`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `ghana.ts`
+- **Thin community `Community 788`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `payment.ts`
+- **Thin community `Community 789`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `crons.ts`
+- **Thin community `Community 790`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 791`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 792`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 793`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 794`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `env.ts`
+- **Thin community `Community 795`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `analytics.ts`
+- **Thin community `Community 796`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `auth.ts`
+- **Thin community `Community 797`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 798`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `colors.ts`
+- **Thin community `Community 799`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `index.ts`
+- **Thin community `Community 800`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `organizations.ts`
+- **Thin community `Community 801`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `products.ts`
+- **Thin community `Community 802`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 803`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `stores.ts`
+- **Thin community `Community 804`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `index.ts`
+- **Thin community `Community 805`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `bag.ts`
+- **Thin community `Community 806`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `guest.ts`
+- **Thin community `Community 807`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 808`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `me.ts`
+- **Thin community `Community 809`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `offers.ts`
+- **Thin community `Community 810`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 811`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `paystack.ts`
+- **Thin community `Community 812`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 813`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `reviews.ts`
+- **Thin community `Community 814`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `rewards.ts`
+- **Thin community `Community 815`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 816`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `security.test.ts`
+- **Thin community `Community 817`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `storefront.ts`
+- **Thin community `Community 818`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `upsells.ts`
+- **Thin community `Community 819`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `user.ts`
+- **Thin community `Community 820`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 821`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `health.test.ts`
+- **Thin community `Community 822`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `http.ts`
+- **Thin community `Community 823`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 824`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 825`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 826`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `categories.ts`
+- **Thin community `Community 827`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `colors.ts`
+- **Thin community `Community 828`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 829`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 830`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 831`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 832`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 833`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `organizations.ts`
+- **Thin community `Community 834`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `pos.ts`
+- **Thin community `Community 835`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 836`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 837`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `productSku.ts`
+- **Thin community `Community 838`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 839`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 840`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 841`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 842`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 843`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 844`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 845`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 846`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 847`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `client.test.ts`
+- **Thin community `Community 848`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `config.test.ts`
+- **Thin community `Community 849`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 850`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `types.ts`
+- **Thin community `Community 851`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 852`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 853`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 854`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 855`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `dto.ts`
+- **Thin community `Community 856`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 857`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 858`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 859`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 860`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `types.ts`
+- **Thin community `Community 861`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 862`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 863`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `catalog.ts`
+- **Thin community `Community 864`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `customers.ts`
+- **Thin community `Community 865`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `register.ts`
+- **Thin community `Community 866`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `terminals.ts`
+- **Thin community `Community 867`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `transactions.ts`
+- **Thin community `Community 868`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `schema.ts`
+- **Thin community `Community 869`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 870`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 871`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 872`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 873`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `category.ts`
+- **Thin community `Community 874`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `color.ts`
+- **Thin community `Community 875`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 876`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 877`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `index.ts`
+- **Thin community `Community 878`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 879`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `organization.ts`
+- **Thin community `Community 880`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 881`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `product.ts`
+- **Thin community `Community 882`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 883`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 884`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `store.ts`
+- **Thin community `Community 885`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 886`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `index.ts`
+- **Thin community `Community 887`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 888`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 889`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 890`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 891`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 892`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `index.ts`
+- **Thin community `Community 893`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 894`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 895`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 896`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 897`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 898`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 899`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 900`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 901`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 902`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `customer.ts`
+- **Thin community `Community 903`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 904`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 905`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 906`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 907`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `index.ts`
+- **Thin community `Community 908`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `posSession.ts`
+- **Thin community `Community 909`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 910`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 911`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 912`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 913`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `index.ts`
+- **Thin community `Community 914`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 915`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 916`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 917`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 918`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 919`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `index.ts`
+- **Thin community `Community 920`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 921`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 922`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 923`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 924`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `vendor.ts`
+- **Thin community `Community 925`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `analytics.ts`
+- **Thin community `Community 926`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `bag.ts`
+- **Thin community `Community 927`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 928`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 929`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 930`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `guest.ts`
+- **Thin community `Community 931`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `index.ts`
+- **Thin community `Community 932`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `offer.ts`
+- **Thin community `Community 933`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 934`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 935`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `review.ts`
+- **Thin community `Community 936`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `rewards.ts`
+- **Thin community `Community 937`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 938`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 939`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 940`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 941`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 942`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 943`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 944`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `bag.ts`
+- **Thin community `Community 945`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 946`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `customer.ts`
+- **Thin community `Community 947`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `guest.ts`
+- **Thin community `Community 948`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 949`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 950`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `payment.ts`
+- **Thin community `Community 951`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 952`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 953`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 954`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `users.ts`
+- **Thin community `Community 955`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `payment.ts`
+- **Thin community `Community 956`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 957`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 958`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 959`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 960`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `index.ts`
+- **Thin community `Community 961`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 962`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `auth.ts`
+- **Thin community `Community 963`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 964`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 965`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 966`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 967`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 968`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 969`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 970`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 971`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 972`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `constants.ts`
+- **Thin community `Community 973`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 974`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 975`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 976`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `types.ts`
+- **Thin community `Community 977`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 979`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 980`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 981`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 982`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 983`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 984`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 985`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `columns.tsx`
+- **Thin community `Community 986`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 987`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 988`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 989`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 990`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `columns.tsx`
+- **Thin community `Community 991`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 992`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `chart.tsx`
+- **Thin community `Community 994`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 995`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -8457,911 +8477,919 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 997`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `columns.tsx`
+- **Thin community `Community 998`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `constants.ts`
+- **Thin community `Community 999`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1000`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1001`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1002`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `data.ts`
+- **Thin community `Community 1003`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1004`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1005`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1006`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1007`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1009`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1011`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1012`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 1013`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1014`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `constants.ts`
+- **Thin community `Community 1015`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1016`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1017`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1018`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `data.ts`
+- **Thin community `Community 1019`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1020`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1021`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 1022`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1023`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1024`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1025`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1026`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1027`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1028`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1029`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1030`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1031`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `constants.ts`
+- **Thin community `Community 1032`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1033`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1034`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1035`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1036`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1037`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1038`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1039`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 1040`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1041`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1042`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1043`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1044`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1045`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1046`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1047`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1048`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 1049`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 1050`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1051`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1052`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1053`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1054`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1055`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `constants.ts`
+- **Thin community `Community 1056`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1057`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1058`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1059`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `data.ts`
+- **Thin community `Community 1060`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `constants.ts`
+- **Thin community `Community 1062`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1063`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1064`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1065`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1066`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `data.ts`
+- **Thin community `Community 1067`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1068`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `constants.ts`
+- **Thin community `Community 1069`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1070`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1071`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1072`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1073`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `data.ts`
+- **Thin community `Community 1074`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1075`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1076`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1077`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1078`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1079`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1080`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1081`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1082`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1083`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1084`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1085`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1086`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1087`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1088`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1090`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1091`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1092`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1093`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1094`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1095`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1096`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1097`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `types.ts`
+- **Thin community `Community 1098`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1099`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1100`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1101`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1102`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1103`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1104`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1105`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1106`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1107`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1108`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1109`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1110`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1111`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1112`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1113`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1114`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1115`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1116`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `data.ts`
+- **Thin community `Community 1117`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1118`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1119`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1120`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1121`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1122`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1123`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1124`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1125`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1126`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1127`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1128`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1129`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1130`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `constants.ts`
+- **Thin community `Community 1131`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1132`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1133`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1134`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data.ts`
+- **Thin community `Community 1135`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `types.ts`
+- **Thin community `Community 1136`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1137`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1138`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1139`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1140`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `index.tsx`
+- **Thin community `Community 1141`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1142`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1143`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1144`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1145`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `index.tsx`
+- **Thin community `Community 1146`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1147`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1148`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1149`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `button.tsx`
+- **Thin community `Community 1150`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1151`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `card.tsx`
+- **Thin community `Community 1152`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1153`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1154`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `command.tsx`
+- **Thin community `Community 1155`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1156`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1157`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1158`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `form.tsx`
+- **Thin community `Community 1159`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1160`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1161`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `input.tsx`
+- **Thin community `Community 1162`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1163`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1164`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1165`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1166`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1167`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `select.tsx`
+- **Thin community `Community 1168`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1169`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1170`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1171`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `table.tsx`
+- **Thin community `Community 1172`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1173`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1174`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1175`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1176`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1177`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1178`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1179`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1180`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `constants.ts`
+- **Thin community `Community 1181`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1182`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1183`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1184`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `data.ts`
+- **Thin community `Community 1185`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1186`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1187`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1188`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1189`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1190`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1191`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1192`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1194`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1195`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1196`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1197`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1198`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `index.ts`
+- **Thin community `Community 1199`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `config.ts`
+- **Thin community `Community 1200`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1201`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1203`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1204`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1206`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `aws.ts`
+- **Thin community `Community 1207`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `constants.ts`
+- **Thin community `Community 1208`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `countries.ts`
+- **Thin community `Community 1209`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1212`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1213`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1214`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1215`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `dto.ts`
+- **Thin community `Community 1216`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `ports.ts`
+- **Thin community `Community 1217`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `constants.ts`
+- **Thin community `Community 1218`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1220`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `index.ts`
+- **Thin community `Community 1221`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1222`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `types.ts`
+- **Thin community `Community 1223`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1226`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1228`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1229`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `category.ts`
+- **Thin community `Community 1230`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `product.ts`
+- **Thin community `Community 1231`** (1 nodes): `useExpenseRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `store.ts`
+- **Thin community `Community 1232`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1233`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `user.ts`
+- **Thin community `Community 1234`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1237`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1238`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1239`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `index.tsx`
+- **Thin community `Community 1240`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `index.tsx`
+- **Thin community `Community 1241`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `index.tsx`
+- **Thin community `Community 1242`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1243`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1244`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1245`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1246`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1247`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `index.tsx`
+- **Thin community `Community 1248`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1249`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1250`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1251`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `home.tsx`
+- **Thin community `Community 1252`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1253`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1254`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1255`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `index.tsx`
+- **Thin community `Community 1256`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `index.tsx`
+- **Thin community `Community 1257`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1258`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1259`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1260`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1261`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1262`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1263`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1264`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1265`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1266`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1267`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `index.tsx`
+- **Thin community `Community 1268`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1269`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1270`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1271`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1272`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1273`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1274`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `index.tsx`
+- **Thin community `Community 1275`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `index.tsx`
+- **Thin community `Community 1276`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `new.tsx`
+- **Thin community `Community 1277`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `index.tsx`
+- **Thin community `Community 1278`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `new.tsx`
+- **Thin community `Community 1279`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1280`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1281`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1282`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1283`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `index.tsx`
+- **Thin community `Community 1284`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1285`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1286`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1287`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1288`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1289`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1291`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `index.tsx`
+- **Thin community `Community 1292`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1294`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1295`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1296`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1297`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1298`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1299`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1300`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1301`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1302`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1303`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1304`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1305`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1306`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1307`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1308`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1309`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1310`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `setup.ts`
+- **Thin community `Community 1313`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1315`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `types.ts`
+- **Thin community `Community 1316`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1317`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1318`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1319`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1320`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `types.ts`
+- **Thin community `Community 1322`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1323`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1324`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1325`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1326`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1327`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1328`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1329`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1330`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1331`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `schema.ts`
+- **Thin community `Community 1332`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1333`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1335`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1337`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1338`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1339`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1340`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1341`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `types.ts`
+- **Thin community `Community 1342`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1344`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1346`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1347`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1349`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `constants.ts`
+- **Thin community `Community 1350`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1351`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `About.tsx`
+- **Thin community `Community 1352`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1353`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1354`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1355`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1356`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1357`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1358`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1359`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1360`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1361`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `types.ts`
+- **Thin community `Community 1362`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1363`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1364`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1365`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1367`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1368`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1369`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1370`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1371`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1372`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `button.tsx`
+- **Thin community `Community 1373`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `card.tsx`
+- **Thin community `Community 1374`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1375`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `command.tsx`
+- **Thin community `Community 1376`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1377`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1378`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1379`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `form.tsx`
+- **Thin community `Community 1380`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1381`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1382`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1383`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1384`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `input.tsx`
+- **Thin community `Community 1385`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `label.tsx`
+- **Thin community `Community 1386`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1387`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1388`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1389`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `index.ts`
+- **Thin community `Community 1390`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `types.ts`
+- **Thin community `Community 1391`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1392`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1393`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1394`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1395`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `select.tsx`
+- **Thin community `Community 1396`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1397`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1398`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `table.tsx`
+- **Thin community `Community 1399`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1400`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1401`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1402`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1403`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1404`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `config.ts`
+- **Thin community `Community 1405`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1406`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1407`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1408`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `constants.ts`
+- **Thin community `Community 1409`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `countries.ts`
+- **Thin community `Community 1410`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1411`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1412`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1413`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1414`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `index.ts`
+- **Thin community `Community 1415`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `store.ts`
+- **Thin community `Community 1416`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `bag.ts`
+- **Thin community `Community 1417`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1418`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `category.ts`
+- **Thin community `Community 1419`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `organization.ts`
+- **Thin community `Community 1420`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `product.ts`
+- **Thin community `Community 1421`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `store.ts`
+- **Thin community `Community 1422`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1423`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `user.ts`
+- **Thin community `Community 1424`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `states.ts`
+- **Thin community `Community 1425`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1426`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1427`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1428`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1429`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1430`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1431`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1432`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `index.tsx`
+- **Thin community `Community 1433`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1434`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `index.tsx`
+- **Thin community `Community 1435`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1436`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1437`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1438`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1439`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1440`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `index.tsx`
+- **Thin community `Community 1441`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1442`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1443`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1444`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1445`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `index.js`
+- **Thin community `Community 1446`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1447`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1448`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1449`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1451`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1452`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1453`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1454`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -9379,5 +9407,5 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
 - **Should `Community 16` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
-- **Should `Community 20` be split into smaller, more focused modules?**
+- **Should `Community 21` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -647,7 +647,7 @@
       "relation": "calls",
       "source": "cashcontrolsdashboard_formatcurrency",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L129",
+      "source_location": "L145",
       "target": "cashcontrolsdashboard_summarystrip",
       "weight": 1
     },
@@ -7283,7 +7283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L363",
+      "source_location": "L347",
       "target": "deposits_collectstaffprofileids",
       "weight": 1
     },
@@ -7307,7 +7307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L281",
+      "source_location": "L282",
       "target": "deposits_listregistersessionsfordashboard",
       "weight": 1
     },
@@ -7319,7 +7319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L337",
+      "source_location": "L321",
       "target": "deposits_listregistersessiontimeline",
       "weight": 1
     },
@@ -7331,7 +7331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L350",
+      "source_location": "L334",
       "target": "deposits_listregistersessiontransactions",
       "weight": 1
     },
@@ -7343,7 +7343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L323",
+      "source_location": "L307",
       "target": "deposits_listsessiondeposits",
       "weight": 1
     },
@@ -7367,7 +7367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_cashcontrols_deposits_ts",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L309",
+      "source_location": "L293",
       "target": "deposits_liststoredeposits",
       "weight": 1
     },
@@ -15839,7 +15839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_utils_ts",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L38",
+      "source_location": "L39",
       "target": "utils_capitalizewords",
       "weight": 1
     },
@@ -15851,7 +15851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_utils_ts",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L47",
+      "source_location": "L48",
       "target": "utils_currencyformatter",
       "weight": 1
     },
@@ -15863,7 +15863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_utils_ts",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L56",
+      "source_location": "L52",
       "target": "utils_formatdate",
       "weight": 1
     },
@@ -15875,7 +15875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_utils_ts",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L77",
+      "source_location": "L73",
       "target": "utils_generatetransactionnumber",
       "weight": 1
     },
@@ -15887,7 +15887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_utils_ts",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "target": "utils_getaddressstring",
       "weight": 1
     },
@@ -15899,7 +15899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_utils_ts",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L64",
+      "source_location": "L60",
       "target": "utils_getproductname",
       "weight": 1
     },
@@ -15911,7 +15911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_utils_ts",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L5",
+      "source_location": "L6",
       "target": "utils_toslug",
       "weight": 1
     },
@@ -16201,6 +16201,18 @@
       "source_file": "packages/athena-webapp/shared/commandResult.ts",
       "source_location": "L44",
       "target": "commandresult_usererror",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_currencyformatter_ts",
+      "_tgt": "currencyformatter_currencyformatter",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_currencyformatter_ts",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L5",
+      "target": "currencyformatter_currencyformatter",
       "weight": 1
     },
     {
@@ -17927,7 +17939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L74",
+      "source_location": "L75",
       "target": "cashcontrolsdashboard_formatcurrency",
       "weight": 1
     },
@@ -17939,7 +17951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L93",
+      "source_location": "L94",
       "target": "cashcontrolsdashboard_formatregistername",
       "weight": 1
     },
@@ -17951,7 +17963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L82",
+      "source_location": "L83",
       "target": "cashcontrolsdashboard_formatstatuslabel",
       "weight": 1
     },
@@ -17963,8 +17975,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L86",
+      "source_location": "L87",
       "target": "cashcontrolsdashboard_formattimestamp",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "_tgt": "cashcontrolsdashboard_getstatusbadgeclass",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L107",
+      "target": "cashcontrolsdashboard_getstatusbadgeclass",
       "weight": 1
     },
     {
@@ -17975,7 +17999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L98",
+      "source_location": "L99",
       "target": "cashcontrolsdashboard_getvariancetone",
       "weight": 1
     },
@@ -17987,7 +18011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L240",
+      "source_location": "L246",
       "target": "cashcontrolsdashboard_if",
       "weight": 1
     },
@@ -17999,8 +18023,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L106",
+      "source_location": "L122",
       "target": "cashcontrolsdashboard_summarystrip",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
+      "_tgt": "cashcontrolsworkspaceheader_cashcontrolsworkspaceheader",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
+      "source_location": "L5",
+      "target": "cashcontrolsworkspaceheader_cashcontrolsworkspaceheader",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
+      "_tgt": "formatreviewreason_formatreviewreason",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
+      "source_location": "L3",
+      "target": "formatreviewreason_formatreviewreason",
       "weight": 1
     },
     {
@@ -18011,7 +18059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L219",
+      "source_location": "L205",
       "target": "registercloseoutview_applycommandresult",
       "weight": 1
     },
@@ -18023,20 +18071,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L631",
+      "source_location": "L617",
       "target": "registercloseoutview_errormessage",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
-      "_tgt": "registercloseoutview_formatreviewreason",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L148",
-      "target": "registercloseoutview_formatreviewreason",
       "weight": 1
     },
     {
@@ -18047,7 +18083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L96",
+      "source_location": "L97",
       "target": "registercloseoutview_formatsessionname",
       "weight": 1
     },
@@ -18059,7 +18095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L100",
+      "source_location": "L101",
       "target": "registercloseoutview_formatstatuslabel",
       "weight": 1
     },
@@ -18071,7 +18107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L123",
+      "source_location": "L124",
       "target": "registercloseoutview_formatstoredamountforinput",
       "weight": 1
     },
@@ -18083,7 +18119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L405",
+      "source_location": "L391",
       "target": "registercloseoutview_formattimestamp",
       "weight": 1
     },
@@ -18095,7 +18131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L163",
+      "source_location": "L149",
       "target": "registercloseoutview_getdefaultactivesessionid",
       "weight": 1
     },
@@ -18107,7 +18143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L127",
+      "source_location": "L128",
       "target": "registercloseoutview_getstatusbadgeclass",
       "weight": 1
     },
@@ -18119,7 +18155,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L111",
+      "source_location": "L112",
       "target": "registercloseoutview_getvariance",
       "weight": 1
     },
@@ -18131,7 +18167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L140",
+      "source_location": "L141",
       "target": "registercloseoutview_getvariancetone",
       "weight": 1
     },
@@ -18143,7 +18179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L278",
+      "source_location": "L264",
       "target": "registercloseoutview_handlereviewcloseout",
       "weight": 1
     },
@@ -18155,7 +18191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L235",
+      "source_location": "L221",
       "target": "registercloseoutview_handlesubmitcloseout",
       "weight": 1
     },
@@ -18167,7 +18203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L91",
+      "source_location": "L92",
       "target": "registercloseoutview_trimoptional",
       "weight": 1
     },
@@ -18179,7 +18215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L300",
+      "source_location": "L375",
       "target": "registersessionview_applycommandresult",
       "weight": 1
     },
@@ -18191,8 +18227,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L146",
+      "source_location": "L149",
       "target": "registersessionview_builddepositsubmissionkey",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "_tgt": "registersessionview_buildlifecyclerows",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L215",
+      "target": "registersessionview_buildlifecyclerows",
       "weight": 1
     },
     {
@@ -18203,7 +18251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L611",
+      "source_location": "L706",
       "target": "registersessionview_canopentransaction",
       "weight": 1
     },
@@ -18215,7 +18263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L865",
+      "source_location": "L960",
       "target": "registersessionview_errormessage",
       "weight": 1
     },
@@ -18227,7 +18275,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L150",
+      "source_location": "L153",
       "target": "registersessionview_formatcurrency",
       "weight": 1
     },
@@ -18239,7 +18287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L169",
+      "source_location": "L172",
       "target": "registersessionview_formatpaymentmethod",
       "weight": 1
     },
@@ -18251,7 +18299,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L182",
+      "source_location": "L185",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -18263,8 +18311,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L177",
+      "source_location": "L180",
       "target": "registersessionview_formatregistername",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "_tgt": "registersessionview_formatstaffbyline",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L207",
+      "target": "registersessionview_formatstaffbyline",
       "weight": 1
     },
     {
@@ -18275,7 +18335,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L165",
+      "source_location": "L168",
       "target": "registersessionview_formatstatuslabel",
       "weight": 1
     },
@@ -18287,7 +18347,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L158",
+      "source_location": "L161",
       "target": "registersessionview_formattimestamp",
       "weight": 1
     },
@@ -18299,7 +18359,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L204",
+      "source_location": "L279",
       "target": "registersessionview_getpaymentmethodicon",
       "weight": 1
     },
@@ -18311,7 +18371,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L196",
+      "source_location": "L199",
       "target": "registersessionview_getvariancetone",
       "weight": 1
     },
@@ -18323,7 +18383,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L310",
+      "source_location": "L385",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -18335,7 +18395,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L584",
+      "source_location": "L679",
       "target": "registersessionview_opentransaction",
       "weight": 1
     },
@@ -18347,7 +18407,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L141",
+      "source_location": "L144",
       "target": "registersessionview_trimoptional",
       "weight": 1
     },
@@ -20027,7 +20087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L39",
+      "source_location": "L36",
       "target": "ordersummary_test_getbalancedueamount",
       "weight": 1
     },
@@ -20039,7 +20099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L56",
+      "source_location": "L53",
       "target": "ordersummary_test_getbalanceduelabel",
       "weight": 1
     },
@@ -20051,7 +20111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L35",
+      "source_location": "L32",
       "target": "ordersummary_test_stripwhitespace",
       "weight": 1
     },
@@ -20753,13 +20813,25 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
+      "_tgt": "transactionsview_formatregisterfilterlabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L27",
+      "target": "transactionsview_formatregisterfilterlabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "_tgt": "transactionsview_istoday",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L28",
+      "source_location": "L40",
       "target": "transactionsview_istoday",
       "weight": 1
     },
@@ -26351,7 +26423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "target": "utils_capitalizefirstletter",
       "weight": 1
     },
@@ -26363,7 +26435,7 @@
       "relation": "contains",
       "source": "utils_capitalizewords",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L19",
+      "source_location": "L20",
       "target": "packages_athena_webapp_src_lib_utils_ts",
       "weight": 1
     },
@@ -26375,7 +26447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L5",
+      "source_location": "L6",
       "target": "utils_cn",
       "weight": 1
     },
@@ -26387,7 +26459,7 @@
       "relation": "contains",
       "source": "utils_currencyformatter",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L28",
+      "source_location": "L29",
       "target": "packages_athena_webapp_src_lib_utils_ts",
       "weight": 1
     },
@@ -26399,7 +26471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L91",
+      "source_location": "L87",
       "target": "utils_formatuserid",
       "weight": 1
     },
@@ -26411,7 +26483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "target": "utils_geterrorforfield",
       "weight": 1
     },
@@ -26423,7 +26495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L54",
+      "source_location": "L50",
       "target": "utils_getrelativetime",
       "weight": 1
     },
@@ -26435,7 +26507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L71",
+      "source_location": "L67",
       "target": "utils_gettimeremaining",
       "weight": 1
     },
@@ -26447,7 +26519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L46",
+      "source_location": "L42",
       "target": "utils_slugtowords",
       "weight": 1
     },
@@ -26459,7 +26531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_utils_ts",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L50",
+      "source_location": "L46",
       "target": "utils_snakecasetowords",
       "weight": 1
     },
@@ -26471,7 +26543,7 @@
       "relation": "contains",
       "source": "utils_toslug",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L37",
+      "source_location": "L33",
       "target": "packages_athena_webapp_src_lib_utils_ts",
       "weight": 1
     },
@@ -34163,7 +34235,7 @@
       "relation": "calls",
       "source": "registercloseoutview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L292",
+      "source_location": "L278",
       "target": "registercloseoutview_handlereviewcloseout",
       "weight": 1
     },
@@ -34175,7 +34247,7 @@
       "relation": "calls",
       "source": "registercloseoutview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L288",
+      "source_location": "L274",
       "target": "registercloseoutview_handlereviewcloseout",
       "weight": 1
     },
@@ -34187,7 +34259,7 @@
       "relation": "calls",
       "source": "registercloseoutview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L263",
+      "source_location": "L249",
       "target": "registercloseoutview_handlesubmitcloseout",
       "weight": 1
     },
@@ -34199,7 +34271,7 @@
       "relation": "calls",
       "source": "registercloseoutview_formatstoredamountforinput",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L239",
+      "source_location": "L225",
       "target": "registercloseoutview_handlesubmitcloseout",
       "weight": 1
     },
@@ -34211,7 +34283,7 @@
       "relation": "calls",
       "source": "registercloseoutview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L257",
+      "source_location": "L243",
       "target": "registercloseoutview_handlesubmitcloseout",
       "weight": 1
     },
@@ -34588,6 +34660,42 @@
       "weight": 1
     },
     {
+      "_src": "registersessionview_buildlifecyclerows",
+      "_tgt": "registersessionview_formatcurrency",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessionview_formatcurrency",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L259",
+      "target": "registersessionview_buildlifecyclerows",
+      "weight": 1
+    },
+    {
+      "_src": "registersessionview_buildlifecyclerows",
+      "_tgt": "registersessionview_formatstaffbyline",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessionview_formatstaffbyline",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L229",
+      "target": "registersessionview_buildlifecyclerows",
+      "weight": 1
+    },
+    {
+      "_src": "registersessionview_buildlifecyclerows",
+      "_tgt": "registersessionview_formattimestamp",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registersessionview_formattimestamp",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L228",
+      "target": "registersessionview_buildlifecyclerows",
+      "weight": 1
+    },
+    {
       "_src": "registersessionview_canopentransaction",
       "_tgt": "registersessionview_opentransaction",
       "confidence": "EXTRACTED",
@@ -34595,7 +34703,7 @@
       "relation": "calls",
       "source": "registersessionview_opentransaction",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L621",
+      "source_location": "L716",
       "target": "registersessionview_canopentransaction",
       "weight": 1
     },
@@ -34607,7 +34715,7 @@
       "relation": "calls",
       "source": "registersessionview_formatregistername",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L183",
+      "source_location": "L186",
       "target": "registersessionview_formatregisterheadername",
       "weight": 1
     },
@@ -34619,7 +34727,7 @@
       "relation": "calls",
       "source": "registersessionview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L340",
+      "source_location": "L415",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -34631,7 +34739,7 @@
       "relation": "calls",
       "source": "registersessionview_builddepositsubmissionkey",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L347",
+      "source_location": "L422",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -34643,7 +34751,7 @@
       "relation": "calls",
       "source": "registersessionview_trimoptional",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L333",
+      "source_location": "L408",
       "target": "registersessionview_handlerecorddeposit",
       "weight": 1
     },
@@ -42455,7 +42563,7 @@
       "relation": "calls",
       "source": "utils_capitalizewords",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L66",
+      "source_location": "L62",
       "target": "utils_getproductname",
       "weight": 1
     },
@@ -43626,6 +43734,42 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1004,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -43633,7 +43777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -43642,7 +43786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43651,7 +43795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -43660,7 +43804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -43669,48 +43813,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1006,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1007,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -43779,6 +43887,42 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1013,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1014,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -43786,7 +43930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -43795,7 +43939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -43804,7 +43948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -43813,7 +43957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -43822,48 +43966,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1016,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1017,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
       "source_location": "L1"
     },
     {
@@ -43932,6 +44040,42 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1023,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1024,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
       "norm_label": "defaultcatchboundary.test.tsx",
@@ -43939,7 +44083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -43948,7 +44092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -43957,7 +44101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -43966,7 +44110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -43975,48 +44119,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1026,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1027,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -44085,6 +44193,42 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1033,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1034,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -44092,7 +44236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -44101,7 +44245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -44110,7 +44254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44119,7 +44263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44128,48 +44272,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1036,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "label": "BulkOperationsPage.tsx",
-      "norm_label": "bulkoperationspage.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1037,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
-      "label": "CashControlsDashboard.auth.test.tsx",
-      "norm_label": "cashcontrolsdashboard.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
-      "label": "CashControlsDashboard.test.tsx",
-      "norm_label": "cashcontrolsdashboard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
-      "label": "CashControlsWorkspaceHeader.tsx",
-      "norm_label": "cashcontrolsworkspaceheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
       "source_location": "L1"
     },
     {
@@ -44238,6 +44346,33 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
+      "label": "BulkOperationsPage.tsx",
+      "norm_label": "bulkoperationspage.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
+      "label": "CashControlsDashboard.auth.test.tsx",
+      "norm_label": "cashcontrolsdashboard.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
+      "label": "CashControlsDashboard.test.tsx",
+      "norm_label": "cashcontrolsdashboard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1043,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
       "norm_label": "registercloseoutview.test.tsx",
@@ -44245,7 +44380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -44254,7 +44389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -44263,7 +44398,16 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1046,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
+      "label": "formatReviewReason.test.ts",
+      "norm_label": "formatreviewreason.test.ts",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -44272,7 +44416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44281,7 +44425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -44290,196 +44434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "label": "MetricCard.tsx",
-      "norm_label": "metriccard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1047,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
-      "label": "index.test.tsx",
-      "norm_label": "index.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
-      "label": "OperationsQueueView.auth.test.tsx",
-      "norm_label": "operationsqueueview.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
-      "label": "OperationsQueueView.test.tsx",
-      "norm_label": "operationsqueueview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 1050,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
-      "label": "StockAdjustmentWorkspace.test.tsx",
-      "norm_label": "stockadjustmentworkspace.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1051,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
-      "label": "OrderStatus.test.tsx",
-      "norm_label": "orderstatus.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1052,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
-      "label": "OrderStatus.tsx",
-      "norm_label": "orderstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1053,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1054,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1055,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
-      "label": "ReturnExchangeView.test.tsx",
-      "norm_label": "returnexchangeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1056,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1057,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
       "label": "reference-fixtures.tsx",
@@ -44488,7 +44443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reference_fixtures_compacttable",
       "label": "CompactTable()",
@@ -44497,7 +44452,7 @@
       "source_location": "L263"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reference_fixtures_framecard",
       "label": "FrameCard()",
@@ -44506,7 +44461,7 @@
       "source_location": "L163"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reference_fixtures_lanecard",
       "label": "LaneCard()",
@@ -44515,7 +44470,7 @@
       "source_location": "L213"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reference_fixtures_metrictile",
       "label": "MetricTile()",
@@ -44524,7 +44479,7 @@
       "source_location": "L194"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reference_fixtures_minitrendchart",
       "label": "MiniTrendChart()",
@@ -44533,7 +44488,7 @@
       "source_location": "L240"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reference_fixtures_referencepageshell",
       "label": "ReferencePageShell()",
@@ -44542,97 +44497,97 @@
       "source_location": "L145"
     },
     {
-      "community": 1060,
+      "community": 1050,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
+      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
+      "label": "MetricCard.tsx",
+      "norm_label": "metriccard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1051,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.test.ts",
+      "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
+      "label": "index.test.tsx",
+      "norm_label": "index.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1052,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
+      "label": "OperationsQueueView.auth.test.tsx",
+      "norm_label": "operationsqueueview.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1053,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
+      "label": "OperationsQueueView.test.tsx",
+      "norm_label": "operationsqueueview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1054,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
+      "label": "StockAdjustmentWorkspace.test.tsx",
+      "norm_label": "stockadjustmentworkspace.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1055,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
+      "label": "OrderStatus.test.tsx",
+      "norm_label": "orderstatus.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1056,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
+      "label": "OrderStatus.tsx",
+      "norm_label": "orderstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1057,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
+      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1058,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "label": "inviteColumns.tsx",
-      "norm_label": "invitecolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1059,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
+      "label": "ReturnExchangeView.test.tsx",
+      "norm_label": "returnexchangeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
       "label": "savedBag.ts",
@@ -44641,7 +44596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "savedbag_additemtosavedbag",
       "label": "addItemToSavedBag()",
@@ -44650,7 +44605,7 @@
       "source_location": "L25"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "savedbag_getactivesavedbag",
       "label": "getActiveSavedBag()",
@@ -44659,7 +44614,7 @@
       "source_location": "L10"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "savedbag_getbaseurl",
       "label": "getBaseUrl()",
@@ -44668,7 +44623,7 @@
       "source_location": "L8"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "savedbag_removeitemfromsavedbag",
       "label": "removeItemFromSavedBag()",
@@ -44677,7 +44632,7 @@
       "source_location": "L91"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "savedbag_updatesavedbagitem",
       "label": "updateSavedBagItem()",
@@ -44686,7 +44641,7 @@
       "source_location": "L61"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "savedbag_updatesavedbagowner",
       "label": "updateSavedBagOwner()",
@@ -44695,7 +44650,196 @@
       "source_location": "L109"
     },
     {
+      "community": 1060,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1063,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1064,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1065,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1066,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1067,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1068,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1069,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
       "community": 1070,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
+      "label": "inviteColumns.tsx",
+      "norm_label": "invitecolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1073,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -44704,7 +44848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -44713,7 +44857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -44722,7 +44866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -44731,7 +44875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -44740,48 +44884,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
       "norm_label": "memberscolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1076,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
-      "label": "organization-switcher.test.tsx",
-      "norm_label": "organization-switcher.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1077,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
-      "label": "CashierAuthDialog.test.tsx",
-      "norm_label": "cashierauthdialog.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "label": "CashierAuthDialog.tsx",
-      "norm_label": "cashierauthdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "label": "CashierView.tsx",
-      "norm_label": "cashierview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1"
     },
     {
@@ -44850,6 +44958,42 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
+      "label": "organization-switcher.test.tsx",
+      "norm_label": "organization-switcher.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "label": "CashierAuthDialog.test.tsx",
+      "norm_label": "cashierauthdialog.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
+      "label": "CashierAuthDialog.tsx",
+      "norm_label": "cashierauthdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1083,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
+      "label": "CashierView.tsx",
+      "norm_label": "cashierview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1084,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
       "norm_label": "posregisterview.tsx",
@@ -44857,7 +45001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -44866,7 +45010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -44875,7 +45019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -44884,7 +45028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -44893,48 +45037,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
       "norm_label": "sessionmanager.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1086,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
-      "label": "TotalsDisplay.test.tsx",
-      "norm_label": "totalsdisplay.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1087,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
-      "label": "TotalsDisplay.tsx",
-      "norm_label": "totalsdisplay.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "label": "ExpenseReportView.tsx",
-      "norm_label": "expensereportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
-      "label": "ExpenseReportsView.test.ts",
-      "norm_label": "expensereportsview.test.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.ts",
       "source_location": "L1"
     },
     {
@@ -45003,6 +45111,42 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
+      "label": "TotalsDisplay.test.tsx",
+      "norm_label": "totalsdisplay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
+      "label": "TotalsDisplay.tsx",
+      "norm_label": "totalsdisplay.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
+      "label": "ExpenseReportView.tsx",
+      "norm_label": "expensereportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1093,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
+      "label": "ExpenseReportsView.test.ts",
+      "norm_label": "expensereportsview.test.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1094,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
       "norm_label": "expensereportcolumns.tsx",
@@ -45010,7 +45154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -45019,7 +45163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -45028,7 +45172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -45037,7 +45181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -45046,48 +45190,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
       "norm_label": "transactionview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1096,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
-      "label": "TransactionsView.test.tsx",
-      "norm_label": "transactionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
-      "label": "ProcurementView.test.tsx",
-      "norm_label": "procurementview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -45336,6 +45444,42 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
+      "label": "TransactionsView.test.tsx",
+      "norm_label": "transactionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
+      "label": "ProcurementView.test.tsx",
+      "norm_label": "procurementview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1104,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
       "norm_label": "receivingview.test.tsx",
@@ -45343,7 +45487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -45352,7 +45496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -45361,7 +45505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -45370,7 +45514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -45379,48 +45523,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
       "norm_label": "categorylistview.tsx",
       "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
-      "label": "ProductSubcategoryToggleGroup.tsx",
-      "norm_label": "productsubcategorytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
-      "label": "StoreProducts.tsx",
-      "norm_label": "storeproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "label": "UnresolvedProducts.tsx",
-      "norm_label": "unresolvedproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -45480,6 +45588,42 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
+      "label": "ProductSubcategoryToggleGroup.tsx",
+      "norm_label": "productsubcategorytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
+      "label": "StoreProducts.tsx",
+      "norm_label": "storeproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
+      "label": "UnresolvedProducts.tsx",
+      "norm_label": "unresolvedproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1114,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
       "norm_label": "complimentaryproducts.tsx",
@@ -45487,7 +45631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -45496,7 +45640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -45505,7 +45649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45514,7 +45658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45523,48 +45667,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "label": "productColumns.tsx",
-      "norm_label": "productcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
-      "label": "PromoCodeHeader.test.tsx",
-      "norm_label": "promocodeheader.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.test.tsx",
       "source_location": "L1"
     },
     {
@@ -45624,6 +45732,42 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
+      "label": "productColumns.tsx",
+      "norm_label": "productcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
+      "label": "PromoCodeHeader.test.tsx",
+      "norm_label": "promocodeheader.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1124,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
       "norm_label": "promocodes.tsx",
@@ -45631,7 +45775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -45640,7 +45784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -45649,7 +45793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -45658,7 +45802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -45667,48 +45811,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -45768,6 +45876,42 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1134,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -45775,7 +45919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -45784,7 +45928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -45793,7 +45937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -45802,7 +45946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -45811,48 +45955,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1136,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
-      "label": "welcome-offer-card.tsx",
-      "norm_label": "welcome-offer-card.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
-      "label": "RatingStars.tsx",
-      "norm_label": "ratingstars.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "label": "ReviewCard.tsx",
-      "norm_label": "reviewcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1"
     },
     {
@@ -45912,6 +46020,42 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
+      "label": "welcome-offer-card.tsx",
+      "norm_label": "welcome-offer-card.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
+      "label": "RatingStars.tsx",
+      "norm_label": "ratingstars.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1143,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
+      "label": "ReviewCard.tsx",
+      "norm_label": "reviewcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1144,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
@@ -45919,7 +46063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -45928,7 +46072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -45937,7 +46081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -45946,7 +46090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -45955,48 +46099,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
       "norm_label": "usestoreconfigupdate.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1146,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1147,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
-      "label": "WorkflowTraceView.test.tsx",
-      "norm_label": "workflowtraceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
-      "label": "button.test.tsx",
-      "norm_label": "button.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1"
     },
     {
@@ -46056,6 +46164,42 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
+      "label": "WorkflowTraceView.test.tsx",
+      "norm_label": "workflowtraceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1152,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1153,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
+      "label": "button.test.tsx",
+      "norm_label": "button.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1154,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
@@ -46063,7 +46207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -46072,7 +46216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -46081,7 +46225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -46090,7 +46234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -46099,48 +46243,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
       "norm_label": "command.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1156,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
       "source_location": "L1"
     },
     {
@@ -46200,6 +46308,42 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1164,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
@@ -46207,7 +46351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -46216,7 +46360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -46225,7 +46369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -46234,7 +46378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -46243,48 +46387,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
       "norm_label": "primitives.test.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1166,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1167,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
       "source_location": "L1"
     },
     {
@@ -46344,6 +46452,42 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1172,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1173,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1174,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
@@ -46351,7 +46495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -46360,7 +46504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -46369,7 +46513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -46378,7 +46522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -46387,48 +46531,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
       "norm_label": "toggle-group.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1176,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1177,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "label": "upload-button.tsx",
-      "norm_label": "upload-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "label": "BagView.tsx",
-      "norm_label": "bagview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
       "source_location": "L1"
     },
     {
@@ -46488,6 +46596,42 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_upload_button_tsx",
+      "label": "upload-button.tsx",
+      "norm_label": "upload-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
+      "label": "BagView.tsx",
+      "norm_label": "bagview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1184,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -46495,7 +46639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -46504,7 +46648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -46513,7 +46657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46522,7 +46666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -46531,48 +46675,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1186,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -46632,6 +46740,42 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1192,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1193,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1194,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -46639,7 +46783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -46648,7 +46792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46657,7 +46801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -46666,7 +46810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -46675,48 +46819,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
       "norm_label": "timelineeventcard.test.tsx",
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1196,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1"
     },
     {
@@ -46956,6 +47064,42 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1203,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
@@ -46963,7 +47107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -46972,7 +47116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -46981,7 +47125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -46990,7 +47134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -46999,48 +47143,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
       "norm_label": "useexpensesessions.test.ts",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1206,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1207,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/src/lib/countries.ts",
       "source_location": "L1"
     },
     {
@@ -47100,6 +47208,42 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1213,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1214,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
       "norm_label": "operatormessages.test.ts",
@@ -47107,7 +47251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -47116,7 +47260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -47125,7 +47269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -47134,7 +47278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -47143,48 +47287,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
       "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1216,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1217,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
-      "label": "displayAmounts.test.ts",
-      "norm_label": "displayamounts.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
       "source_location": "L1"
     },
     {
@@ -47244,6 +47352,42 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1222,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1223,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1224,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
       "norm_label": "cart.test.ts",
@@ -47251,7 +47395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -47260,7 +47404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -47269,7 +47413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -47278,7 +47422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -47287,7 +47431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -47296,187 +47440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
-      "label": "loggerGateway.ts",
-      "norm_label": "loggergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
-      "label": "useExpenseRegisterViewModel.test.ts",
-      "norm_label": "useexpenseregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
-      "label": "registerUiState.ts",
-      "norm_label": "registeruistate.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 123,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1230,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1231,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1232,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1233,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1234,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1235,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1236,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1237,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -47485,7 +47449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -47494,7 +47458,7 @@
       "source_location": "L147"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -47503,7 +47467,7 @@
       "source_location": "L105"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -47512,7 +47476,7 @@
       "source_location": "L224"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -47521,7 +47485,7 @@
       "source_location": "L228"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -47530,97 +47494,97 @@
       "source_location": "L45"
     },
     {
-      "community": 1240,
+      "community": 1230,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
+      "label": "loggerGateway.ts",
+      "norm_label": "loggergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1231,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "label": "useExpenseRegisterViewModel.test.ts",
+      "norm_label": "useexpenseregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1232,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
+      "label": "registerUiState.ts",
+      "norm_label": "registeruistate.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1233,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "label": "$storeUrlSlug.tsx",
-      "norm_label": "$storeurlslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1234,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1235,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "label": "assets.index.tsx",
-      "norm_label": "assets.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1236,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "label": "bags.$bagId.tsx",
-      "norm_label": "bags.$bagid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1237,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1238,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
-      "community": 1249,
+      "community": 1239,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -47629,7 +47593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -47638,7 +47602,7 @@
       "source_location": "L56"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -47647,7 +47611,7 @@
       "source_location": "L87"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -47656,7 +47620,7 @@
       "source_location": "L101"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -47665,7 +47629,7 @@
       "source_location": "L158"
     },
     {
-      "community": 125,
+      "community": 124,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -47674,97 +47638,97 @@
       "source_location": "L139"
     },
     {
-      "community": 1250,
+      "community": 1240,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1241,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1242,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1243,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "label": "logs.$logId.tsx",
-      "norm_label": "logs.$logid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1244,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "label": "members.index.tsx",
-      "norm_label": "members.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1256,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1245,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1246,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "label": "all.index.tsx",
-      "norm_label": "all.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1247,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "label": "cancelled.index.tsx",
-      "norm_label": "cancelled.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
+      "label": "$storeUrlSlug.tsx",
+      "norm_label": "$storeurlslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 1248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
+      "label": "assets.index.tsx",
+      "norm_label": "assets.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -47773,7 +47737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -47782,7 +47746,7 @@
       "source_location": "L42"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -47791,7 +47755,7 @@
       "source_location": "L32"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -47800,7 +47764,7 @@
       "source_location": "L62"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -47809,7 +47773,7 @@
       "source_location": "L101"
     },
     {
-      "community": 126,
+      "community": 125,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -47818,97 +47782,97 @@
       "source_location": "L10"
     },
     {
-      "community": 1260,
+      "community": 1250,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
+      "label": "bags.$bagId.tsx",
+      "norm_label": "bags.$bagid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1251,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1252,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1253,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1254,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1255,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1256,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1257,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
+      "label": "logs.$logId.tsx",
+      "norm_label": "logs.$logid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1258,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1259,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
+      "label": "members.index.tsx",
+      "norm_label": "members.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -47917,7 +47881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -47926,7 +47890,7 @@
       "source_location": "L17"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -47935,7 +47899,7 @@
       "source_location": "L24"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -47944,7 +47908,7 @@
       "source_location": "L10"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -47953,7 +47917,7 @@
       "source_location": "L33"
     },
     {
-      "community": 127,
+      "community": 126,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -47962,97 +47926,97 @@
       "source_location": "L31"
     },
     {
-      "community": 1270,
+      "community": 1260,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1271,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1272,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1273,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1274,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1275,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1261,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1262,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
+      "label": "all.index.tsx",
+      "norm_label": "all.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1263,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
+      "label": "cancelled.index.tsx",
+      "norm_label": "cancelled.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1264,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1265,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1279,
+      "community": 1266,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 128,
+      "community": 1267,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1268,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1269,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 127,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -48061,7 +48025,7 @@
       "source_location": "L173"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -48070,7 +48034,7 @@
       "source_location": "L71"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -48079,7 +48043,7 @@
       "source_location": "L251"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -48088,7 +48052,7 @@
       "source_location": "L36"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -48097,7 +48061,7 @@
       "source_location": "L277"
     },
     {
-      "community": 128,
+      "community": 127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -48106,97 +48070,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1280,
+      "community": 1270,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1271,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1272,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1273,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1274,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1275,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1276,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1277,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1278,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1279,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1285,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "label": "new.index.tsx",
-      "norm_label": "new.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1286,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
-      "label": "active-cases.index.tsx",
-      "norm_label": "active-cases.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1287,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
-      "label": "appointments.index.tsx",
-      "norm_label": "appointments.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -48205,7 +48169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -48214,7 +48178,7 @@
       "source_location": "L107"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -48223,7 +48187,7 @@
       "source_location": "L63"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -48232,7 +48196,7 @@
       "source_location": "L80"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -48241,7 +48205,7 @@
       "source_location": "L46"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -48250,7 +48214,187 @@
       "source_location": "L97"
     },
     {
+      "community": 1280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1282,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1283,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1284,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1285,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1286,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1287,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1288,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1289,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
+      "label": "new.index.tsx",
+      "norm_label": "new.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
+    },
+    {
       "community": 1290,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
+      "label": "active-cases.index.tsx",
+      "norm_label": "active-cases.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
+      "label": "appointments.index.tsx",
+      "norm_label": "appointments.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1292,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1293,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -48259,7 +48403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -48268,7 +48412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -48277,7 +48421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -48286,7 +48430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -48295,48 +48439,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
       "norm_label": "_layout.index.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1296,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
-      "label": "_layout.test.tsx",
-      "norm_label": "_layout.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1297,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "label": "StoresSettingsAccordion.tsx",
-      "norm_label": "storessettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "label": "expenseStore.ts",
-      "norm_label": "expensestore.ts",
-      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -48427,7 +48535,7 @@
       "label": "formatUserId()",
       "norm_label": "formatuserid()",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L91"
+      "source_location": "L87"
     },
     {
       "community": 13,
@@ -48436,7 +48544,7 @@
       "label": "generateTransactionNumber()",
       "norm_label": "generatetransactionnumber()",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L77"
+      "source_location": "L73"
     },
     {
       "community": 13,
@@ -48445,7 +48553,7 @@
       "label": "getAddressString()",
       "norm_label": "getaddressstring()",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L14"
+      "source_location": "L15"
     },
     {
       "community": 13,
@@ -48463,7 +48571,7 @@
       "label": "getProductName()",
       "norm_label": "getproductname()",
       "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L64"
+      "source_location": "L60"
     },
     {
       "community": 13,
@@ -48490,7 +48598,7 @@
       "label": "getTimeRemaining()",
       "norm_label": "gettimeremaining()",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L71"
+      "source_location": "L67"
     },
     {
       "community": 13,
@@ -48508,7 +48616,7 @@
       "label": "snakeCaseToWords()",
       "norm_label": "snakecasetowords()",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L50"
+      "source_location": "L46"
     },
     {
       "community": 13,
@@ -48517,154 +48625,10 @@
       "label": "toSlug()",
       "norm_label": "toslug()",
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L37"
+      "source_location": "L33"
     },
     {
       "community": 130,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 1300,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1301,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1302,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1303,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1304,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
-      "label": "AdminShell.stories.tsx",
-      "norm_label": "adminshell.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1305,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
-      "label": "admin-shell-patterns.test.tsx",
-      "norm_label": "admin-shell-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1306,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
-      "label": "Surfaces.stories.tsx",
-      "norm_label": "surfaces.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1307,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 131,
       "file_type": "code",
       "id": "cataloggateway_mapproductbyidresult",
       "label": "mapProductByIdResult()",
@@ -48673,7 +48637,7 @@
       "source_location": "L38"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "cataloggateway_useconvexbarcodelookup",
       "label": "useConvexBarcodeLookup()",
@@ -48682,7 +48646,7 @@
       "source_location": "L85"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductidlookup",
       "label": "useConvexProductIdLookup()",
@@ -48691,7 +48655,7 @@
       "source_location": "L96"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductsearch",
       "label": "useConvexProductSearch()",
@@ -48700,7 +48664,7 @@
       "source_location": "L67"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "cataloggateway_useconvexquickaddcatalogitem",
       "label": "useConvexQuickAddCatalogItem()",
@@ -48709,7 +48673,7 @@
       "source_location": "L128"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
       "label": "catalogGateway.ts",
@@ -48718,97 +48682,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1310,
+      "community": 1300,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
-      "label": "reference-fixtures.test.tsx",
-      "norm_label": "reference-fixtures.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
+      "label": "_layout.test.tsx",
+      "norm_label": "_layout.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1301,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
-      "label": "storybook-config.test.ts",
-      "norm_label": "storybook-config.test.ts",
-      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
+      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
+      "label": "StoresSettingsAccordion.tsx",
+      "norm_label": "storessettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1302,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
-      "label": "storybook-theme-decorator.test.ts",
-      "norm_label": "storybook-theme-decorator.test.ts",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.test.ts",
+      "id": "packages_athena_webapp_src_stores_expensestore_ts",
+      "label": "expenseStore.ts",
+      "norm_label": "expensestore.ts",
+      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1303,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_test_setup_ts",
-      "label": "setup.ts",
-      "norm_label": "setup.ts",
-      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1304,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "label": "usePrint.test.ts",
-      "norm_label": "useprint.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1305,
       "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1306,
       "file_type": "code",
-      "id": "packages_athena_webapp_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/types.ts",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1307,
       "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1308,
       "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
+      "label": "AdminShell.stories.tsx",
+      "norm_label": "adminshell.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1319,
+      "community": 1309,
       "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -48817,7 +48781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -48826,7 +48790,7 @@
       "source_location": "L28"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -48835,7 +48799,7 @@
       "source_location": "L37"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -48844,7 +48808,7 @@
       "source_location": "L12"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -48853,7 +48817,7 @@
       "source_location": "L6"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -48862,97 +48826,97 @@
       "source_location": "L49"
     },
     {
-      "community": 1320,
+      "community": 1310,
       "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
+      "label": "Surfaces.stories.tsx",
+      "norm_label": "surfaces.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1311,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1312,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/api/types.ts",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1313,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "label": "HeartIconFilled.tsx",
-      "norm_label": "hearticonfilled.tsx",
-      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1314,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
+      "label": "reference-fixtures.test.tsx",
+      "norm_label": "reference-fixtures.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1315,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
+      "label": "storybook-config.test.ts",
+      "norm_label": "storybook-config.test.ts",
+      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1316,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
+      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
+      "label": "storybook-theme-decorator.test.ts",
+      "norm_label": "storybook-theme-decorator.test.ts",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1317,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
+      "id": "packages_athena_webapp_src_test_setup_ts",
+      "label": "setup.ts",
+      "norm_label": "setup.ts",
+      "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1318,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "label": "Upsell.tsx",
-      "norm_label": "upsell.tsx",
-      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
+      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "label": "usePrint.test.ts",
+      "norm_label": "useprint.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1329,
+      "community": 1319,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
-      "label": "Checkout.test.tsx",
-      "norm_label": "checkout.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
       "source_location": "L1"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -48961,7 +48925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -48970,7 +48934,7 @@
       "source_location": "L171"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -48979,7 +48943,7 @@
       "source_location": "L302"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -48988,7 +48952,7 @@
       "source_location": "L319"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -48997,7 +48961,7 @@
       "source_location": "L312"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -49006,97 +48970,97 @@
       "source_location": "L293"
     },
     {
-      "community": 1330,
+      "community": 1320,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "label": "Checkout.tsx",
-      "norm_label": "checkout.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
+      "id": "packages_athena_webapp_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1321,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1322,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1323,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
-      "label": "DeliveryDetailsSection.tsx",
-      "norm_label": "deliverydetailssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1324,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
-      "label": "checkoutStorage.test.ts",
-      "norm_label": "checkoutstorage.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1325,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "label": "deliveryFees.test.ts",
-      "norm_label": "deliveryfees.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1326,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "label": "deriveCheckoutState.test.ts",
-      "norm_label": "derivecheckoutstate.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
+      "id": "packages_storefront_webapp_src_api_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/api/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1327,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
+      "label": "HeartIconFilled.tsx",
+      "norm_label": "hearticonfilled.tsx",
+      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1328,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "label": "checkoutFormSchema.ts",
-      "norm_label": "checkoutformschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
+      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1339,
+      "community": 1329,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
-      "label": "customerDetailsSchema.ts",
-      "norm_label": "customerdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -49105,7 +49069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -49114,7 +49078,7 @@
       "source_location": "L12"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -49123,7 +49087,7 @@
       "source_location": "L21"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -49132,7 +49096,7 @@
       "source_location": "L101"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -49141,7 +49105,7 @@
       "source_location": "L35"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -49150,97 +49114,97 @@
       "source_location": "L66"
     },
     {
-      "community": 1340,
+      "community": 1330,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "label": "deliveryDetailsSchema.ts",
-      "norm_label": "deliverydetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1331,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1332,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
+      "id": "packages_storefront_webapp_src_components_upsell_tsx",
+      "label": "Upsell.tsx",
+      "norm_label": "upsell.tsx",
+      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1333,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
+      "label": "Checkout.test.tsx",
+      "norm_label": "checkout.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1334,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
-      "label": "ProductFilterBar.tsx",
-      "norm_label": "productfilterbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
+      "label": "Checkout.tsx",
+      "norm_label": "checkout.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1335,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
-      "label": "BestSellersSection.test.tsx",
-      "norm_label": "bestsellerssection.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1336,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "label": "HomeHero.tsx",
-      "norm_label": "homehero.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1337,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
+      "label": "DeliveryDetailsSection.tsx",
+      "norm_label": "deliverydetailssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1338,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
-      "label": "homePageContent.test.ts",
-      "norm_label": "homepagecontent.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
+      "label": "checkoutStorage.test.ts",
+      "norm_label": "checkoutstorage.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1349,
+      "community": 1339,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
-      "label": "MobileMenu.tsx",
-      "norm_label": "mobilemenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
+      "label": "deliveryFees.test.ts",
+      "norm_label": "deliveryfees.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -49249,7 +49213,7 @@
       "source_location": "L155"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -49258,7 +49222,7 @@
       "source_location": "L197"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -49267,7 +49231,7 @@
       "source_location": "L104"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -49276,7 +49240,7 @@
       "source_location": "L25"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -49285,7 +49249,7 @@
       "source_location": "L72"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -49294,97 +49258,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1350,
+      "community": 1340,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
+      "label": "deriveCheckoutState.test.ts",
+      "norm_label": "derivecheckoutstate.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1341,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1342,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
-      "label": "About.tsx",
-      "norm_label": "about.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
+      "label": "checkoutFormSchema.ts",
+      "norm_label": "checkoutformschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1343,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
-      "label": "AboutProduct.tsx",
-      "norm_label": "aboutproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
+      "label": "customerDetailsSchema.ts",
+      "norm_label": "customerdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1344,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
-      "label": "ProductActions.test.tsx",
-      "norm_label": "productactions.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
+      "label": "deliveryDetailsSchema.ts",
+      "norm_label": "deliverydetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1345,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "label": "ProductInfo.tsx",
-      "norm_label": "productinfo.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1346,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "label": "ProductReviews.tsx",
-      "norm_label": "productreviews.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1347,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1348,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "label": "ErrorMessage.tsx",
-      "norm_label": "errormessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
+      "label": "ProductFilterBar.tsx",
+      "norm_label": "productfilterbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1359,
+      "community": 1349,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
-      "label": "ExistingReviewMessage.tsx",
-      "norm_label": "existingreviewmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
+      "label": "BestSellersSection.test.tsx",
+      "norm_label": "bestsellerssection.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -49393,7 +49357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -49402,7 +49366,7 @@
       "source_location": "L231"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -49411,7 +49375,7 @@
       "source_location": "L167"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -49420,7 +49384,7 @@
       "source_location": "L116"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -49429,7 +49393,7 @@
       "source_location": "L83"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -49438,97 +49402,97 @@
       "source_location": "L29"
     },
     {
-      "community": 1360,
+      "community": 1350,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "label": "ReviewForm.tsx",
-      "norm_label": "reviewform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
+      "label": "HomeHero.tsx",
+      "norm_label": "homehero.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1351,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "label": "SuccessMessage.tsx",
-      "norm_label": "successmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1352,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
+      "label": "homePageContent.test.ts",
+      "norm_label": "homepagecontent.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1353,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "label": "SavedBag.tsx",
-      "norm_label": "savedbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
+      "label": "MobileMenu.tsx",
+      "norm_label": "mobilemenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1354,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "label": "SavedIcon.tsx",
-      "norm_label": "savedicon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1355,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
-      "label": "CartIcon.tsx",
-      "norm_label": "carticon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1356,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
+      "label": "About.tsx",
+      "norm_label": "about.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1357,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
+      "label": "AboutProduct.tsx",
+      "norm_label": "aboutproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1358,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
-      "label": "Maintenance.tsx",
-      "norm_label": "maintenance.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
+      "label": "ProductActions.test.tsx",
+      "norm_label": "productactions.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1369,
+      "community": 1359,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "label": "AnimatedCard.tsx",
-      "norm_label": "animatedcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
+      "label": "ProductInfo.tsx",
+      "norm_label": "productinfo.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -49537,7 +49501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -49546,7 +49510,7 @@
       "source_location": "L83"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -49555,7 +49519,7 @@
       "source_location": "L62"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -49564,7 +49528,7 @@
       "source_location": "L95"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -49573,7 +49537,7 @@
       "source_location": "L41"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -49582,97 +49546,97 @@
       "source_location": "L12"
     },
     {
-      "community": 1370,
+      "community": 1360,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
+      "label": "ProductReviews.tsx",
+      "norm_label": "productreviews.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1361,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "label": "alert.tsx",
-      "norm_label": "alert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1362,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "label": "breadcrumb.tsx",
-      "norm_label": "breadcrumb.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
+      "label": "ErrorMessage.tsx",
+      "norm_label": "errormessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1363,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
+      "label": "ExistingReviewMessage.tsx",
+      "norm_label": "existingreviewmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1364,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
+      "label": "ReviewForm.tsx",
+      "norm_label": "reviewform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1365,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
+      "label": "SuccessMessage.tsx",
+      "norm_label": "successmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1366,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1367,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
+      "label": "SavedBag.tsx",
+      "norm_label": "savedbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1368,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
+      "label": "SavedIcon.tsx",
+      "norm_label": "savedicon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1379,
+      "community": 1369,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
+      "label": "CartIcon.tsx",
+      "norm_label": "carticon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -49681,7 +49645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -49690,7 +49654,7 @@
       "source_location": "L4"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -49699,7 +49663,7 @@
       "source_location": "L49"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -49708,7 +49672,7 @@
       "source_location": "L34"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -49717,7 +49681,7 @@
       "source_location": "L74"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -49726,97 +49690,97 @@
       "source_location": "L6"
     },
     {
-      "community": 1380,
+      "community": 1370,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1371,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1372,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "label": "image-with-fallback.tsx",
-      "norm_label": "image-with-fallback.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
+      "label": "Maintenance.tsx",
+      "norm_label": "maintenance.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1373,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
+      "label": "AnimatedCard.tsx",
+      "norm_label": "animatedcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1374,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
-      "label": "input-with-end-button.tsx",
-      "norm_label": "input-with-end-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1375,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
+      "label": "alert.tsx",
+      "norm_label": "alert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1376,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
+      "label": "breadcrumb.tsx",
+      "norm_label": "breadcrumb.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1377,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "label": "LeaveAReviewModalForm.tsx",
-      "norm_label": "leaveareviewmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1378,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1389,
+      "community": 1379,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
-      "label": "welcomeBackModalAnimations.ts",
-      "norm_label": "welcomebackmodalanimations.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -49825,7 +49789,7 @@
       "source_location": "L173"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -49834,7 +49798,7 @@
       "source_location": "L102"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -49843,7 +49807,7 @@
       "source_location": "L201"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -49852,7 +49816,7 @@
       "source_location": "L150"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -49861,7 +49825,7 @@
       "source_location": "L155"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -49870,7 +49834,187 @@
       "source_location": "L1"
     },
     {
+      "community": 1380,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1382,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1383,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1384,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1385,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1386,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
+      "label": "image-with-fallback.tsx",
+      "norm_label": "image-with-fallback.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1387,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1388,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
+      "label": "input-with-end-button.tsx",
+      "norm_label": "input-with-end-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1389,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 1390,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
+      "label": "LeaveAReviewModalForm.tsx",
+      "norm_label": "leaveareviewmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1392,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1393,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
+      "label": "welcomeBackModalAnimations.ts",
+      "norm_label": "welcomebackmodalanimations.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -49879,7 +50023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -49888,7 +50032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -49897,7 +50041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -49906,7 +50050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -49915,48 +50059,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
       "norm_label": "scroll-area.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1396,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1397,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1398,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
@@ -50133,150 +50241,6 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1400,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1401,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1402,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1403,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1404,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1405,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/storefront-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1406,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1407,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1408,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "label": "useStorefrontObservability.ts",
-      "norm_label": "usestorefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
       "norm_label": "checkoutexpired()",
@@ -50284,7 +50248,7 @@
       "source_location": "L9"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -50293,7 +50257,7 @@
       "source_location": "L73"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -50302,7 +50266,7 @@
       "source_location": "L54"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -50311,7 +50275,7 @@
       "source_location": "L98"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -50320,7 +50284,7 @@
       "source_location": "L33"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -50329,7 +50293,187 @@
       "source_location": "L1"
     },
     {
+      "community": 1400,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1402,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1403,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1404,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1405,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1406,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1407,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1408,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1409,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 1410,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1412,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
+      "label": "useStorefrontObservability.ts",
+      "norm_label": "usestorefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1413,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -50338,7 +50482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -50347,7 +50491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -50356,7 +50500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -50365,7 +50509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -50374,48 +50518,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1416,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1417,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1418,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
@@ -50475,6 +50583,42 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1422,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1423,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1424,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
@@ -50482,7 +50626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -50491,7 +50635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -50500,7 +50644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -50509,7 +50653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -50518,48 +50662,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
       "norm_label": "states.ts",
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1426,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "label": "storefrontFailureObservability.test.ts",
-      "norm_label": "storefrontfailureobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1427,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "label": "storefrontJourneyEvents.test.ts",
-      "norm_label": "storefrontjourneyevents.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1428,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1"
     },
     {
@@ -50619,6 +50727,42 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
+      "label": "storefrontFailureObservability.test.ts",
+      "norm_label": "storefrontfailureobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
+      "label": "storefrontJourneyEvents.test.ts",
+      "norm_label": "storefrontjourneyevents.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1432,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1433,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1434,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
       "norm_label": "-homepageloader.test.ts",
@@ -50626,7 +50770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -50635,7 +50779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -50644,7 +50788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -50653,7 +50797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -50662,48 +50806,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1436,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "label": "rewards.index.tsx",
-      "norm_label": "rewards.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1437,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "label": "shop.saved.index.tsx",
-      "norm_label": "shop.saved.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1438,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "label": "bag.index.tsx",
-      "norm_label": "bag.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
-      "label": "complete.tsx",
-      "norm_label": "complete.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
       "source_location": "L1"
     },
     {
@@ -50763,6 +50871,42 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
+      "label": "rewards.index.tsx",
+      "norm_label": "rewards.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
+      "label": "shop.saved.index.tsx",
+      "norm_label": "shop.saved.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1442,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
+      "label": "bag.index.tsx",
+      "norm_label": "bag.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1443,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
+      "label": "complete.tsx",
+      "norm_label": "complete.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1444,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
       "norm_label": "incomplete.tsx",
@@ -50770,7 +50914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -50779,7 +50923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1442,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -50788,7 +50932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -50797,7 +50941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -50806,48 +50950,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
       "norm_label": "vitest.setup.ts",
       "source_file": "packages/storefront-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1446,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_index_js",
-      "label": "index.js",
-      "norm_label": "index.js",
-      "source_file": "packages/valkey-proxy-server/index.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1447,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_test_ts",
-      "label": "harness-app-registry.test.ts",
-      "norm_label": "harness-app-registry.test.ts",
-      "source_file": "scripts/harness-app-registry.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1448,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
-      "label": "valkey-runtime-app.test.ts",
-      "norm_label": "valkey-runtime-app.test.ts",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_test_ts",
-      "label": "harness-behavior-scenarios.test.ts",
-      "norm_label": "harness-behavior-scenarios.test.ts",
-      "source_file": "scripts/harness-behavior-scenarios.test.ts",
       "source_location": "L1"
     },
     {
@@ -50906,6 +51014,42 @@
     },
     {
       "community": 1450,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_index_js",
+      "label": "index.js",
+      "norm_label": "index.js",
+      "source_file": "packages/valkey-proxy-server/index.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_test_ts",
+      "label": "harness-app-registry.test.ts",
+      "norm_label": "harness-app-registry.test.ts",
+      "source_file": "scripts/harness-app-registry.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1452,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
+      "label": "valkey-runtime-app.test.ts",
+      "norm_label": "valkey-runtime-app.test.ts",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1453,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_scenarios_test_ts",
+      "label": "harness-behavior-scenarios.test.ts",
+      "norm_label": "harness-behavior-scenarios.test.ts",
+      "source_file": "scripts/harness-behavior-scenarios.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1454,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -51924,51 +52068,6 @@
     {
       "community": 161,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
       "norm_label": "pageheader.tsx",
@@ -51976,7 +52075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -51985,7 +52084,7 @@
       "source_location": "L29"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -51994,7 +52093,7 @@
       "source_location": "L7"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -52003,7 +52102,7 @@
       "source_location": "L48"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -52012,7 +52111,7 @@
       "source_location": "L65"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -52021,7 +52120,7 @@
       "source_location": "L20"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -52030,7 +52129,7 @@
       "source_location": "L50"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -52039,7 +52138,7 @@
       "source_location": "L342"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -52048,7 +52147,7 @@
       "source_location": "L322"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -52057,7 +52156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -52066,7 +52165,7 @@
       "source_location": "L61"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -52075,7 +52174,7 @@
       "source_location": "L57"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -52084,7 +52183,7 @@
       "source_location": "L98"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -52093,7 +52192,7 @@
       "source_location": "L134"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -52102,7 +52201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -52111,7 +52210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -52120,7 +52219,7 @@
       "source_location": "L38"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -52129,7 +52228,7 @@
       "source_location": "L64"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -52138,7 +52237,7 @@
       "source_location": "L135"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -52147,7 +52246,7 @@
       "source_location": "L43"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -52156,7 +52255,7 @@
       "source_location": "L58"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -52165,7 +52264,7 @@
       "source_location": "L63"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -52174,7 +52273,7 @@
       "source_location": "L50"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -52183,7 +52282,7 @@
       "source_location": "L53"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -52192,7 +52291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -52201,7 +52300,7 @@
       "source_location": "L140"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -52210,7 +52309,7 @@
       "source_location": "L177"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -52219,7 +52318,7 @@
       "source_location": "L195"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -52228,7 +52327,7 @@
       "source_location": "L45"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -52237,7 +52336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -52246,7 +52345,7 @@
       "source_location": "L92"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -52255,7 +52354,7 @@
       "source_location": "L307"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -52264,7 +52363,7 @@
       "source_location": "L70"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -52273,12 +52372,57 @@
       "source_location": "L50"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -52941,164 +53085,164 @@
     {
       "community": 18,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L272"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "label": "RegisterSessionView.tsx",
+      "norm_label": "registersessionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L375"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_builddepositsubmissionkey",
+      "label": "buildDepositSubmissionKey()",
+      "norm_label": "builddepositsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L149"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_buildlifecyclerows",
+      "label": "buildLifecycleRows()",
+      "norm_label": "buildlifecyclerows()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L215"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_canopentransaction",
+      "label": "canOpenTransaction()",
+      "norm_label": "canopentransaction()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L706"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L960"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L153"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L172"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_formatregisterheadername",
+      "label": "formatRegisterHeaderName()",
+      "norm_label": "formatregisterheadername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L185"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L180"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_formatstaffbyline",
+      "label": "formatStaffByline()",
+      "norm_label": "formatstaffbyline()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L207"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L168"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L279"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L199"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_handlerecorddeposit",
+      "label": "handleRecordDeposit()",
+      "norm_label": "handlerecorddeposit()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L385"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_opentransaction",
+      "label": "openTransaction()",
+      "norm_label": "opentransaction()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L679"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "registersessionview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L144"
     },
     {
       "community": 180,
@@ -53544,155 +53688,164 @@
     {
       "community": 19,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
-      "label": "staffCredentials.ts",
-      "norm_label": "staffcredentials.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_assertstaffprofilereadyforcredential",
-      "label": "assertStaffProfileReadyForCredential()",
-      "norm_label": "assertstaffprofilereadyforcredential()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
-      "label": "authenticateStaffCredentialForTerminalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L496"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialwithctx",
-      "label": "authenticateStaffCredentialWithCtx()",
-      "norm_label": "authenticatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L406"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_createstaffcredentialwithctx",
-      "label": "createStaffCredentialWithCtx()",
-      "norm_label": "createstaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getactiverolesforstaffprofile",
-      "label": "getActiveRolesForStaffProfile()",
-      "norm_label": "getactiverolesforstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyid",
-      "label": "getCredentialById()",
-      "norm_label": "getcredentialbyid()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getcredentialbyusername",
-      "label": "getCredentialByUsername()",
-      "norm_label": "getcredentialbyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
-      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
-      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
-      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
-      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_invalidstaffcredentialsresult",
-      "label": "invalidStaffCredentialsResult()",
-      "norm_label": "invalidstaffcredentialsresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
-      "label": "listStaffCredentialsByStoreWithCtx()",
-      "norm_label": "liststaffcredentialsbystorewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_normalizeusername",
-      "label": "normalizeUsername()",
-      "norm_label": "normalizeusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_requirenonemptyusername",
-      "label": "requireNonEmptyUsername()",
-      "norm_label": "requirenonemptyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_staffauthorizationfailedresult",
-      "label": "staffAuthorizationFailedResult()",
-      "norm_label": "staffauthorizationfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_staffpreconditionfailedresult",
-      "label": "staffPreconditionFailedResult()",
-      "norm_label": "staffpreconditionfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "staffcredentials_updatestaffcredentialwithctx",
-      "label": "updateStaffCredentialWithCtx()",
-      "norm_label": "updatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L310"
     },
     {
       "community": 190,
@@ -54354,155 +54507,155 @@
     {
       "community": 20,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
+      "label": "staffCredentials.ts",
+      "norm_label": "staffcredentials.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
       "source_location": "L1"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_assertstaffprofilereadyforcredential",
+      "label": "assertStaffProfileReadyForCredential()",
+      "norm_label": "assertstaffprofilereadyforcredential()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L164"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
+      "label": "authenticateStaffCredentialForTerminalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L496"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_authenticatestaffcredentialwithctx",
+      "label": "authenticateStaffCredentialWithCtx()",
+      "norm_label": "authenticatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L406"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_createstaffcredentialwithctx",
+      "label": "createStaffCredentialWithCtx()",
+      "norm_label": "createstaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L268"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_getactiverolesforstaffprofile",
+      "label": "getActiveRolesForStaffProfile()",
+      "norm_label": "getactiverolesforstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L141"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_getcredentialbyid",
+      "label": "getCredentialById()",
+      "norm_label": "getcredentialbyid()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L113"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_getcredentialbyusername",
+      "label": "getCredentialByUsername()",
+      "norm_label": "getcredentialbyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L120"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
+      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
+      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L78"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
+      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
+      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L198"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_invalidstaffcredentialsresult",
+      "label": "invalidStaffCredentialsResult()",
+      "norm_label": "invalidstaffcredentialsresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L53"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
+      "label": "listStaffCredentialsByStoreWithCtx()",
+      "norm_label": "liststaffcredentialsbystorewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L217"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_normalizeusername",
+      "label": "normalizeUsername()",
+      "norm_label": "normalizeusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L39"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_requirenonemptyusername",
+      "label": "requireNonEmptyUsername()",
+      "norm_label": "requirenonemptyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L43"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_staffauthorizationfailedresult",
+      "label": "staffAuthorizationFailedResult()",
+      "norm_label": "staffauthorizationfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L60"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "staffcredentials_staffpreconditionfailedresult",
+      "label": "staffPreconditionFailedResult()",
+      "norm_label": "staffpreconditionfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "staffcredentials_updatestaffcredentialwithctx",
+      "label": "updateStaffCredentialWithCtx()",
+      "norm_label": "updatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L310"
     },
     {
       "community": 200,
@@ -54867,154 +55020,154 @@
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L131"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
@@ -55380,154 +55533,154 @@
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L215"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L131"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L119"
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
     },
     {
       "community": 22,
       "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1"
     },
     {
@@ -55753,7 +55906,7 @@
       "label": "getBalanceDueAmount()",
       "norm_label": "getbalancedueamount()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L39"
+      "source_location": "L36"
     },
     {
       "community": 226,
@@ -55762,7 +55915,7 @@
       "label": "getBalanceDueLabel()",
       "norm_label": "getbalanceduelabel()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L56"
+      "source_location": "L53"
     },
     {
       "community": 226,
@@ -55771,7 +55924,7 @@
       "label": "stripWhitespace()",
       "norm_label": "stripwhitespace()",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L35"
+      "source_location": "L32"
     },
     {
       "community": 226,
@@ -55893,146 +56046,155 @@
     {
       "community": 23,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
-      "label": "registerSessions.ts",
-      "norm_label": "registersessions.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L1"
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_assertregistersessionidentity",
-      "label": "assertRegisterSessionIdentity()",
-      "norm_label": "assertregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L61"
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_assertregistersessionmatchestransaction",
-      "label": "assertRegisterSessionMatchesTransaction()",
-      "norm_label": "assertregistersessionmatchestransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L71"
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_assertvalidregistersessiontransition",
-      "label": "assertValidRegisterSessionTransition()",
-      "norm_label": "assertvalidregistersessiontransition()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L128"
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_buildclosedregistersessionpatch",
-      "label": "buildClosedRegisterSessionPatch()",
-      "norm_label": "buildclosedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L243"
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L93"
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_buildregistersessioncloseoutpatch",
-      "label": "buildRegisterSessionCloseoutPatch()",
-      "norm_label": "buildregistersessioncloseoutpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L188"
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiondepositpatch",
-      "label": "buildRegisterSessionDepositPatch()",
-      "norm_label": "buildregistersessiondepositpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L214"
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L131"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiontransactionpatch",
-      "label": "buildRegisterSessionTransactionPatch()",
-      "norm_label": "buildregistersessiontransactionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L147"
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_calculateregistersessioncashdelta",
-      "label": "calculateRegisterSessionCashDelta()",
-      "norm_label": "calculateregistersessioncashdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L115"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "registersessions_findconflictingregistersession",
-      "label": "findConflictingRegisterSession()",
-      "norm_label": "findconflictingregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L269"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "registersessions_normalizeregistersessionidentity",
-      "label": "normalizeRegisterSessionIdentity()",
-      "norm_label": "normalizeregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "registersessions_recordregistersessiondepositwithctx",
-      "label": "recordRegisterSessionDepositWithCtx()",
-      "norm_label": "recordregistersessiondepositwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L546"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "registersessions_registersessionstatusset",
-      "label": "registerSessionStatusSet()",
-      "norm_label": "registersessionstatusset()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "registersessions_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L27"
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L1"
     },
     {
       "community": 230,
@@ -56073,6 +56235,42 @@
     {
       "community": 231,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
+      "label": "TransactionsView.tsx",
+      "norm_label": "transactionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "transactionsview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "transactionsview_formatregisterfilterlabel",
+      "label": "formatRegisterFilterLabel()",
+      "norm_label": "formatregisterfilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "transactionsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
       "norm_label": "procurementview.tsx",
@@ -56080,7 +56278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -56089,7 +56287,7 @@
       "source_location": "L78"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -56098,7 +56296,7 @@
       "source_location": "L118"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -56107,7 +56305,7 @@
       "source_location": "L89"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -56116,7 +56314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -56125,7 +56323,7 @@
       "source_location": "L63"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -56134,7 +56332,7 @@
       "source_location": "L54"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -56143,7 +56341,7 @@
       "source_location": "L11"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -56152,7 +56350,7 @@
       "source_location": "L16"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -56161,7 +56359,7 @@
       "source_location": "L35"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -56170,7 +56368,7 @@
       "source_location": "L6"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -56179,7 +56377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -56188,7 +56386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -56197,7 +56395,7 @@
       "source_location": "L5"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -56206,7 +56404,7 @@
       "source_location": "L30"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -56215,7 +56413,7 @@
       "source_location": "L21"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -56224,7 +56422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -56233,7 +56431,7 @@
       "source_location": "L178"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -56242,7 +56440,7 @@
       "source_location": "L205"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -56251,7 +56449,7 @@
       "source_location": "L806"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -56260,7 +56458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -56269,7 +56467,7 @@
       "source_location": "L41"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -56278,7 +56476,7 @@
       "source_location": "L45"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -56287,7 +56485,7 @@
       "source_location": "L65"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -56296,7 +56494,7 @@
       "source_location": "L75"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -56305,7 +56503,7 @@
       "source_location": "L82"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -56314,7 +56512,7 @@
       "source_location": "L93"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -56323,7 +56521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -56332,7 +56530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -56341,7 +56539,7 @@
       "source_location": "L15"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -56350,7 +56548,7 @@
       "source_location": "L28"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -56359,7 +56557,151 @@
       "source_location": "L54"
     },
     {
-      "community": 239,
+      "community": 24,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "label": "registerSessions.ts",
+      "norm_label": "registersessions.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_assertregistersessionidentity",
+      "label": "assertRegisterSessionIdentity()",
+      "norm_label": "assertregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_assertregistersessionmatchestransaction",
+      "label": "assertRegisterSessionMatchesTransaction()",
+      "norm_label": "assertregistersessionmatchestransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_assertvalidregistersessiontransition",
+      "label": "assertValidRegisterSessionTransition()",
+      "norm_label": "assertvalidregistersessiontransition()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_buildclosedregistersessionpatch",
+      "label": "buildClosedRegisterSessionPatch()",
+      "norm_label": "buildclosedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L243"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_buildregistersessioncloseoutpatch",
+      "label": "buildRegisterSessionCloseoutPatch()",
+      "norm_label": "buildregistersessioncloseoutpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_buildregistersessiondepositpatch",
+      "label": "buildRegisterSessionDepositPatch()",
+      "norm_label": "buildregistersessiondepositpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_buildregistersessiontransactionpatch",
+      "label": "buildRegisterSessionTransactionPatch()",
+      "norm_label": "buildregistersessiontransactionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_calculateregistersessioncashdelta",
+      "label": "calculateRegisterSessionCashDelta()",
+      "norm_label": "calculateregistersessioncashdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_findconflictingregistersession",
+      "label": "findConflictingRegisterSession()",
+      "norm_label": "findconflictingregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L269"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_normalizeregistersessionidentity",
+      "label": "normalizeRegisterSessionIdentity()",
+      "norm_label": "normalizeregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_recordregistersessiondepositwithctx",
+      "label": "recordRegisterSessionDepositWithCtx()",
+      "norm_label": "recordregistersessiondepositwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L546"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_registersessionstatusset",
+      "label": "registerSessionStatusSet()",
+      "norm_label": "registersessionstatusset()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "registersessions_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 240,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -56368,7 +56710,7 @@
       "source_location": "L66"
     },
     {
-      "community": 239,
+      "community": 240,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -56377,7 +56719,7 @@
       "source_location": "L121"
     },
     {
-      "community": 239,
+      "community": 240,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -56386,7 +56728,7 @@
       "source_location": "L74"
     },
     {
-      "community": 239,
+      "community": 240,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -56395,151 +56737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_assertvalidonlineorderstatustransition",
-      "label": "assertValidOnlineOrderStatusTransition()",
-      "norm_label": "assertvalidonlineorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentamount",
-      "label": "getOnlineOrderPaymentAmount()",
-      "norm_label": "getonlineorderpaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentmethodlabel",
-      "label": "getOnlineOrderPaymentMethodLabel()",
-      "norm_label": "getonlineorderpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderstatuseventtype",
-      "label": "getOnlineOrderStatusEventType()",
-      "norm_label": "getonlineorderstatuseventtype()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_ispaymentondeliveryorder",
-      "label": "isPaymentOnDeliveryOrder()",
-      "norm_label": "ispaymentondeliveryorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineordercreatedevent",
-      "label": "recordOnlineOrderCreatedEvent()",
-      "norm_label": "recordonlineordercreatedevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderfulfillmentmovement",
-      "label": "recordOnlineOrderFulfillmentMovement()",
-      "norm_label": "recordonlineorderfulfillmentmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L381"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentcollected",
-      "label": "recordOnlineOrderPaymentCollected()",
-      "norm_label": "recordonlineorderpaymentcollected()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentverified",
-      "label": "recordOnlineOrderPaymentVerified()",
-      "norm_label": "recordonlineorderpaymentverified()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrefundallocation",
-      "label": "recordOnlineOrderRefundAllocation()",
-      "norm_label": "recordonlineorderrefundallocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrestockmovement",
-      "label": "recordOnlineOrderRestockMovement()",
-      "norm_label": "recordonlineorderrestockmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderstatusevent",
-      "label": "recordOnlineOrderStatusEvent()",
-      "norm_label": "recordonlineorderstatusevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
-      "label": "resolveCustomerProfileForStoreFrontActor()",
-      "norm_label": "resolvecustomerprofileforstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "orderoperations_resolveonlineordercontext",
-      "label": "resolveOnlineOrderContext()",
-      "norm_label": "resolveonlineordercontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
-      "label": "orderOperations.ts",
-      "norm_label": "orderoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -56548,7 +56746,7 @@
       "source_location": "L51"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -56557,7 +56755,7 @@
       "source_location": "L92"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -56566,7 +56764,7 @@
       "source_location": "L16"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -56575,7 +56773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -56584,7 +56782,7 @@
       "source_location": "L22"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -56593,7 +56791,7 @@
       "source_location": "L10"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -56602,7 +56800,7 @@
       "source_location": "L57"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -56611,7 +56809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -56620,7 +56818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -56629,7 +56827,7 @@
       "source_location": "L83"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -56638,7 +56836,7 @@
       "source_location": "L100"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -56647,7 +56845,7 @@
       "source_location": "L79"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -56656,7 +56854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -56665,7 +56863,7 @@
       "source_location": "L38"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -56674,7 +56872,7 @@
       "source_location": "L65"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -56683,7 +56881,7 @@
       "source_location": "L91"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -56692,7 +56890,7 @@
       "source_location": "L4"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -56701,7 +56899,7 @@
       "source_location": "L20"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -56710,7 +56908,7 @@
       "source_location": "L42"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -56719,7 +56917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -56728,7 +56926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -56737,7 +56935,7 @@
       "source_location": "L36"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -56746,7 +56944,7 @@
       "source_location": "L48"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -56755,7 +56953,7 @@
       "source_location": "L64"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -56764,7 +56962,7 @@
       "source_location": "L102"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -56773,7 +56971,7 @@
       "source_location": "L69"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -56782,7 +56980,7 @@
       "source_location": "L43"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -56791,7 +56989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -56800,7 +56998,7 @@
       "source_location": "L13"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -56809,7 +57007,7 @@
       "source_location": "L46"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -56818,7 +57016,7 @@
       "source_location": "L21"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -56827,7 +57025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -56836,7 +57034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -56845,7 +57043,7 @@
       "source_location": "L8"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -56854,7 +57052,7 @@
       "source_location": "L5"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -56863,7 +57061,151 @@
       "source_location": "L20"
     },
     {
-      "community": 249,
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_assertvalidonlineorderstatustransition",
+      "label": "assertValidOnlineOrderStatusTransition()",
+      "norm_label": "assertvalidonlineorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentamount",
+      "label": "getOnlineOrderPaymentAmount()",
+      "norm_label": "getonlineorderpaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentmethodlabel",
+      "label": "getOnlineOrderPaymentMethodLabel()",
+      "norm_label": "getonlineorderpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderstatuseventtype",
+      "label": "getOnlineOrderStatusEventType()",
+      "norm_label": "getonlineorderstatuseventtype()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_ispaymentondeliveryorder",
+      "label": "isPaymentOnDeliveryOrder()",
+      "norm_label": "ispaymentondeliveryorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineordercreatedevent",
+      "label": "recordOnlineOrderCreatedEvent()",
+      "norm_label": "recordonlineordercreatedevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderfulfillmentmovement",
+      "label": "recordOnlineOrderFulfillmentMovement()",
+      "norm_label": "recordonlineorderfulfillmentmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentcollected",
+      "label": "recordOnlineOrderPaymentCollected()",
+      "norm_label": "recordonlineorderpaymentcollected()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentverified",
+      "label": "recordOnlineOrderPaymentVerified()",
+      "norm_label": "recordonlineorderpaymentverified()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrefundallocation",
+      "label": "recordOnlineOrderRefundAllocation()",
+      "norm_label": "recordonlineorderrefundallocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrestockmovement",
+      "label": "recordOnlineOrderRestockMovement()",
+      "norm_label": "recordonlineorderrestockmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderstatusevent",
+      "label": "recordOnlineOrderStatusEvent()",
+      "norm_label": "recordonlineorderstatusevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
+      "label": "resolveCustomerProfileForStoreFrontActor()",
+      "norm_label": "resolvecustomerprofileforstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "orderoperations_resolveonlineordercontext",
+      "label": "resolveOnlineOrderContext()",
+      "norm_label": "resolveonlineordercontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
+      "label": "orderOperations.ts",
+      "norm_label": "orderoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -56872,7 +57214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 249,
+      "community": 250,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -56881,7 +57223,7 @@
       "source_location": "L11"
     },
     {
-      "community": 249,
+      "community": 250,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -56890,7 +57232,7 @@
       "source_location": "L9"
     },
     {
-      "community": 249,
+      "community": 250,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -56899,151 +57241,7 @@
       "source_location": "L25"
     },
     {
-      "community": 25,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
-      "label": "RegisterSessionView.tsx",
-      "norm_label": "registersessionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L300"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_builddepositsubmissionkey",
-      "label": "buildDepositSubmissionKey()",
-      "norm_label": "builddepositsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L146"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_canopentransaction",
-      "label": "canOpenTransaction()",
-      "norm_label": "canopentransaction()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L611"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L865"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_formatregisterheadername",
-      "label": "formatRegisterHeaderName()",
-      "norm_label": "formatregisterheadername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L182"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L165"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L158"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L204"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L196"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_handlerecorddeposit",
-      "label": "handleRecordDeposit()",
-      "norm_label": "handlerecorddeposit()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L310"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_opentransaction",
-      "label": "openTransaction()",
-      "norm_label": "opentransaction()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L584"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessionview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -57052,7 +57250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -57061,7 +57259,7 @@
       "source_location": "L50"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -57070,7 +57268,7 @@
       "source_location": "L92"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -57079,7 +57277,7 @@
       "source_location": "L74"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -57088,7 +57286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -57097,7 +57295,7 @@
       "source_location": "L62"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -57106,7 +57304,7 @@
       "source_location": "L109"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -57115,7 +57313,7 @@
       "source_location": "L177"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -57124,7 +57322,7 @@
       "source_location": "L18"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -57133,7 +57331,7 @@
       "source_location": "L52"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -57142,7 +57340,7 @@
       "source_location": "L68"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -57151,7 +57349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -57160,7 +57358,7 @@
       "source_location": "L68"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -57169,7 +57367,7 @@
       "source_location": "L26"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -57178,7 +57376,7 @@
       "source_location": "L7"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -57187,7 +57385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -57196,7 +57394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -57205,7 +57403,7 @@
       "source_location": "L81"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -57214,7 +57412,7 @@
       "source_location": "L85"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -57223,7 +57421,7 @@
       "source_location": "L27"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -57232,7 +57430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -57241,7 +57439,7 @@
       "source_location": "L43"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -57250,7 +57448,7 @@
       "source_location": "L13"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -57259,7 +57457,7 @@
       "source_location": "L88"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -57268,7 +57466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -57277,7 +57475,7 @@
       "source_location": "L111"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -57286,7 +57484,7 @@
       "source_location": "L66"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -57295,7 +57493,7 @@
       "source_location": "L127"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -57304,7 +57502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -57313,7 +57511,7 @@
       "source_location": "L115"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -57322,7 +57520,7 @@
       "source_location": "L105"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -57331,7 +57529,7 @@
       "source_location": "L110"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -57340,7 +57538,7 @@
       "source_location": "L121"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -57349,7 +57547,7 @@
       "source_location": "L26"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -57358,48 +57556,12 @@
       "source_location": "L71"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "bootstrap_bootstrapcheckout",
-      "label": "bootstrapCheckout()",
-      "norm_label": "bootstrapcheckout()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "bootstrap_createbootstraptoken",
-      "label": "createBootstrapToken()",
-      "norm_label": "createbootstraptoken()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "bootstrap_createmarker",
-      "label": "createMarker()",
-      "norm_label": "createmarker()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "label": "bootstrap.ts",
-      "norm_label": "bootstrap.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1"
     },
     {
@@ -57549,6 +57711,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "bootstrap_bootstrapcheckout",
+      "label": "bootstrapCheckout()",
+      "norm_label": "bootstrapcheckout()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "bootstrap_createbootstraptoken",
+      "label": "createBootstrapToken()",
+      "norm_label": "createbootstraptoken()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "bootstrap_createmarker",
+      "label": "createMarker()",
+      "norm_label": "createmarker()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
+      "label": "bootstrap.ts",
+      "norm_label": "bootstrap.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
       "norm_label": "createinmemoryredis()",
@@ -57556,7 +57754,7 @@
       "source_location": "L33"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -57565,7 +57763,7 @@
       "source_location": "L6"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -57574,7 +57772,7 @@
       "source_location": "L25"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -57583,7 +57781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -57592,7 +57790,7 @@
       "source_location": "L17"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -57601,7 +57799,7 @@
       "source_location": "L11"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -57610,7 +57808,7 @@
       "source_location": "L24"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -57619,7 +57817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -57628,7 +57826,7 @@
       "source_location": "L20"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -57637,7 +57835,7 @@
       "source_location": "L65"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -57646,7 +57844,7 @@
       "source_location": "L14"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -57655,7 +57853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -57664,7 +57862,7 @@
       "source_location": "L126"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -57673,7 +57871,7 @@
       "source_location": "L130"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -57682,7 +57880,7 @@
       "source_location": "L874"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -57691,7 +57889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -57700,7 +57898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -57709,7 +57907,7 @@
       "source_location": "L8"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -57718,7 +57916,7 @@
       "source_location": "L79"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -57727,7 +57925,7 @@
       "source_location": "L61"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -57736,7 +57934,7 @@
       "source_location": "L49"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -57745,7 +57943,7 @@
       "source_location": "L17"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -57754,7 +57952,7 @@
       "source_location": "L11"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -57763,7 +57961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -57772,7 +57970,7 @@
       "source_location": "L26"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -57781,7 +57979,7 @@
       "source_location": "L72"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -57790,7 +57988,7 @@
       "source_location": "L36"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -57799,7 +57997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -57808,7 +58006,7 @@
       "source_location": "L96"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -57817,7 +58015,7 @@
       "source_location": "L94"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -57826,7 +58024,7 @@
       "source_location": "L95"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -57835,7 +58033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -57844,7 +58042,7 @@
       "source_location": "L98"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -57853,39 +58051,12 @@
       "source_location": "L33"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
       "norm_label": "discountcode.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "discountreminder_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "discountreminder_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "label": "DiscountReminder.tsx",
-      "norm_label": "discountreminder.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1"
     },
     {
@@ -57922,7 +58093,7 @@
       "label": "collectStaffProfileIds()",
       "norm_label": "collectstaffprofileids()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L363"
+      "source_location": "L347"
     },
     {
       "community": 27,
@@ -57940,7 +58111,7 @@
       "label": "listRegisterSessionsForDashboard()",
       "norm_label": "listregistersessionsfordashboard()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L281"
+      "source_location": "L282"
     },
     {
       "community": 27,
@@ -57949,7 +58120,7 @@
       "label": "listRegisterSessionTimeline()",
       "norm_label": "listregistersessiontimeline()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L337"
+      "source_location": "L321"
     },
     {
       "community": 27,
@@ -57958,7 +58129,7 @@
       "label": "listRegisterSessionTransactions()",
       "norm_label": "listregistersessiontransactions()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L350"
+      "source_location": "L334"
     },
     {
       "community": 27,
@@ -57967,7 +58138,7 @@
       "label": "listSessionDeposits()",
       "norm_label": "listsessiondeposits()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L323"
+      "source_location": "L307"
     },
     {
       "community": 27,
@@ -57985,7 +58156,7 @@
       "label": "listStoreDeposits()",
       "norm_label": "liststoredeposits()",
       "source_file": "packages/athena-webapp/convex/cashControls/deposits.ts",
-      "source_location": "L309"
+      "source_location": "L293"
     },
     {
       "community": 27,
@@ -58026,6 +58197,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "discountreminder_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "discountreminder_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
+      "label": "DiscountReminder.tsx",
+      "norm_label": "discountreminder.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
       "norm_label": "removestorefronthiddencategories()",
@@ -58033,7 +58231,7 @@
       "source_location": "L12"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -58042,7 +58240,7 @@
       "source_location": "L21"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -58051,7 +58249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -58060,7 +58258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -58069,7 +58267,7 @@
       "source_location": "L5"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -58078,7 +58276,7 @@
       "source_location": "L12"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -58087,7 +58285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -58096,7 +58294,7 @@
       "source_location": "L14"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -58105,7 +58303,7 @@
       "source_location": "L10"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -58114,7 +58312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -58123,7 +58321,7 @@
       "source_location": "L6"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -58132,7 +58330,7 @@
       "source_location": "L9"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -58141,7 +58339,7 @@
       "source_location": "L43"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -58150,7 +58348,7 @@
       "source_location": "L11"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -58159,7 +58357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -58168,7 +58366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -58177,7 +58375,7 @@
       "source_location": "L23"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -58186,7 +58384,7 @@
       "source_location": "L105"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -58195,7 +58393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -58204,7 +58402,7 @@
       "source_location": "L16"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -58213,7 +58411,7 @@
       "source_location": "L92"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -58222,7 +58420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -58231,7 +58429,7 @@
       "source_location": "L21"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -58240,7 +58438,7 @@
       "source_location": "L31"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -58249,7 +58447,7 @@
       "source_location": "L7"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -58258,39 +58456,12 @@
       "source_location": "L109"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "getregisterstate_buildregisterstate",
-      "label": "buildRegisterState()",
-      "norm_label": "buildregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "getregisterstate_getregisterstate",
-      "label": "getRegisterState()",
-      "norm_label": "getregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
-      "label": "getRegisterState.ts",
-      "norm_label": "getregisterstate.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
       "source_location": "L1"
     },
     {
@@ -58431,6 +58602,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "getregisterstate_buildregisterstate",
+      "label": "buildRegisterState()",
+      "norm_label": "buildregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "getregisterstate_getregisterstate",
+      "label": "getRegisterState()",
+      "norm_label": "getregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
+      "label": "getRegisterState.ts",
+      "norm_label": "getregisterstate.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
       "norm_label": "terminals.ts",
@@ -58438,7 +58636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -58447,7 +58645,7 @@
       "source_location": "L18"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -58456,7 +58654,7 @@
       "source_location": "L9"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -58465,7 +58663,7 @@
       "source_location": "L8"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -58474,7 +58672,7 @@
       "source_location": "L9"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -58483,7 +58681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -58492,7 +58690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -58501,7 +58699,7 @@
       "source_location": "L7"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -58510,7 +58708,7 @@
       "source_location": "L29"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -58519,7 +58717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -58528,7 +58726,7 @@
       "source_location": "L13"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -58537,7 +58735,7 @@
       "source_location": "L45"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -58546,7 +58744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -58555,7 +58753,7 @@
       "source_location": "L33"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -58564,7 +58762,7 @@
       "source_location": "L13"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -58573,7 +58771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -58582,7 +58780,7 @@
       "source_location": "L13"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -58591,7 +58789,7 @@
       "source_location": "L17"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -58600,7 +58798,7 @@
       "source_location": "L17"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -58609,7 +58807,7 @@
       "source_location": "L61"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -58618,7 +58816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -58627,7 +58825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -58636,7 +58834,7 @@
       "source_location": "L23"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -58645,7 +58843,7 @@
       "source_location": "L16"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -58654,7 +58852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -58663,40 +58861,13 @@
       "source_location": "L20"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
-      "label": "vendors.ts",
-      "norm_label": "vendors.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "vendors_normalizevendorlookupkey",
-      "label": "normalizeVendorLookupKey()",
-      "norm_label": "normalizevendorlookupkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "vendors_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L7"
     },
     {
       "community": 29,
@@ -58836,6 +59007,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
+      "label": "vendors.ts",
+      "norm_label": "vendors.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "vendors_normalizevendorlookupkey",
+      "label": "normalizeVendorLookupKey()",
+      "norm_label": "normalizevendorlookupkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "vendors_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
@@ -58843,7 +59041,7 @@
       "source_location": "L25"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -58852,7 +59050,7 @@
       "source_location": "L21"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -58861,7 +59059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -58870,7 +59068,7 @@
       "source_location": "L7"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -58879,7 +59077,7 @@
       "source_location": "L14"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -58888,7 +59086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -58897,7 +59095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -58906,7 +59104,7 @@
       "source_location": "L45"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -58915,7 +59113,7 @@
       "source_location": "L37"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -58924,7 +59122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -58933,7 +59131,7 @@
       "source_location": "L10"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -58942,7 +59140,7 @@
       "source_location": "L44"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -58951,7 +59149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -58960,7 +59158,7 @@
       "source_location": "L84"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -58969,7 +59167,7 @@
       "source_location": "L100"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -58978,7 +59176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -58987,7 +59185,7 @@
       "source_location": "L35"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -58996,7 +59194,7 @@
       "source_location": "L25"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -59005,7 +59203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -59014,7 +59212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -59023,7 +59221,7 @@
       "source_location": "L4"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -59032,7 +59230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -59041,7 +59239,7 @@
       "source_location": "L19"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -59050,7 +59248,7 @@
       "source_location": "L5"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -59059,7 +59257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -59068,40 +59266,13 @@
       "source_location": "L19"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
       "norm_label": "usesheet()",
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "label": "WigType.tsx",
-      "norm_label": "wigtype.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "wigtype_wigtype",
-      "label": "WigType()",
-      "norm_label": "wigtype()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "wigtype_wigtypeview",
-      "label": "WigTypeView()",
-      "norm_label": "wigtypeview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L8"
     },
     {
       "community": 3,
@@ -59385,411 +59556,6 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
-      "label": "RegisterCloseoutView.tsx",
-      "norm_label": "registercloseoutview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L219"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L631"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_formatreviewreason",
-      "label": "formatReviewReason()",
-      "norm_label": "formatreviewreason()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L148"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_formatsessionname",
-      "label": "formatSessionName()",
-      "norm_label": "formatsessionname()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_formatstoredamountforinput",
-      "label": "formatStoredAmountForInput()",
-      "norm_label": "formatstoredamountforinput()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_getdefaultactivesessionid",
-      "label": "getDefaultActiveSessionId()",
-      "norm_label": "getdefaultactivesessionid()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_getstatusbadgeclass",
-      "label": "getStatusBadgeClass()",
-      "norm_label": "getstatusbadgeclass()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_getvariance",
-      "label": "getVariance()",
-      "norm_label": "getvariance()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L111"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_handlereviewcloseout",
-      "label": "handleReviewCloseout()",
-      "norm_label": "handlereviewcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L278"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_handlesubmitcloseout",
-      "label": "handleSubmitCloseout()",
-      "norm_label": "handlesubmitcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L235"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "registercloseoutview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "copyimagesprovider_copyimagesprovider",
-      "label": "CopyImagesProvider()",
-      "norm_label": "copyimagesprovider()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "copyimagesprovider_usecopyimages",
-      "label": "useCopyImages()",
-      "norm_label": "usecopyimages()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
-      "label": "CopyImagesProvider.tsx",
-      "norm_label": "copyimagesprovider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "analyticscombinedusers_analyticscombinedusers",
-      "label": "AnalyticsCombinedUsers()",
-      "norm_label": "analyticscombinedusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "analyticscombinedusers_processanalyticstousers",
-      "label": "processAnalyticsToUsers()",
-      "norm_label": "processanalyticstousers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
-      "label": "AnalyticsCombinedUsers.tsx",
-      "norm_label": "analyticscombinedusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 302,
-      "file_type": "code",
-      "id": "analyticstopusers_analyticstopusers",
-      "label": "AnalyticsTopUsers()",
-      "norm_label": "analyticstopusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 302,
-      "file_type": "code",
-      "id": "analyticstopusers_processanalyticstousers",
-      "label": "processAnalyticsToUsers()",
-      "norm_label": "processanalyticstousers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 302,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
-      "label": "AnalyticsTopUsers.tsx",
-      "norm_label": "analyticstopusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 303,
-      "file_type": "code",
-      "id": "log_items_provider_logitemsprovider",
-      "label": "LogItemsProvider()",
-      "norm_label": "logitemsprovider()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 303,
-      "file_type": "code",
-      "id": "log_items_provider_uselogitems",
-      "label": "useLogItems()",
-      "norm_label": "uselogitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 303,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
-      "label": "log-items-provider.tsx",
-      "norm_label": "log-items-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 304,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 304,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 304,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "fadein_fadein",
-      "label": "FadeIn()",
-      "norm_label": "fadein()",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 306,
-      "file_type": "code",
-      "id": "bestsellers_handleremovebestseller",
-      "label": "handleRemoveBestSeller()",
-      "norm_label": "handleremovebestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 306,
-      "file_type": "code",
-      "id": "bestsellers_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 306,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "label": "BestSellers.tsx",
-      "norm_label": "bestsellers.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "featuredsection_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "featuredsection_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "label": "FeaturedSection.tsx",
-      "norm_label": "featuredsection.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "videoplayer_videoplayer",
-      "label": "VideoPlayer()",
-      "norm_label": "videoplayer()",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "operationsqueueview_handledecideapprovalrequest",
-      "label": "handleDecideApprovalRequest()",
-      "norm_label": "handledecideapprovalrequest()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L301"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "operationsqueueview_handlesubmitstockbatch",
-      "label": "handleSubmitStockBatch()",
-      "norm_label": "handlesubmitstockbatch()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L291"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
       "id": "harness_audit_addgroupederror",
       "label": "addGroupedError()",
       "norm_label": "addgroupederror()",
@@ -59797,7 +59563,7 @@
       "source_location": "L102"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_collectlivesurfaceentries",
       "label": "collectLiveSurfaceEntries()",
@@ -59806,7 +59572,7 @@
       "source_location": "L135"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_fileexists",
       "label": "fileExists()",
@@ -59815,7 +59581,7 @@
       "source_location": "L57"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_formatgroupederrors",
       "label": "formatGroupedErrors()",
@@ -59824,7 +59590,7 @@
       "source_location": "L341"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_hasanyharnessdocs",
       "label": "hasAnyHarnessDocs()",
@@ -59833,7 +59599,7 @@
       "source_location": "L66"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_infergroupfromerror",
       "label": "inferGroupFromError()",
@@ -59842,7 +59608,7 @@
       "source_location": "L116"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_loadaudittarget",
       "label": "loadAuditTarget()",
@@ -59851,7 +59617,7 @@
       "source_location": "L164"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_matchespathprefix",
       "label": "matchesPathPrefix()",
@@ -59860,7 +59626,7 @@
       "source_location": "L43"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_normalizebehaviorscenarioname",
       "label": "normalizeBehaviorScenarioName()",
@@ -59869,7 +59635,7 @@
       "source_location": "L98"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -59878,7 +59644,7 @@
       "source_location": "L39"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_normalizevalidationcommand",
       "label": "normalizeValidationCommand()",
@@ -59887,7 +59653,7 @@
       "source_location": "L90"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_readjsonfile",
       "label": "readJsonFile()",
@@ -59896,7 +59662,7 @@
       "source_location": "L86"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_runharnessaudit",
       "label": "runHarnessAudit()",
@@ -59905,7 +59671,7 @@
       "source_location": "L356"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "harness_audit_shouldskipsurfaceentry",
       "label": "shouldSkipSurfaceEntry()",
@@ -59914,7 +59680,7 @@
       "source_location": "L121"
     },
     {
-      "community": 31,
+      "community": 30,
       "file_type": "code",
       "id": "scripts_harness_audit_ts",
       "label": "harness-audit.ts",
@@ -59923,7 +59689,430 @@
       "source_location": "L1"
     },
     {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
+      "label": "WigType.tsx",
+      "norm_label": "wigtype.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "wigtype_wigtype",
+      "label": "WigType()",
+      "norm_label": "wigtype()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "wigtype_wigtypeview",
+      "label": "WigTypeView()",
+      "norm_label": "wigtypeview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "copyimagesprovider_copyimagesprovider",
+      "label": "CopyImagesProvider()",
+      "norm_label": "copyimagesprovider()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "copyimagesprovider_usecopyimages",
+      "label": "useCopyImages()",
+      "norm_label": "usecopyimages()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
+      "label": "CopyImagesProvider.tsx",
+      "norm_label": "copyimagesprovider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "analyticscombinedusers_analyticscombinedusers",
+      "label": "AnalyticsCombinedUsers()",
+      "norm_label": "analyticscombinedusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "analyticscombinedusers_processanalyticstousers",
+      "label": "processAnalyticsToUsers()",
+      "norm_label": "processanalyticstousers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
+      "label": "AnalyticsCombinedUsers.tsx",
+      "norm_label": "analyticscombinedusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 303,
+      "file_type": "code",
+      "id": "analyticstopusers_analyticstopusers",
+      "label": "AnalyticsTopUsers()",
+      "norm_label": "analyticstopusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 303,
+      "file_type": "code",
+      "id": "analyticstopusers_processanalyticstousers",
+      "label": "processAnalyticsToUsers()",
+      "norm_label": "processanalyticstousers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 303,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
+      "label": "AnalyticsTopUsers.tsx",
+      "norm_label": "analyticstopusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 304,
+      "file_type": "code",
+      "id": "log_items_provider_logitemsprovider",
+      "label": "LogItemsProvider()",
+      "norm_label": "logitemsprovider()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 304,
+      "file_type": "code",
+      "id": "log_items_provider_uselogitems",
+      "label": "useLogItems()",
+      "norm_label": "uselogitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 304,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
+      "label": "log-items-provider.tsx",
+      "norm_label": "log-items-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 306,
+      "file_type": "code",
+      "id": "fadein_fadein",
+      "label": "FadeIn()",
+      "norm_label": "fadein()",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 306,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 306,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 307,
+      "file_type": "code",
+      "id": "bestsellers_handleremovebestseller",
+      "label": "handleRemoveBestSeller()",
+      "norm_label": "handleremovebestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 307,
+      "file_type": "code",
+      "id": "bestsellers_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 307,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
+      "label": "BestSellers.tsx",
+      "norm_label": "bestsellers.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 308,
+      "file_type": "code",
+      "id": "featuredsection_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 308,
+      "file_type": "code",
+      "id": "featuredsection_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 308,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
+      "label": "FeaturedSection.tsx",
+      "norm_label": "featuredsection.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "videoplayer_videoplayer",
+      "label": "VideoPlayer()",
+      "norm_label": "videoplayer()",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_assertroleconfiguration",
+      "label": "assertRoleConfiguration()",
+      "norm_label": "assertroleconfiguration()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_buildstafffullname",
+      "label": "buildStaffFullName()",
+      "norm_label": "buildstafffullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_buildstaffprofileresult",
+      "label": "buildStaffProfileResult()",
+      "norm_label": "buildstaffprofileresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_createstaffprofilewithctx",
+      "label": "createStaffProfileWithCtx()",
+      "norm_label": "createstaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L292"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_ensurelinkeduseravailable",
+      "label": "ensureLinkedUserAvailable()",
+      "norm_label": "ensurelinkeduseravailable()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_getstaffprofilebyidwithctx",
+      "label": "getStaffProfileByIdWithCtx()",
+      "norm_label": "getstaffprofilebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_liststaffprofileswithctx",
+      "label": "listStaffProfilesWithCtx()",
+      "norm_label": "liststaffprofileswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L243"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_normalizeoptionalstring",
+      "label": "normalizeOptionalString()",
+      "norm_label": "normalizeoptionalstring()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_normalizestaffprofilepatch",
+      "label": "normalizeStaffProfilePatch()",
+      "norm_label": "normalizestaffprofilepatch()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_requirenamesegment",
+      "label": "requireNameSegment()",
+      "norm_label": "requirenamesegment()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_syncstaffroleassignmentswithctx",
+      "label": "syncStaffRoleAssignmentsWithCtx()",
+      "norm_label": "syncstaffroleassignmentswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "staffprofiles_updatestaffprofilewithctx",
+      "label": "updateStaffProfileWithCtx()",
+      "norm_label": "updatestaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L367"
+    },
+    {
       "community": 310,
+      "file_type": "code",
+      "id": "operationsqueueview_handledecideapprovalrequest",
+      "label": "handleDecideApprovalRequest()",
+      "norm_label": "handledecideapprovalrequest()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L301"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "operationsqueueview_handlesubmitstockbatch",
+      "label": "handleSubmitStockBatch()",
+      "norm_label": "handlesubmitstockbatch()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L291"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -59932,7 +60121,7 @@
       "source_location": "L70"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -59941,7 +60130,7 @@
       "source_location": "L227"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -59950,7 +60139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -59959,7 +60148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -59968,7 +60157,7 @@
       "source_location": "L71"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -59977,7 +60166,7 @@
       "source_location": "L9"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -59986,7 +60175,7 @@
       "source_location": "L100"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -59995,7 +60184,7 @@
       "source_location": "L95"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -60004,7 +60193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -60013,7 +60202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -60022,7 +60211,7 @@
       "source_location": "L115"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -60031,7 +60220,7 @@
       "source_location": "L82"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -60040,7 +60229,7 @@
       "source_location": "L28"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -60049,7 +60238,7 @@
       "source_location": "L34"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -60058,7 +60247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -60067,7 +60256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "registerdrawergate_cashcontrolsbutton",
       "label": "CashControlsButton()",
@@ -60076,7 +60265,7 @@
       "source_location": "L11"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -60085,7 +60274,7 @@
       "source_location": "L44"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -60094,7 +60283,7 @@
       "source_location": "L36"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -60103,40 +60292,13 @@
       "source_location": "L32"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
       "norm_label": "heldsessionslist.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "label": "TransactionsView.tsx",
-      "norm_label": "transactionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "transactionsview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "transactionsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L28"
     },
     {
       "community": 318,
@@ -60195,128 +60357,128 @@
     {
       "community": 32,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_tsx",
+      "label": "RegisterCloseoutView.tsx",
+      "norm_label": "registercloseoutview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
       "source_location": "L1"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_assertroleconfiguration",
-      "label": "assertRoleConfiguration()",
-      "norm_label": "assertroleconfiguration()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "registercloseoutview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L205"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "registercloseoutview_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L617"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "registercloseoutview_formatsessionname",
+      "label": "formatSessionName()",
+      "norm_label": "formatsessionname()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L97"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "registercloseoutview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "registercloseoutview_formatstoredamountforinput",
+      "label": "formatStoredAmountForInput()",
+      "norm_label": "formatstoredamountforinput()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L124"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "registercloseoutview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
       "source_location": "L105"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L83"
+      "id": "registercloseoutview_getdefaultactivesessionid",
+      "label": "getDefaultActiveSessionId()",
+      "norm_label": "getdefaultactivesessionid()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L149"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_buildstafffullname",
-      "label": "buildStaffFullName()",
-      "norm_label": "buildstafffullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L55"
+      "id": "registercloseoutview_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L128"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_buildstaffprofileresult",
-      "label": "buildStaffProfileResult()",
-      "norm_label": "buildstaffprofileresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L186"
+      "id": "registercloseoutview_getvariance",
+      "label": "getVariance()",
+      "norm_label": "getvariance()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L112"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_createstaffprofilewithctx",
-      "label": "createStaffProfileWithCtx()",
-      "norm_label": "createstaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L292"
+      "id": "registercloseoutview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L141"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_ensurelinkeduseravailable",
-      "label": "ensureLinkedUserAvailable()",
-      "norm_label": "ensurelinkeduseravailable()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L59"
+      "id": "registercloseoutview_handlereviewcloseout",
+      "label": "handleReviewCloseout()",
+      "norm_label": "handlereviewcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L264"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_getstaffprofilebyidwithctx",
-      "label": "getStaffProfileByIdWithCtx()",
-      "norm_label": "getstaffprofilebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L204"
+      "id": "registercloseoutview_handlesubmitcloseout",
+      "label": "handleSubmitCloseout()",
+      "norm_label": "handlesubmitcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L221"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "staffprofiles_liststaffprofileswithctx",
-      "label": "listStaffProfilesWithCtx()",
-      "norm_label": "liststaffprofileswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L243"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "staffprofiles_normalizeoptionalstring",
-      "label": "normalizeOptionalString()",
-      "norm_label": "normalizeoptionalstring()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "staffprofiles_normalizestaffprofilepatch",
-      "label": "normalizeStaffProfilePatch()",
-      "norm_label": "normalizestaffprofilepatch()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "staffprofiles_requirenamesegment",
-      "label": "requireNameSegment()",
-      "norm_label": "requirenamesegment()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "staffprofiles_syncstaffroleassignmentswithctx",
-      "label": "syncStaffRoleAssignmentsWithCtx()",
-      "norm_label": "syncstaffroleassignmentswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "staffprofiles_updatestaffprofilewithctx",
-      "label": "updateStaffProfileWithCtx()",
-      "norm_label": "updatestaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L367"
+      "id": "registercloseoutview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx",
+      "source_location": "L92"
     },
     {
       "community": 320,
@@ -65820,6 +65982,24 @@
     {
       "community": 471,
       "file_type": "code",
+      "id": "currencyformatter_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_currencyformatter_ts",
+      "label": "currencyFormatter.ts",
+      "norm_label": "currencyformatter.ts",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
       "norm_label": "serviceintake.ts",
@@ -65827,7 +66007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -65836,7 +66016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -65845,7 +66025,7 @@
       "source_location": "L7"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -65854,7 +66034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -65863,7 +66043,7 @@
       "source_location": "L12"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -65872,7 +66052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -65881,7 +66061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -65890,7 +66070,7 @@
       "source_location": "L11"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -65899,7 +66079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -65908,7 +66088,7 @@
       "source_location": "L11"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -65917,7 +66097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -65926,7 +66106,7 @@
       "source_location": "L3"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -65935,7 +66115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -65944,7 +66124,7 @@
       "source_location": "L12"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -65953,31 +66133,13 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
       "norm_label": "storedropdown()",
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
     },
     {
       "community": 48,
@@ -66081,6 +66243,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
       "norm_label": "storesdropdown.tsx",
@@ -66088,7 +66268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -66097,7 +66277,7 @@
       "source_location": "L42"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -66106,7 +66286,7 @@
       "source_location": "L31"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -66115,7 +66295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -66124,7 +66304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -66133,7 +66313,7 @@
       "source_location": "L10"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -66142,7 +66322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -66151,7 +66331,7 @@
       "source_location": "L14"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -66160,7 +66340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -66169,7 +66349,7 @@
       "source_location": "L5"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -66178,7 +66358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -66187,7 +66367,7 @@
       "source_location": "L10"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -66196,7 +66376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -66205,7 +66385,7 @@
       "source_location": "L15"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -66214,7 +66394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -66223,7 +66403,7 @@
       "source_location": "L13"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -66232,31 +66412,13 @@
       "source_location": "L118"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
       "norm_label": "copyimagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
     },
     {
       "community": 49,
@@ -66351,6 +66513,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
       "norm_label": "capitalizefirstletter()",
@@ -66358,7 +66538,7 @@
       "source_location": "L151"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -66367,7 +66547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -66376,7 +66556,7 @@
       "source_location": "L6"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -66385,7 +66565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -66394,7 +66574,7 @@
       "source_location": "L19"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -66403,7 +66583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -66412,7 +66592,7 @@
       "source_location": "L7"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -66421,7 +66601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -66430,7 +66610,7 @@
       "source_location": "L42"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -66439,7 +66619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -66448,7 +66628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -66457,7 +66637,7 @@
       "source_location": "L66"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -66466,7 +66646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -66475,7 +66655,7 @@
       "source_location": "L18"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -66484,7 +66664,7 @@
       "source_location": "L6"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -66493,7 +66673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -66502,30 +66682,12 @@
       "source_location": "L10"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1"
     },
     {
@@ -66873,6 +67035,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
       "norm_label": "useloadlogitems.ts",
@@ -66880,7 +67060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -66889,7 +67069,7 @@
       "source_location": "L12"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -66898,7 +67078,7 @@
       "source_location": "L3"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -66907,7 +67087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -66916,7 +67096,7 @@
       "source_location": "L5"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -66925,7 +67105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -66934,7 +67114,7 @@
       "source_location": "L49"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -66943,7 +67123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -66952,7 +67132,7 @@
       "source_location": "L23"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -66961,7 +67141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -66970,7 +67150,7 @@
       "source_location": "L50"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -66979,7 +67159,43 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
+      "file_type": "code",
+      "id": "cashcontrolsworkspaceheader_cashcontrolsworkspaceheader",
+      "label": "CashControlsWorkspaceHeader()",
+      "norm_label": "cashcontrolsworkspaceheader()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 507,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
+      "label": "CashControlsWorkspaceHeader.tsx",
+      "norm_label": "cashcontrolsworkspaceheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 508,
+      "file_type": "code",
+      "id": "formatreviewreason_formatreviewreason",
+      "label": "formatReviewReason()",
+      "norm_label": "formatreviewreason()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 508,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
+      "label": "formatReviewReason.ts",
+      "norm_label": "formatreviewreason.ts",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 509,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -66988,66 +67204,12 @@
       "source_location": "L13"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
       "norm_label": "checkoutsessionstable.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "checkoutsesssionsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
-      "label": "CheckoutSesssionsView.tsx",
-      "norm_label": "checkoutsesssionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "expensecompletion_expensecompletion",
-      "label": "ExpenseCompletion()",
-      "norm_label": "expensecompletion()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "label": "ExpenseCompletion.tsx",
-      "norm_label": "expensecompletion.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "expenseview_expenseview",
-      "label": "ExpenseView()",
-      "norm_label": "expenseview()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
-      "label": "ExpenseView.tsx",
-      "norm_label": "expenseview.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1"
     },
     {
@@ -67143,6 +67305,60 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "checkoutsesssionsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
+      "label": "CheckoutSesssionsView.tsx",
+      "norm_label": "checkoutsesssionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "expensecompletion_expensecompletion",
+      "label": "ExpenseCompletion()",
+      "norm_label": "expensecompletion()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
+      "label": "ExpenseCompletion.tsx",
+      "norm_label": "expensecompletion.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "expenseview_expenseview",
+      "label": "ExpenseView()",
+      "norm_label": "expenseview()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
+      "label": "ExpenseView.tsx",
+      "norm_label": "expenseview.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 513,
+      "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
       "norm_label": "handleaddbestseller()",
@@ -67150,7 +67366,7 @@
       "source_location": "L29"
     },
     {
-      "community": 510,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -67159,7 +67375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -67168,7 +67384,7 @@
       "source_location": "L37"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -67177,7 +67393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -67186,7 +67402,7 @@
       "source_location": "L25"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -67195,7 +67411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -67204,7 +67420,7 @@
       "source_location": "L83"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -67213,7 +67429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -67222,7 +67438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -67231,7 +67447,7 @@
       "source_location": "L35"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -67240,7 +67456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -67249,7 +67465,7 @@
       "source_location": "L28"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -67258,66 +67474,12 @@
       "source_location": "L12"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "customerdetailsview_customerdetailsview",
-      "label": "CustomerDetailsView()",
-      "norm_label": "customerdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "label": "CustomerDetailsView.tsx",
-      "norm_label": "customerdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "emailstatusview_handlesendorderemail",
-      "label": "handleSendOrderEmail()",
-      "norm_label": "handlesendorderemail()",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "label": "EmailStatusView.tsx",
-      "norm_label": "emailstatusview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1"
     },
     {
@@ -67413,6 +67575,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "customerdetailsview_customerdetailsview",
+      "label": "CustomerDetailsView()",
+      "norm_label": "customerdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
+      "label": "CustomerDetailsView.tsx",
+      "norm_label": "customerdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "emailstatusview_handlesendorderemail",
+      "label": "handleSendOrderEmail()",
+      "norm_label": "handlesendorderemail()",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
+      "label": "EmailStatusView.tsx",
+      "norm_label": "emailstatusview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 523,
+      "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
       "norm_label": "gettimefilter()",
@@ -67420,7 +67636,7 @@
       "source_location": "L35"
     },
     {
-      "community": 520,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -67429,7 +67645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -67438,7 +67654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -67447,7 +67663,7 @@
       "source_location": "L81"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -67456,7 +67672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -67465,7 +67681,7 @@
       "source_location": "L6"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -67474,7 +67690,7 @@
       "source_location": "L34"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -67483,7 +67699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -67492,7 +67708,7 @@
       "source_location": "L89"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -67501,7 +67717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -67510,7 +67726,7 @@
       "source_location": "L215"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -67519,7 +67735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -67528,67 +67744,13 @@
       "source_location": "L5"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
       "norm_label": "debugproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "noresultsmessage_noresultsmessage",
-      "label": "NoResultsMessage()",
-      "norm_label": "noresultsmessage()",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
-      "label": "NoResultsMessage.tsx",
-      "norm_label": "noresultsmessage.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L35"
     },
     {
       "community": 53,
@@ -67683,6 +67845,60 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "noresultsmessage_noresultsmessage",
+      "label": "NoResultsMessage()",
+      "norm_label": "noresultsmessage()",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
+      "label": "NoResultsMessage.tsx",
+      "norm_label": "noresultsmessage.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 533,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
       "norm_label": "printinstructions.tsx",
@@ -67690,7 +67906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 533,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -67699,7 +67915,7 @@
       "source_location": "L3"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -67708,7 +67924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -67717,7 +67933,7 @@
       "source_location": "L14"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -67726,7 +67942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -67735,7 +67951,7 @@
       "source_location": "L12"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -67744,7 +67960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -67753,7 +67969,7 @@
       "source_location": "L15"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -67762,7 +67978,7 @@
       "source_location": "L9"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -67771,7 +67987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -67780,7 +67996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -67789,7 +68005,7 @@
       "source_location": "L28"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -67798,67 +68014,13 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
       "norm_label": "registercustomerpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
-      "label": "RegisterSessionPanel.tsx",
-      "norm_label": "registersessionpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "registersessionpanel_registersessionpanel",
-      "label": "RegisterSessionPanel()",
-      "norm_label": "registersessionpanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
-      "label": "transactionColumns.test.tsx",
-      "norm_label": "transactioncolumns.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "transactioncolumns_test_rendertransactioncell",
-      "label": "renderTransactionCell()",
-      "norm_label": "rendertransactioncell()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L34"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L26"
     },
     {
       "community": 54,
@@ -67953,6 +68115,60 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
+      "label": "RegisterSessionPanel.tsx",
+      "norm_label": "registersessionpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "registersessionpanel_registersessionpanel",
+      "label": "RegisterSessionPanel()",
+      "norm_label": "registersessionpanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
+      "label": "transactionColumns.test.tsx",
+      "norm_label": "transactioncolumns.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "transactioncolumns_test_rendertransactioncell",
+      "label": "renderTransactionCell()",
+      "norm_label": "rendertransactioncell()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L34"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 543,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -67960,7 +68176,7 @@
       "source_location": "L14"
     },
     {
-      "community": 540,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -67969,7 +68185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -67978,7 +68194,7 @@
       "source_location": "L6"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -67987,7 +68203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -67996,7 +68212,7 @@
       "source_location": "L37"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -68005,7 +68221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -68014,7 +68230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -68023,7 +68239,7 @@
       "source_location": "L11"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -68032,7 +68248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -68041,7 +68257,7 @@
       "source_location": "L10"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -68050,7 +68266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -68059,7 +68275,7 @@
       "source_location": "L6"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -68068,67 +68284,13 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
       "norm_label": "productsview()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "add_product_command_addproductcommand",
-      "label": "AddProductCommand()",
-      "norm_label": "addproductcommand()",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
-      "label": "add-product-command.tsx",
-      "norm_label": "add-product-command.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "products_products",
-      "label": "Products()",
-      "norm_label": "products()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
-      "label": "PromoCodeForm.tsx",
-      "norm_label": "promocodeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "promocodeform_togglediscounttype",
-      "label": "toggleDiscountType()",
-      "norm_label": "togglediscounttype()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L84"
     },
     {
       "community": 55,
@@ -68223,6 +68385,60 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "add_product_command_addproductcommand",
+      "label": "AddProductCommand()",
+      "norm_label": "addproductcommand()",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
+      "label": "add-product-command.tsx",
+      "norm_label": "add-product-command.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "products_products",
+      "label": "Products()",
+      "norm_label": "products()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
+      "label": "PromoCodeForm.tsx",
+      "norm_label": "promocodeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "promocodeform_togglediscounttype",
+      "label": "toggleDiscountType()",
+      "norm_label": "togglediscounttype()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 553,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
       "norm_label": "promocodeheader.tsx",
@@ -68230,7 +68446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 553,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -68239,7 +68455,7 @@
       "source_location": "L23"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -68248,7 +68464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -68257,7 +68473,7 @@
       "source_location": "L37"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -68266,7 +68482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -68275,7 +68491,7 @@
       "source_location": "L9"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -68284,7 +68500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -68293,7 +68509,7 @@
       "source_location": "L23"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -68302,7 +68518,7 @@
       "source_location": "L5"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -68311,7 +68527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -68320,7 +68536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -68329,7 +68545,7 @@
       "source_location": "L4"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -68338,67 +68554,13 @@
       "source_location": "L13"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
       "norm_label": "capturedemails.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
-      "label": "promo-code-modal.tsx",
-      "norm_label": "promo-code-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "promo_code_modal_promocodemodal",
-      "label": "PromoCodeModal()",
-      "norm_label": "promocodemodal()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
-      "label": "ReviewActions.tsx",
-      "norm_label": "reviewactions.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "reviewactions_reviewactions",
-      "label": "ReviewActions()",
-      "norm_label": "reviewactions()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
-      "label": "ServiceCasesView.test.tsx",
-      "norm_label": "servicecasesview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "servicecasesview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L63"
     },
     {
       "community": 56,
@@ -68493,6 +68655,60 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
+      "label": "promo-code-modal.tsx",
+      "norm_label": "promo-code-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "promo_code_modal_promocodemodal",
+      "label": "PromoCodeModal()",
+      "norm_label": "promocodemodal()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
+      "label": "ReviewActions.tsx",
+      "norm_label": "reviewactions.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "reviewactions_reviewactions",
+      "label": "ReviewActions()",
+      "norm_label": "reviewactions()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
+      "label": "ServiceCasesView.test.tsx",
+      "norm_label": "servicecasesview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "servicecasesview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
       "norm_label": "servicecatalogview.test.tsx",
@@ -68500,7 +68716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 563,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -68509,7 +68725,7 @@
       "source_location": "L30"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -68518,7 +68734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -68527,7 +68743,7 @@
       "source_location": "L59"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -68536,7 +68752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -68545,7 +68761,7 @@
       "source_location": "L45"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -68554,7 +68770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -68563,7 +68779,7 @@
       "source_location": "L47"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -68572,7 +68788,7 @@
       "source_location": "L29"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -68581,7 +68797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -68590,7 +68806,7 @@
       "source_location": "L3"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -68599,7 +68815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -68608,66 +68824,12 @@
       "source_location": "L4"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
       "norm_label": "nopermissionview.tsx",
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "notfoundview_notfoundview",
-      "label": "NotFoundView()",
-      "norm_label": "notfoundview()",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
-      "label": "NotFoundView.tsx",
-      "norm_label": "notfoundview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
-      "label": "ProtectedAdminSignInView.tsx",
-      "norm_label": "protectedadminsigninview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "protectedadminsigninview_protectedadminsigninview",
-      "label": "ProtectedAdminSignInView()",
-      "norm_label": "protectedadminsigninview()",
-      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "contactview_contactview",
-      "label": "ContactView()",
-      "norm_label": "contactview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "label": "ContactView.tsx",
-      "norm_label": "contactview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L1"
     },
     {
@@ -68763,6 +68925,60 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "notfoundview_notfoundview",
+      "label": "NotFoundView()",
+      "norm_label": "notfoundview()",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
+      "label": "NotFoundView.tsx",
+      "norm_label": "notfoundview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
+      "label": "ProtectedAdminSignInView.tsx",
+      "norm_label": "protectedadminsigninview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "protectedadminsigninview_protectedadminsigninview",
+      "label": "ProtectedAdminSignInView()",
+      "norm_label": "protectedadminsigninview()",
+      "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "contactview_contactview",
+      "label": "ContactView()",
+      "norm_label": "contactview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
+      "label": "ContactView.tsx",
+      "norm_label": "contactview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
       "id": "header_header",
       "label": "Header()",
       "norm_label": "header()",
@@ -68770,7 +68986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -68779,7 +68995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -68788,7 +69004,7 @@
       "source_location": "L11"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -68797,7 +69013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -68806,7 +69022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -68815,7 +69031,7 @@
       "source_location": "L25"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -68824,7 +69040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -68833,7 +69049,7 @@
       "source_location": "L21"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -68842,7 +69058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -68851,7 +69067,7 @@
       "source_location": "L63"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -68860,7 +69076,7 @@
       "source_location": "L7"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -68869,7 +69085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -68878,66 +69094,12 @@
       "source_location": "L25"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
       "norm_label": "chart.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "copy_button_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "label": "copy-button.tsx",
-      "norm_label": "copy-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "copy_wrapper_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "label": "copy-wrapper.tsx",
-      "norm_label": "copy-wrapper.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "label_label",
-      "label": "Label()",
-      "norm_label": "label()",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L1"
     },
     {
@@ -69024,6 +69186,60 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "copy_button_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
+      "label": "copy-button.tsx",
+      "norm_label": "copy-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "copy_wrapper_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
+      "label": "copy-wrapper.tsx",
+      "norm_label": "copy-wrapper.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "label_label",
+      "label": "Label()",
+      "norm_label": "label()",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
       "norm_label": "custommodal()",
@@ -69031,7 +69247,7 @@
       "source_location": "L25"
     },
     {
-      "community": 580,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -69040,7 +69256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -69049,7 +69265,7 @@
       "source_location": "L49"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -69058,7 +69274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -69067,7 +69283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -69076,7 +69292,7 @@
       "source_location": "L63"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -69085,7 +69301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -69094,7 +69310,7 @@
       "source_location": "L5"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -69103,7 +69319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -69112,7 +69328,7 @@
       "source_location": "L12"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -69121,7 +69337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -69130,7 +69346,7 @@
       "source_location": "L15"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -69139,67 +69355,13 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
       "norm_label": "timelineitem()",
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
-      "label": "webp-image.tsx",
-      "norm_label": "webp-image.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "webp_image_webpimage",
-      "label": "WebpImage()",
-      "norm_label": "webpimage()",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "bagitems_bagitems",
-      "label": "BagItems()",
-      "norm_label": "bagitems()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "label": "BagItems.tsx",
-      "norm_label": "bagitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "bagitemsview_bagitemsview",
-      "label": "BagItemsView()",
-      "norm_label": "bagitemsview()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "label": "BagItemsView.tsx",
-      "norm_label": "bagitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 59,
@@ -69285,6 +69447,60 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
+      "label": "webp-image.tsx",
+      "norm_label": "webp-image.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "webp_image_webpimage",
+      "label": "WebpImage()",
+      "norm_label": "webpimage()",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "bagitems_bagitems",
+      "label": "BagItems()",
+      "norm_label": "bagitems()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
+      "label": "BagItems.tsx",
+      "norm_label": "bagitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "bagitemsview_bagitemsview",
+      "label": "BagItemsView()",
+      "norm_label": "bagitemsview()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
+      "label": "BagItemsView.tsx",
+      "norm_label": "bagitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 593,
+      "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
       "norm_label": "bags()",
@@ -69292,7 +69508,7 @@
       "source_location": "L4"
     },
     {
-      "community": 590,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -69301,7 +69517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -69310,7 +69526,7 @@
       "source_location": "L102"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -69319,7 +69535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -69328,7 +69544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -69337,7 +69553,7 @@
       "source_location": "L13"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -69346,7 +69562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -69355,7 +69571,7 @@
       "source_location": "L7"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -69364,7 +69580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -69373,7 +69589,7 @@
       "source_location": "L11"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -69382,7 +69598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -69391,7 +69607,7 @@
       "source_location": "L7"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -69400,67 +69616,13 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
       "norm_label": "useractions()",
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L45"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "customerjourneystage_customerjourneystagecard",
-      "label": "CustomerJourneyStageCard()",
-      "norm_label": "customerjourneystagecard()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
-      "label": "CustomerJourneyStage.tsx",
-      "norm_label": "customerjourneystage.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
-      "label": "use-image-upload.ts",
-      "norm_label": "use-image-upload.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "use_image_upload_useimageupload",
-      "label": "useImageUpload()",
-      "norm_label": "useimageupload()",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "label": "use-mobile.tsx",
-      "norm_label": "use-mobile.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "use_mobile_useismobile",
-      "label": "useIsMobile()",
-      "norm_label": "useismobile()",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
     },
     {
       "community": 6,
@@ -69780,6 +69942,60 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "customerjourneystage_customerjourneystagecard",
+      "label": "CustomerJourneyStageCard()",
+      "norm_label": "customerjourneystagecard()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
+      "label": "CustomerJourneyStage.tsx",
+      "norm_label": "customerjourneystage.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
+      "label": "use-image-upload.ts",
+      "norm_label": "use-image-upload.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "use_image_upload_useimageupload",
+      "label": "useImageUpload()",
+      "norm_label": "useimageupload()",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
+      "label": "use-mobile.tsx",
+      "norm_label": "use-mobile.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "use_mobile_useismobile",
+      "label": "useIsMobile()",
+      "norm_label": "useismobile()",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
       "norm_label": "use-navigate-back.ts",
@@ -69787,7 +70003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 603,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -69796,7 +70012,7 @@
       "source_location": "L5"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -69805,7 +70021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -69814,7 +70030,7 @@
       "source_location": "L7"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -69823,7 +70039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -69832,7 +70048,7 @@
       "source_location": "L9"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -69841,7 +70057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -69850,7 +70066,7 @@
       "source_location": "L6"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -69859,7 +70075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -69868,7 +70084,7 @@
       "source_location": "L168"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -69877,7 +70093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -69886,7 +70102,7 @@
       "source_location": "L5"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -69895,67 +70111,13 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
       "norm_label": "usecopytext()",
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "label": "useCreateComplimentaryProduct.ts",
-      "norm_label": "usecreatecomplimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "label": "useCreateComplimentaryProduct()",
-      "norm_label": "usecreatecomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
-      "label": "useDebounce.ts",
-      "norm_label": "usedebounce.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "usedebounce_usedebounce",
-      "label": "useDebounce()",
-      "norm_label": "usedebounce()",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L24"
     },
     {
       "community": 61,
@@ -70041,6 +70203,60 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
+      "label": "useCreateComplimentaryProduct.ts",
+      "norm_label": "usecreatecomplimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
+      "label": "useCreateComplimentaryProduct()",
+      "norm_label": "usecreatecomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
+      "label": "useDebounce.ts",
+      "norm_label": "usedebounce.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "usedebounce_usedebounce",
+      "label": "useDebounce()",
+      "norm_label": "usedebounce()",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
       "norm_label": "usegetactiveproduct.ts",
@@ -70048,7 +70264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 613,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -70057,7 +70273,7 @@
       "source_location": "L6"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -70066,7 +70282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -70075,7 +70291,7 @@
       "source_location": "L4"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -70084,7 +70300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -70093,7 +70309,7 @@
       "source_location": "L5"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -70102,7 +70318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -70111,7 +70327,7 @@
       "source_location": "L5"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -70120,7 +70336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -70129,7 +70345,7 @@
       "source_location": "L4"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -70138,7 +70354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -70147,7 +70363,7 @@
       "source_location": "L5"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -70156,7 +70372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -70165,7 +70381,88 @@
       "source_location": "L5"
     },
     {
-      "community": 617,
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L94"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L99"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_summarystrip",
+      "label": "SummaryStrip()",
+      "norm_label": "summarystrip()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -70174,7 +70471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 620,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -70183,7 +70480,7 @@
       "source_location": "L8"
     },
     {
-      "community": 618,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -70192,7 +70489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 621,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -70201,7 +70498,7 @@
       "source_location": "L13"
     },
     {
-      "community": 619,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -70210,7 +70507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 619,
+      "community": 622,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -70219,88 +70516,7 @@
       "source_location": "L3"
     },
     {
-      "community": 62,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
-      "label": "refundUtils.ts",
-      "norm_label": "refundutils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_calculaterefundamount",
-      "label": "calculateRefundAmount()",
-      "norm_label": "calculaterefundamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_getamountrefunded",
-      "label": "getAmountRefunded()",
-      "norm_label": "getamountrefunded()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_getavailableitems",
-      "label": "getAvailableItems()",
-      "norm_label": "getavailableitems()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_getitemstorefund",
-      "label": "getItemsToRefund()",
-      "norm_label": "getitemstorefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_getnetamount",
-      "label": "getNetAmount()",
-      "norm_label": "getnetamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_refundreducer",
-      "label": "refundReducer()",
-      "norm_label": "refundreducer()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_shouldshowreturntostock",
-      "label": "shouldShowReturnToStock()",
-      "norm_label": "shouldshowreturntostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "refundutils_validaterefund",
-      "label": "validateRefund()",
-      "norm_label": "validaterefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 620,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -70309,7 +70525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 623,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -70318,7 +70534,7 @@
       "source_location": "L27"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -70327,7 +70543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -70336,7 +70552,7 @@
       "source_location": "L7"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -70345,7 +70561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -70354,7 +70570,7 @@
       "source_location": "L5"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -70363,7 +70579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -70372,7 +70588,7 @@
       "source_location": "L12"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -70381,7 +70597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -70390,7 +70606,7 @@
       "source_location": "L12"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -70399,7 +70615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -70408,7 +70624,7 @@
       "source_location": "L5"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -70417,7 +70633,7 @@
       "source_location": "L44"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -70426,7 +70642,88 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 63,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
+      "label": "refundUtils.ts",
+      "norm_label": "refundutils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_calculaterefundamount",
+      "label": "calculateRefundAmount()",
+      "norm_label": "calculaterefundamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_getamountrefunded",
+      "label": "getAmountRefunded()",
+      "norm_label": "getamountrefunded()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_getavailableitems",
+      "label": "getAvailableItems()",
+      "norm_label": "getavailableitems()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_getitemstorefund",
+      "label": "getItemsToRefund()",
+      "norm_label": "getitemstorefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_getnetamount",
+      "label": "getNetAmount()",
+      "norm_label": "getnetamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_refundreducer",
+      "label": "refundReducer()",
+      "norm_label": "refundreducer()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_shouldshowreturntostock",
+      "label": "shouldShowReturnToStock()",
+      "norm_label": "shouldshowreturntostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "refundutils_validaterefund",
+      "label": "validateRefund()",
+      "norm_label": "validaterefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 630,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -70435,7 +70732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 630,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -70444,7 +70741,7 @@
       "source_location": "L6"
     },
     {
-      "community": 628,
+      "community": 631,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -70453,7 +70750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 631,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -70462,7 +70759,7 @@
       "source_location": "L7"
     },
     {
-      "community": 629,
+      "community": 632,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -70471,7 +70768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 629,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -70480,88 +70777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 63,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
-      "label": "ServiceCatalogView.tsx",
-      "norm_label": "servicecatalogview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L187"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_handleedit",
-      "label": "handleEdit()",
-      "norm_label": "handleedit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_handlereset",
-      "label": "handleReset()",
-      "norm_label": "handlereset()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L209"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_itemtoformstate",
-      "label": "itemToFormState()",
-      "norm_label": "itemtoformstate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_parseservicecatalogform",
-      "label": "parseServiceCatalogForm()",
-      "norm_label": "parseservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_validateservicecatalogform",
-      "label": "validateServiceCatalogForm()",
-      "norm_label": "validateservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "servicecatalogview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L499"
-    },
-    {
-      "community": 630,
+      "community": 633,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -70570,7 +70786,7 @@
       "source_location": "L5"
     },
     {
-      "community": 630,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -70579,7 +70795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -70588,7 +70804,7 @@
       "source_location": "L6"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -70597,7 +70813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -70606,7 +70822,7 @@
       "source_location": "L5"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -70615,7 +70831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -70624,7 +70840,7 @@
       "source_location": "L5"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -70633,7 +70849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -70642,7 +70858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -70651,7 +70867,7 @@
       "source_location": "L5"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -70660,7 +70876,7 @@
       "source_location": "L10"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -70669,7 +70885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
@@ -70678,7 +70894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "useregisterviewmodel_test_deferred",
       "label": "deferred()",
@@ -70687,7 +70903,88 @@
       "source_location": "L165"
     },
     {
-      "community": 637,
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
+      "label": "ServiceCatalogView.tsx",
+      "norm_label": "servicecatalogview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L187"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_handleedit",
+      "label": "handleEdit()",
+      "norm_label": "handleedit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_handlereset",
+      "label": "handleReset()",
+      "norm_label": "handlereset()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L209"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_itemtoformstate",
+      "label": "itemToFormState()",
+      "norm_label": "itemtoformstate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_parseservicecatalogform",
+      "label": "parseServiceCatalogForm()",
+      "norm_label": "parseservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_validateservicecatalogform",
+      "label": "validateServiceCatalogForm()",
+      "norm_label": "validateservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "servicecatalogview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L499"
+    },
+    {
+      "community": 640,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -70696,7 +70993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 640,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -70705,7 +71002,7 @@
       "source_location": "L12"
     },
     {
-      "community": 638,
+      "community": 641,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -70714,7 +71011,7 @@
       "source_location": "L9"
     },
     {
-      "community": 638,
+      "community": 641,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -70723,7 +71020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 639,
+      "community": 642,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -70732,7 +71029,7 @@
       "source_location": "L6"
     },
     {
-      "community": 639,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -70741,88 +71038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "label": "handleDeliveryRestrictionToggle()",
-      "norm_label": "handledeliveryrestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "label": "handlePickupRestrictionToggle()",
-      "norm_label": "handlepickuprestrictiontoggle()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "label": "handleSaveDeliveryRestriction()",
-      "norm_label": "handlesavedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_handlesavepickuprestriction",
-      "label": "handleSavePickupRestriction()",
-      "norm_label": "handlesavepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_savedeliveryrestriction",
-      "label": "saveDeliveryRestriction()",
-      "norm_label": "savedeliveryrestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_saveenabledeliverychanges",
-      "label": "saveEnableDeliveryChanges()",
-      "norm_label": "saveenabledeliverychanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_saveenablestorepickupchanges",
-      "label": "saveEnableStorePickupChanges()",
-      "norm_label": "saveenablestorepickupchanges()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "fulfillmentview_savepickuprestriction",
-      "label": "savePickupRestriction()",
-      "norm_label": "savepickuprestriction()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
-      "label": "FulfillmentView.tsx",
-      "norm_label": "fulfillmentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 640,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -70831,7 +71047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 643,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -70840,7 +71056,7 @@
       "source_location": "L6"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -70849,7 +71065,7 @@
       "source_location": "L13"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -70858,7 +71074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -70867,7 +71083,7 @@
       "source_location": "L6"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -70876,7 +71092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -70885,7 +71101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -70894,7 +71110,7 @@
       "source_location": "L9"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -70903,7 +71119,7 @@
       "source_location": "L13"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -70912,7 +71128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -70921,7 +71137,7 @@
       "source_location": "L4"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -70930,7 +71146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -70939,7 +71155,7 @@
       "source_location": "L13"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -70948,7 +71164,88 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_handledeliveryrestrictiontoggle",
+      "label": "handleDeliveryRestrictionToggle()",
+      "norm_label": "handledeliveryrestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_handlepickuprestrictiontoggle",
+      "label": "handlePickupRestrictionToggle()",
+      "norm_label": "handlepickuprestrictiontoggle()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_handlesavedeliveryrestriction",
+      "label": "handleSaveDeliveryRestriction()",
+      "norm_label": "handlesavedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_handlesavepickuprestriction",
+      "label": "handleSavePickupRestriction()",
+      "norm_label": "handlesavepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_savedeliveryrestriction",
+      "label": "saveDeliveryRestriction()",
+      "norm_label": "savedeliveryrestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_saveenabledeliverychanges",
+      "label": "saveEnableDeliveryChanges()",
+      "norm_label": "saveenabledeliverychanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_saveenablestorepickupchanges",
+      "label": "saveEnableStorePickupChanges()",
+      "norm_label": "saveenablestorepickupchanges()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "fulfillmentview_savepickuprestriction",
+      "label": "savePickupRestriction()",
+      "norm_label": "savepickuprestriction()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
+      "label": "FulfillmentView.tsx",
+      "norm_label": "fulfillmentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -70957,7 +71254,7 @@
       "source_location": "L5"
     },
     {
-      "community": 647,
+      "community": 650,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -70966,7 +71263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 651,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -70975,7 +71272,7 @@
       "source_location": "L17"
     },
     {
-      "community": 648,
+      "community": 651,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -70984,7 +71281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 649,
+      "community": 652,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -70993,7 +71290,7 @@
       "source_location": "L15"
     },
     {
-      "community": 649,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -71002,88 +71299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger",
-      "label": "Logger",
-      "norm_label": "logger",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger_debug",
-      "label": ".debug()",
-      "norm_label": ".debug()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger_error",
-      "label": ".error()",
-      "norm_label": ".error()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger_formatmessage",
-      "label": ".formatMessage()",
-      "norm_label": ".formatmessage()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger_info",
-      "label": ".info()",
-      "norm_label": ".info()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger_shouldlog",
-      "label": ".shouldLog()",
-      "norm_label": ".shouldlog()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "logger_logger_warn",
-      "label": ".warn()",
-      "norm_label": ".warn()",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_logger_ts",
-      "label": "logger.ts",
-      "norm_label": "logger.ts",
-      "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 650,
+      "community": 653,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -71092,7 +71308,7 @@
       "source_location": "L12"
     },
     {
-      "community": 650,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -71101,7 +71317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -71110,7 +71326,7 @@
       "source_location": "L5"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -71119,7 +71335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -71128,7 +71344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -71137,7 +71353,7 @@
       "source_location": "L13"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -71146,7 +71362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -71155,7 +71371,7 @@
       "source_location": "L14"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -71164,7 +71380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -71173,7 +71389,7 @@
       "source_location": "L13"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -71182,7 +71398,7 @@
       "source_location": "L5"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -71191,7 +71407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -71200,7 +71416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -71209,7 +71425,88 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger",
+      "label": "Logger",
+      "norm_label": "logger",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger_debug",
+      "label": ".debug()",
+      "norm_label": ".debug()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger_error",
+      "label": ".error()",
+      "norm_label": ".error()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger_formatmessage",
+      "label": ".formatMessage()",
+      "norm_label": ".formatmessage()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger_info",
+      "label": ".info()",
+      "norm_label": ".info()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger_shouldlog",
+      "label": ".shouldLog()",
+      "norm_label": ".shouldlog()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "logger_logger_warn",
+      "label": ".warn()",
+      "norm_label": ".warn()",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_logger_ts",
+      "label": "logger.ts",
+      "norm_label": "logger.ts",
+      "source_file": "packages/athena-webapp/src/lib/logger.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -71218,7 +71515,7 @@
       "source_location": "L4"
     },
     {
-      "community": 657,
+      "community": 660,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -71227,7 +71524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 661,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -71236,7 +71533,7 @@
       "source_location": "L27"
     },
     {
-      "community": 658,
+      "community": 661,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -71245,7 +71542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 659,
+      "community": 662,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -71254,7 +71551,7 @@
       "source_location": "L4"
     },
     {
-      "community": 659,
+      "community": 662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -71263,88 +71560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L277"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L357"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L208"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L336"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L259"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L212"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 660,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -71353,7 +71569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 663,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -71362,7 +71578,7 @@
       "source_location": "L5"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -71371,7 +71587,7 @@
       "source_location": "L10"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -71380,7 +71596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -71389,7 +71605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -71398,7 +71614,7 @@
       "source_location": "L10"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -71407,7 +71623,7 @@
       "source_location": "L4"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -71416,7 +71632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -71425,7 +71641,7 @@
       "source_location": "L39"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -71434,7 +71650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -71443,7 +71659,7 @@
       "source_location": "L18"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -71452,7 +71668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -71461,7 +71677,7 @@
       "source_location": "L71"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -71470,7 +71686,88 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L277"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L357"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L208"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L336"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L259"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L212"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -71479,7 +71776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 670,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -71488,7 +71785,7 @@
       "source_location": "L12"
     },
     {
-      "community": 668,
+      "community": 671,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -71497,7 +71794,7 @@
       "source_location": "L6"
     },
     {
-      "community": 668,
+      "community": 671,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -71506,7 +71803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 669,
+      "community": 672,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -71515,7 +71812,7 @@
       "source_location": "L18"
     },
     {
-      "community": 669,
+      "community": 672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -71524,79 +71821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 67,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "r2_getr2",
-      "label": "getR2()",
-      "norm_label": "getr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L188"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "r2_readenvvalue",
-      "label": "readEnvValue()",
-      "norm_label": "readenvvalue()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "r2_resolver2configfromenv",
-      "label": "resolveR2ConfigFromEnv()",
-      "norm_label": "resolver2configfromenv()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 670,
+      "community": 673,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -71605,7 +71830,7 @@
       "source_location": "L10"
     },
     {
-      "community": 670,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -71614,7 +71839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -71623,7 +71848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -71632,7 +71857,7 @@
       "source_location": "L8"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -71641,7 +71866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -71650,7 +71875,7 @@
       "source_location": "L27"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -71659,7 +71884,7 @@
       "source_location": "L40"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -71668,7 +71893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -71677,7 +71902,7 @@
       "source_location": "L3"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -71686,7 +71911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -71695,7 +71920,7 @@
       "source_location": "L8"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -71704,7 +71929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -71713,7 +71938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -71722,7 +71947,79 @@
       "source_location": "L12"
     },
     {
-      "community": 677,
+      "community": 68,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "r2_getr2",
+      "label": "getR2()",
+      "norm_label": "getr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "r2_readenvvalue",
+      "label": "readEnvValue()",
+      "norm_label": "readenvvalue()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "r2_resolver2configfromenv",
+      "label": "resolveR2ConfigFromEnv()",
+      "norm_label": "resolver2configfromenv()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 680,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -71731,7 +72028,7 @@
       "source_location": "L77"
     },
     {
-      "community": 677,
+      "community": 680,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -71740,7 +72037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 681,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -71749,7 +72046,7 @@
       "source_location": "L161"
     },
     {
-      "community": 678,
+      "community": 681,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -71758,7 +72055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 679,
+      "community": 682,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -71767,7 +72064,7 @@
       "source_location": "L3"
     },
     {
-      "community": 679,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -71776,79 +72073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 68,
-      "file_type": "code",
-      "id": "athenauserauth_findathenauserbyemailwithctx",
-      "label": "findAthenaUserByEmailWithCtx()",
-      "norm_label": "findathenauserbyemailwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "athenauserauth_getauthenticatedathenauserwithctx",
-      "label": "getAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "getauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "athenauserauth_getauthenticateduserrecord",
-      "label": "getAuthenticatedUserRecord()",
-      "norm_label": "getauthenticateduserrecord()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "athenauserauth_normalizeemail",
-      "label": "normalizeEmail()",
-      "norm_label": "normalizeemail()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
-      "label": "requireAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "requireauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "athenauserauth_requireorganizationmemberrolewithctx",
-      "label": "requireOrganizationMemberRoleWithCtx()",
-      "norm_label": "requireorganizationmemberrolewithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
-      "label": "syncAuthenticatedAthenaUserWithCtx()",
-      "norm_label": "syncauthenticatedathenauserwithctx()",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
-      "label": "athenaUserAuth.ts",
-      "norm_label": "athenauserauth.ts",
-      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 680,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -71857,7 +72082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 683,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -71866,7 +72091,7 @@
       "source_location": "L4"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -71875,7 +72100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -71884,7 +72109,7 @@
       "source_location": "L14"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -71893,7 +72118,7 @@
       "source_location": "L27"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -71902,7 +72127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -71911,7 +72136,7 @@
       "source_location": "L17"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -71920,7 +72145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -71929,7 +72154,7 @@
       "source_location": "L13"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -71938,7 +72163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -71947,7 +72172,7 @@
       "source_location": "L47"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -71956,7 +72181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -71965,7 +72190,7 @@
       "source_location": "L7"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -71974,7 +72199,79 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 69,
+      "file_type": "code",
+      "id": "athenauserauth_findathenauserbyemailwithctx",
+      "label": "findAthenaUserByEmailWithCtx()",
+      "norm_label": "findathenauserbyemailwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "athenauserauth_getauthenticatedathenauserwithctx",
+      "label": "getAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "getauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "athenauserauth_getauthenticateduserrecord",
+      "label": "getAuthenticatedUserRecord()",
+      "norm_label": "getauthenticateduserrecord()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "athenauserauth_normalizeemail",
+      "label": "normalizeEmail()",
+      "norm_label": "normalizeemail()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "athenauserauth_requireauthenticatedathenauserwithctx",
+      "label": "requireAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "requireauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "athenauserauth_requireorganizationmemberrolewithctx",
+      "label": "requireOrganizationMemberRoleWithCtx()",
+      "norm_label": "requireorganizationmemberrolewithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "athenauserauth_syncauthenticatedathenauserwithctx",
+      "label": "syncAuthenticatedAthenaUserWithCtx()",
+      "norm_label": "syncauthenticatedathenauserwithctx()",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_athenauserauth_ts",
+      "label": "athenaUserAuth.ts",
+      "norm_label": "athenauserauth.ts",
+      "source_file": "packages/athena-webapp/convex/lib/athenaUserAuth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -71983,7 +72280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 690,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -71992,7 +72289,7 @@
       "source_location": "L17"
     },
     {
-      "community": 688,
+      "community": 691,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -72001,7 +72298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 691,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -72010,7 +72307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 689,
+      "community": 692,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -72019,7 +72316,7 @@
       "source_location": "L12"
     },
     {
-      "community": 689,
+      "community": 692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -72028,79 +72325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 690,
+      "community": 693,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -72109,7 +72334,7 @@
       "source_location": "L7"
     },
     {
-      "community": 690,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -72118,7 +72343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -72127,7 +72352,7 @@
       "source_location": "L45"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -72136,7 +72361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -72145,7 +72370,7 @@
       "source_location": "L5"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -72154,7 +72379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -72163,7 +72388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -72172,7 +72397,7 @@
       "source_location": "L17"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -72181,7 +72406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -72190,7 +72415,7 @@
       "source_location": "L3"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -72199,7 +72424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -72208,7 +72433,7 @@
       "source_location": "L37"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -72217,67 +72442,13 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
       "norm_label": "showshippingpolicy()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L79"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
-      "label": "ProductReview.tsx",
-      "norm_label": "productreview.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "productreview_handlehelpful",
-      "label": "handleHelpful()",
-      "norm_label": "handlehelpful()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "label": "ReviewSummary.tsx",
-      "norm_label": "reviewsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "reviewsummary_reviewsummary",
-      "label": "ReviewSummary()",
-      "norm_label": "reviewsummary()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 7,
@@ -72507,77 +72678,131 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
-      "community": 70,
+      "community": 700,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
+      "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
+      "label": "ProductReview.tsx",
+      "norm_label": "productreview.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L1"
     },
     {
       "community": 700,
+      "file_type": "code",
+      "id": "productreview_handlehelpful",
+      "label": "handleHelpful()",
+      "norm_label": "handlehelpful()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
+      "label": "ReviewSummary.tsx",
+      "norm_label": "reviewsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "reviewsummary_reviewsummary",
+      "label": "ReviewSummary()",
+      "norm_label": "reviewsummary()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -72586,7 +72811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 703,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -72595,7 +72820,7 @@
       "source_location": "L18"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -72604,7 +72829,7 @@
       "source_location": "L10"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -72613,7 +72838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -72622,7 +72847,7 @@
       "source_location": "L11"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -72631,7 +72856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -72640,7 +72865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -72649,7 +72874,7 @@
       "source_location": "L59"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -72658,7 +72883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -72667,7 +72892,7 @@
       "source_location": "L33"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -72676,7 +72901,7 @@
       "source_location": "L19"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -72685,7 +72910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -72694,7 +72919,7 @@
       "source_location": "L4"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -72703,7 +72928,79 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
+    },
+    {
+      "community": 710,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -72712,7 +73009,7 @@
       "source_location": "L22"
     },
     {
-      "community": 707,
+      "community": 710,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -72721,7 +73018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 711,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -72730,7 +73027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 711,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -72739,7 +73036,7 @@
       "source_location": "L11"
     },
     {
-      "community": 709,
+      "community": 712,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -72748,7 +73045,7 @@
       "source_location": "L3"
     },
     {
-      "community": 709,
+      "community": 712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -72757,79 +73054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 71,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 710,
+      "community": 713,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -72838,7 +73063,7 @@
       "source_location": "L3"
     },
     {
-      "community": 710,
+      "community": 713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -72847,7 +73072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -72856,7 +73081,7 @@
       "source_location": "L9"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -72865,7 +73090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -72874,7 +73099,7 @@
       "source_location": "L66"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -72883,7 +73108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -72892,7 +73117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -72901,7 +73126,7 @@
       "source_location": "L19"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -72910,7 +73135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -72919,7 +73144,7 @@
       "source_location": "L13"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -72928,7 +73153,7 @@
       "source_location": "L46"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -72937,7 +73162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -72946,7 +73171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -72955,7 +73180,79 @@
       "source_location": "L46"
     },
     {
-      "community": 717,
+      "community": 72,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 720,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -72964,7 +73261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 720,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -72973,7 +73270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 721,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -72982,7 +73279,7 @@
       "source_location": "L15"
     },
     {
-      "community": 718,
+      "community": 721,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -72991,7 +73288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 719,
+      "community": 722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -73000,7 +73297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 719,
+      "community": 722,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -73009,79 +73306,7 @@
       "source_location": "L5"
     },
     {
-      "community": 72,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 720,
+      "community": 723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -73090,7 +73315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 720,
+      "community": 723,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -73099,7 +73324,7 @@
       "source_location": "L14"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -73108,7 +73333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -73117,7 +73342,7 @@
       "source_location": "L29"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -73126,7 +73351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -73135,7 +73360,7 @@
       "source_location": "L5"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -73144,7 +73369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -73153,7 +73378,7 @@
       "source_location": "L5"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -73162,7 +73387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -73171,7 +73396,7 @@
       "source_location": "L3"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -73180,7 +73405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -73189,7 +73414,7 @@
       "source_location": "L4"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -73198,7 +73423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -73207,7 +73432,79 @@
       "source_location": "L4"
     },
     {
-      "community": 727,
+      "community": 73,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 730,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -73216,7 +73513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 730,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -73225,7 +73522,7 @@
       "source_location": "L9"
     },
     {
-      "community": 728,
+      "community": 731,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -73234,7 +73531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 731,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -73243,7 +73540,7 @@
       "source_location": "L17"
     },
     {
-      "community": 729,
+      "community": 732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -73252,7 +73549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 729,
+      "community": 732,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -73261,79 +73558,7 @@
       "source_location": "L5"
     },
     {
-      "community": 73,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2348"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2342"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2338"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2358"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2104"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2194"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2086"
-    },
-    {
-      "community": 730,
+      "community": 733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -73342,7 +73567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 730,
+      "community": 733,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -73351,7 +73576,7 @@
       "source_location": "L15"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -73360,7 +73585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -73369,7 +73594,7 @@
       "source_location": "L18"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -73378,7 +73603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -73387,7 +73612,7 @@
       "source_location": "L9"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -73396,7 +73621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -73405,7 +73630,7 @@
       "source_location": "L16"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -73414,7 +73639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -73423,7 +73648,7 @@
       "source_location": "L4"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -73432,7 +73657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -73441,7 +73666,7 @@
       "source_location": "L11"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -73450,7 +73675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -73459,7 +73684,79 @@
       "source_location": "L3"
     },
     {
-      "community": 737,
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2348"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2342"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2338"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2358"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2104"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2194"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2086"
+    },
+    {
+      "community": 740,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -73468,7 +73765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 740,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -73477,7 +73774,7 @@
       "source_location": "L7"
     },
     {
-      "community": 738,
+      "community": 741,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -73486,7 +73783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 741,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -73495,7 +73792,7 @@
       "source_location": "L4"
     },
     {
-      "community": 739,
+      "community": 742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -73504,7 +73801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 739,
+      "community": 742,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -73513,79 +73810,7 @@
       "source_location": "L14"
     },
     {
-      "community": 74,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 740,
+      "community": 743,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -73594,7 +73819,7 @@
       "source_location": "L4"
     },
     {
-      "community": 740,
+      "community": 743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -73603,7 +73828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -73612,7 +73837,7 @@
       "source_location": "L7"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -73621,7 +73846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -73630,7 +73855,7 @@
       "source_location": "L6"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -73639,7 +73864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -73648,7 +73873,7 @@
       "source_location": "L10"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -73657,7 +73882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -73666,7 +73891,7 @@
       "source_location": "L6"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -73675,7 +73900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 748,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -73684,7 +73909,7 @@
       "source_location": "L5"
     },
     {
-      "community": 745,
+      "community": 748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -73693,7 +73918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -73702,7 +73927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 749,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -73711,7 +73936,79 @@
       "source_location": "L5"
     },
     {
-      "community": 747,
+      "community": 75,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -73720,7 +74017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 750,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -73729,7 +74026,7 @@
       "source_location": "L14"
     },
     {
-      "community": 748,
+      "community": 751,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -73738,7 +74035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 751,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -73747,7 +74044,7 @@
       "source_location": "L9"
     },
     {
-      "community": 749,
+      "community": 752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -73756,7 +74053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 749,
+      "community": 752,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -73765,79 +74062,7 @@
       "source_location": "L10"
     },
     {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_buildpendingskucontextbyid",
-      "label": "buildPendingSkuContextById()",
-      "norm_label": "buildpendingskucontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_getstatusrank",
-      "label": "getStatusRank()",
-      "norm_label": "getstatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 750,
+      "community": 753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -73846,7 +74071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 750,
+      "community": 753,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -73855,7 +74080,7 @@
       "source_location": "L11"
     },
     {
-      "community": 751,
+      "community": 754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -73864,7 +74089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 754,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -73873,7 +74098,7 @@
       "source_location": "L6"
     },
     {
-      "community": 752,
+      "community": 755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -73882,7 +74107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 755,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -73891,7 +74116,7 @@
       "source_location": "L5"
     },
     {
-      "community": 753,
+      "community": 756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -73900,7 +74125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 756,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -73909,7 +74134,7 @@
       "source_location": "L6"
     },
     {
-      "community": 754,
+      "community": 757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -73918,7 +74143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 757,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -73927,7 +74152,7 @@
       "source_location": "L10"
     },
     {
-      "community": 755,
+      "community": 758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -73936,7 +74161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 758,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -73945,7 +74170,7 @@
       "source_location": "L15"
     },
     {
-      "community": 756,
+      "community": 759,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -73954,7 +74179,7 @@
       "source_location": "L14"
     },
     {
-      "community": 756,
+      "community": 759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -73963,7 +74188,79 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_buildpendingskucontextbyid",
+      "label": "buildPendingSkuContextById()",
+      "norm_label": "buildpendingskucontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_getstatusrank",
+      "label": "getStatusRank()",
+      "norm_label": "getstatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -73972,7 +74269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 760,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -73981,7 +74278,7 @@
       "source_location": "L6"
     },
     {
-      "community": 758,
+      "community": 761,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -73990,7 +74287,7 @@
       "source_location": "L13"
     },
     {
-      "community": 758,
+      "community": 761,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -73999,7 +74296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 762,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -74008,7 +74305,7 @@
       "source_location": "L8"
     },
     {
-      "community": 759,
+      "community": 762,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -74017,79 +74314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "data_table_row_actions_datatablerowactions",
-      "label": "DataTableRowActions()",
-      "norm_label": "datatablerowactions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 760,
+      "community": 763,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -74098,7 +74323,7 @@
       "source_location": "L14"
     },
     {
-      "community": 760,
+      "community": 763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -74107,7 +74332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 764,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -74116,7 +74341,7 @@
       "source_location": "L13"
     },
     {
-      "community": 761,
+      "community": 764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -74125,7 +74350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -74134,7 +74359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 765,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -74143,7 +74368,7 @@
       "source_location": "L9"
     },
     {
-      "community": 763,
+      "community": 766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -74152,7 +74377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 766,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -74161,7 +74386,7 @@
       "source_location": "L15"
     },
     {
-      "community": 764,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -74170,7 +74395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 767,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -74179,7 +74404,7 @@
       "source_location": "L16"
     },
     {
-      "community": 765,
+      "community": 768,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -74188,7 +74413,7 @@
       "source_location": "L6"
     },
     {
-      "community": 765,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -74197,7 +74422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 769,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -74206,7 +74431,7 @@
       "source_location": "L10"
     },
     {
-      "community": 766,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -74215,7 +74440,79 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 77,
+      "file_type": "code",
+      "id": "data_table_row_actions_datatablerowactions",
+      "label": "DataTableRowActions()",
+      "norm_label": "datatablerowactions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -74224,7 +74521,7 @@
       "source_location": "L21"
     },
     {
-      "community": 767,
+      "community": 770,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -74233,7 +74530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 771,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -74242,7 +74539,7 @@
       "source_location": "L33"
     },
     {
-      "community": 768,
+      "community": 771,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -74251,7 +74548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -74260,7 +74557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 772,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -74269,79 +74566,7 @@
       "source_location": "L193"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_summarystrip",
-      "label": "SummaryStrip()",
-      "norm_label": "summarystrip()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 770,
+      "community": 773,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -74350,7 +74575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 770,
+      "community": 773,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -74359,7 +74584,7 @@
       "source_location": "L7"
     },
     {
-      "community": 771,
+      "community": 774,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -74368,7 +74593,7 @@
       "source_location": "L10"
     },
     {
-      "community": 771,
+      "community": 774,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -74377,7 +74602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 775,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -74386,7 +74611,7 @@
       "source_location": "L32"
     },
     {
-      "community": 772,
+      "community": 775,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -74395,7 +74620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 776,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -74404,7 +74629,7 @@
       "source_location": "L211"
     },
     {
-      "community": 773,
+      "community": 776,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -74413,7 +74638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 777,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -74422,7 +74647,7 @@
       "source_location": "L85"
     },
     {
-      "community": 774,
+      "community": 777,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -74431,7 +74656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 778,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -74440,7 +74665,7 @@
       "source_location": "L15"
     },
     {
-      "community": 775,
+      "community": 778,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -74449,39 +74674,12 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
       "norm_label": "api.d.ts",
       "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 777,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_js",
-      "label": "api.js",
-      "norm_label": "api.js",
-      "source_file": "packages/athena-webapp/convex/_generated/api.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
-      "label": "dataModel.d.ts",
-      "norm_label": "datamodel.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_server_d_ts",
-      "label": "server.d.ts",
-      "norm_label": "server.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
       "source_location": "L1"
     },
     {
@@ -74559,6 +74757,33 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_js",
+      "label": "api.js",
+      "norm_label": "api.js",
+      "source_file": "packages/athena-webapp/convex/_generated/api.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
+      "label": "dataModel.d.ts",
+      "norm_label": "datamodel.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_server_d_ts",
+      "label": "server.d.ts",
+      "norm_label": "server.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 783,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
       "norm_label": "server.js",
@@ -74566,7 +74791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -74575,7 +74800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -74584,7 +74809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -74593,7 +74818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -74602,7 +74827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
@@ -74611,39 +74836,12 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
       "source_file": "packages/athena-webapp/convex/constants/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 787,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/athena-webapp/convex/constants/email.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
       "source_location": "L1"
     },
     {
@@ -74721,6 +74919,33 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/athena-webapp/convex/constants/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 792,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 793,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
       "norm_label": "crons.ts",
@@ -74728,7 +74953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -74737,7 +74962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -74746,7 +74971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -74755,7 +74980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -74764,7 +74989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -74773,39 +74998,12 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 797,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
-      "label": "colors.ts",
-      "norm_label": "colors.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/colors.ts",
       "source_location": "L1"
     },
     {
@@ -75081,6 +75279,33 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
+      "label": "colors.ts",
+      "norm_label": "colors.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/colors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 803,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -75088,7 +75313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -75097,7 +75322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -75106,7 +75331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -75115,7 +75340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -75124,7 +75349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -75133,39 +75358,12 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 807,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
-      "label": "me.ts",
-      "norm_label": "me.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
       "source_location": "L1"
     },
     {
@@ -75243,6 +75441,33 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 812,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
+      "label": "me.ts",
+      "norm_label": "me.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 813,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
@@ -75250,7 +75475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -75259,7 +75484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -75268,7 +75493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -75277,7 +75502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -75286,7 +75511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -75295,39 +75520,12 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 817,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "label": "security.test.ts",
-      "norm_label": "security.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
       "source_location": "L1"
     },
     {
@@ -75405,6 +75603,33 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
+      "label": "security.test.ts",
+      "norm_label": "security.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 823,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -75412,7 +75637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -75421,7 +75646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -75430,7 +75655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -75439,7 +75664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -75448,7 +75673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -75457,39 +75682,12 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
       "norm_label": "bestseller.ts",
       "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 827,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_categories_ts",
-      "label": "categories.ts",
-      "norm_label": "categories.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_colors_ts",
-      "label": "colors.ts",
-      "norm_label": "colors.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
       "source_location": "L1"
     },
     {
@@ -75567,6 +75765,33 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_categories_ts",
+      "label": "categories.ts",
+      "norm_label": "categories.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_colors_ts",
+      "label": "colors.ts",
+      "norm_label": "colors.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 833,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
       "norm_label": "expensetransactions.test.ts",
@@ -75574,7 +75799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -75583,7 +75808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -75592,7 +75817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -75601,7 +75826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -75610,7 +75835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -75619,39 +75844,12 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
       "norm_label": "poscustomers.ts",
       "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 837,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
-      "label": "posTerminal.ts",
-      "norm_label": "posterminal.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productsku_ts",
-      "label": "productSku.ts",
-      "norm_label": "productsku.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
-      "label": "productUtil.test.ts",
-      "norm_label": "productutil.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.test.ts",
       "source_location": "L1"
     },
     {
@@ -75729,6 +75927,33 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
+      "label": "posTerminal.ts",
+      "norm_label": "posterminal.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productsku_ts",
+      "label": "productSku.ts",
+      "norm_label": "productsku.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
+      "label": "productUtil.test.ts",
+      "norm_label": "productutil.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 843,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
@@ -75736,7 +75961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -75745,7 +75970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -75754,7 +75979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -75763,7 +75988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -75772,7 +75997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -75781,39 +76006,12 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 847,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
-      "label": "migrateAmountsToPesewas.ts",
-      "norm_label": "migrateamountstopesewas.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_test_ts",
-      "label": "client.test.ts",
-      "norm_label": "client.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
-      "label": "config.test.ts",
-      "norm_label": "config.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L1"
     },
     {
@@ -75891,6 +76089,33 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
+      "label": "migrateAmountsToPesewas.ts",
+      "norm_label": "migrateamountstopesewas.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_client_test_ts",
+      "label": "client.test.ts",
+      "norm_label": "client.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
+      "label": "config.test.ts",
+      "norm_label": "config.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 853,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
       "norm_label": "normalize.test.ts",
@@ -75898,7 +76123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -75907,7 +76132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -75916,7 +76141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -75925,7 +76150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -75934,7 +76159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -75943,39 +76168,12 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 857,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
-      "label": "getRegisterState.test.ts",
-      "norm_label": "getregisterstate.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
-      "label": "getTransactions.test.ts",
-      "norm_label": "gettransactions.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
-      "label": "posSessionTracing.test.ts",
-      "norm_label": "possessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
       "source_location": "L1"
     },
     {
@@ -76044,6 +76242,33 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
+      "label": "getRegisterState.test.ts",
+      "norm_label": "getregisterstate.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
+      "label": "getTransactions.test.ts",
+      "norm_label": "gettransactions.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
+      "label": "posSessionTracing.test.ts",
+      "norm_label": "possessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 863,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
       "norm_label": "terminals.test.ts",
@@ -76051,7 +76276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -76060,7 +76285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -76069,7 +76294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -76078,7 +76303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -76087,7 +76312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -76096,39 +76321,12 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/register.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 867,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/terminals.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
-      "label": "transactions.ts",
-      "norm_label": "transactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/athena-webapp/convex/schema.ts",
       "source_location": "L1"
     },
     {
@@ -76197,6 +76395,33 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/terminals.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
+      "label": "transactions.ts",
+      "norm_label": "transactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/athena-webapp/convex/schema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 873,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
       "norm_label": "appverificationcode.ts",
@@ -76204,7 +76429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -76213,7 +76438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -76222,7 +76447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -76231,7 +76456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -76240,7 +76465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -76249,39 +76474,12 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 877,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
       "source_location": "L1"
     },
     {
@@ -76350,6 +76548,33 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 883,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
@@ -76357,7 +76582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -76366,7 +76591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -76375,7 +76600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -76384,7 +76609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -76393,7 +76618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -76402,39 +76627,12 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 887,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
-      "label": "workflowTrace.ts",
-      "norm_label": "workflowtrace.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
-      "label": "workflowTraceEvent.ts",
-      "norm_label": "workflowtraceevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
       "source_location": "L1"
     },
     {
@@ -76503,6 +76701,33 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
+      "label": "workflowTraceEvent.ts",
+      "norm_label": "workflowtraceevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 893,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
       "norm_label": "workflowtracelookup.ts",
@@ -76510,7 +76735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -76519,7 +76744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -76528,7 +76753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -76537,7 +76762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -76546,7 +76771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -76555,39 +76780,12 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
       "norm_label": "operationalworkitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 897,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
-      "label": "paymentAllocation.ts",
-      "norm_label": "paymentallocation.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/paymentAllocation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
-      "label": "registerSession.ts",
-      "norm_label": "registersession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
-      "label": "staffCredential.ts",
-      "norm_label": "staffcredential.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
       "source_location": "L1"
     },
     {
@@ -76845,6 +77043,33 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
+      "label": "paymentAllocation.ts",
+      "norm_label": "paymentallocation.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/paymentAllocation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
+      "label": "registerSession.ts",
+      "norm_label": "registersession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
+      "label": "staffCredential.ts",
+      "norm_label": "staffcredential.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 903,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
       "norm_label": "staffprofile.ts",
@@ -76852,7 +77077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -76861,7 +77086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -76870,7 +77095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -76879,7 +77104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -76888,7 +77113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -76897,39 +77122,12 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
       "norm_label": "expensetransaction.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 907,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
-      "label": "expenseTransactionItem.ts",
-      "norm_label": "expensetransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1"
     },
     {
@@ -76998,6 +77196,33 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
+      "label": "expenseTransactionItem.ts",
+      "norm_label": "expensetransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 913,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
       "norm_label": "possessionitem.ts",
@@ -77005,7 +77230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -77014,7 +77239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -77023,7 +77248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -77032,7 +77257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -77041,7 +77266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -77050,39 +77275,12 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
       "norm_label": "servicecase.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 917,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
-      "label": "serviceCaseLineItem.ts",
-      "norm_label": "servicecaselineitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCaseLineItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
-      "label": "serviceCatalog.ts",
-      "norm_label": "servicecatalog.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
-      "label": "serviceInventoryUsage.ts",
-      "norm_label": "serviceinventoryusage.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
       "source_location": "L1"
     },
     {
@@ -77151,6 +77349,33 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
+      "label": "serviceCaseLineItem.ts",
+      "norm_label": "servicecaselineitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCaseLineItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
+      "label": "serviceCatalog.ts",
+      "norm_label": "servicecatalog.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCatalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
+      "label": "serviceInventoryUsage.ts",
+      "norm_label": "serviceinventoryusage.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 923,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -77158,7 +77383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -77167,7 +77392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -77176,7 +77401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -77185,7 +77410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -77194,7 +77419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -77203,39 +77428,12 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 927,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -77304,6 +77502,33 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 933,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
       "norm_label": "checkoutsessionitem.ts",
@@ -77311,7 +77536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -77320,7 +77545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -77329,7 +77554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -77338,7 +77563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -77347,7 +77572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -77356,39 +77581,12 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
       "norm_label": "review.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 937,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
       "source_location": "L1"
     },
     {
@@ -77457,6 +77655,33 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 943,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
       "norm_label": "storefrontsession.ts",
@@ -77464,7 +77689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -77473,7 +77698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -77482,7 +77707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -77491,7 +77716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -77500,7 +77725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -77509,39 +77734,12 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 947,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1"
     },
     {
@@ -77610,6 +77808,33 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 953,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
       "norm_label": "orderoperations.test.ts",
@@ -77617,7 +77842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -77626,7 +77851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -77635,7 +77860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -77644,7 +77869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -77653,7 +77878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -77662,39 +77887,12 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
       "source_file": "packages/athena-webapp/convex/types/payment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 957,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
-      "label": "posSession.test.ts",
-      "norm_label": "possession.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
-      "label": "registerSession.test.ts",
-      "norm_label": "registersession.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
-      "label": "presentation.test.ts",
-      "norm_label": "presentation.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
       "source_location": "L1"
     },
     {
@@ -77763,6 +77961,33 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
+      "label": "posSession.test.ts",
+      "norm_label": "possession.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
+      "label": "registerSession.test.ts",
+      "norm_label": "registersession.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
+      "label": "presentation.test.ts",
+      "norm_label": "presentation.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 963,
+      "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
@@ -77770,7 +77995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -77779,7 +78004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -77788,7 +78013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -77797,7 +78022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -77806,48 +78031,21 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
-      "label": "registerSessionStatus.test.ts",
-      "norm_label": "registersessionstatus.test.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 966,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
-      "label": "staffDisplayName.test.ts",
-      "norm_label": "staffdisplayname.test.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 967,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
-      "label": "GenericComboBox.tsx",
-      "norm_label": "genericcombobox.tsx",
-      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 968,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
-      "label": "StoreAccordion.tsx",
-      "norm_label": "storeaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
+      "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
+      "label": "currencyFormatter.test.ts",
+      "norm_label": "currencyformatter.test.ts",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.test.ts",
       "source_location": "L1"
     },
     {
       "community": 969,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
-      "label": "StoresAccordion.tsx",
-      "norm_label": "storesaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
+      "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
+      "label": "registerSessionStatus.test.ts",
+      "norm_label": "registersessionstatus.test.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
       "source_location": "L1"
     },
     {
@@ -77916,6 +78114,42 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
+      "label": "staffDisplayName.test.ts",
+      "norm_label": "staffdisplayname.test.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
+      "label": "GenericComboBox.tsx",
+      "norm_label": "genericcombobox.tsx",
+      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
+      "label": "StoreAccordion.tsx",
+      "norm_label": "storeaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 973,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
+      "label": "StoresAccordion.tsx",
+      "norm_label": "storesaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 974,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
       "norm_label": "themetoggle.tsx",
@@ -77923,7 +78157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -77932,7 +78166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -77941,7 +78175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -77950,7 +78184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -77959,48 +78193,12 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 976,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 977,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
-      "label": "ConversionFunnelChart.tsx",
-      "norm_label": "conversionfunnelchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
-      "label": "RevenueChart.tsx",
-      "norm_label": "revenuechart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1"
     },
     {
@@ -78069,6 +78267,42 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
+      "label": "ConversionFunnelChart.tsx",
+      "norm_label": "conversionfunnelchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 983,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
+      "label": "RevenueChart.tsx",
+      "norm_label": "revenuechart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 984,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
       "norm_label": "analytics-columns.tsx",
@@ -78076,7 +78310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -78085,7 +78319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -78094,7 +78328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -78103,7 +78337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -78112,48 +78346,12 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 986,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 987,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -78222,6 +78420,42 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 993,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 994,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -78229,7 +78463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -78238,7 +78472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -78247,7 +78481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -78256,7 +78490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -78265,48 +78499,12 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 996,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1536
-- Graph nodes: 3975
-- Graph edges: 3544
-- Communities: 1451
+- Code files discovered: 1540
+- Graph nodes: 3985
+- Graph edges: 3553
+- Communities: 1455
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 260) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 261) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -70,9 +70,26 @@ describe("cash control deposits", () => {
           status: "closing",
           variance: -500,
         },
+        {
+          _id: "session_closed" as Id<"registerSession">,
+          countedCash: 5000,
+          expectedCash: 5000,
+          openedAt: 5,
+          openingFloat: 5000,
+          registerNumber: "C3",
+          status: "closed",
+          variance: 0,
+        },
       ],
       staffNamesById: new Map(),
     });
+
+    expect(snapshot.registerSessions).toHaveLength(3);
+    expect(snapshot.registerSessions.map((session) => session._id)).toEqual([
+      "session_closing",
+      "session_open",
+      "session_closed",
+    ]);
 
     expect(snapshot.openSessions).toHaveLength(1);
     expect(snapshot.openSessions[0]).toMatchObject({

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -243,6 +243,7 @@ export function buildCashControlsDashboardSnapshot(args: {
     );
 
   return {
+    registerSessions: sessionSummaries,
     openSessions: sessionSummaries.filter((registerSession) =>
       isPosUsableRegisterSessionStatus(registerSession.status)
     ),
@@ -282,28 +283,11 @@ async function listRegisterSessionsForDashboard(
   ctx: Pick<QueryCtx, "db">,
   storeId: Id<"store">
 ) {
-  const [openSessions, activeSessions, closingSessions] = await Promise.all([
-    ctx.db
-      .query("registerSession")
-      .withIndex("by_storeId_status", (q) =>
-        q.eq("storeId", storeId).eq("status", "open")
-      )
-      .take(SESSION_LIMIT),
-    ctx.db
-      .query("registerSession")
-      .withIndex("by_storeId_status", (q) =>
-        q.eq("storeId", storeId).eq("status", "active")
-      )
-      .take(SESSION_LIMIT),
-    ctx.db
-      .query("registerSession")
-      .withIndex("by_storeId_status", (q) =>
-        q.eq("storeId", storeId).eq("status", "closing")
-      )
-      .take(SESSION_LIMIT),
-  ]);
-
-  return [...openSessions, ...activeSessions, ...closingSessions];
+  return ctx.db
+    .query("registerSession")
+    .withIndex("by_storeId", (q) => q.eq("storeId", storeId))
+    .order("desc")
+    .take(SESSION_LIMIT);
 }
 
 async function listStoreDeposits(

--- a/packages/athena-webapp/convex/utils.ts
+++ b/packages/athena-webapp/convex/utils.ts
@@ -1,6 +1,7 @@
 import { Address, OnlineOrder } from "../types";
 import { ALL_COUNTRIES } from "./constants/countries";
 import { accraNeighborhoods, ghanaRegions } from "./constants/ghana";
+import { currencyFormatter as sharedCurrencyFormatter } from "../shared/currencyFormatter";
 
 export function toSlug(str: string) {
   return str
@@ -45,12 +46,7 @@ export function capitalizeWords(str: string): string {
 }
 
 export function currencyFormatter(currency: string) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
+  return sharedCurrencyFormatter(currency);
 }
 
 export function formatDate(timestamp: number) {

--- a/packages/athena-webapp/docs/agent/design.md
+++ b/packages/athena-webapp/docs/agent/design.md
@@ -77,7 +77,8 @@ Rules:
 The font tokens are:
 
 - `--font-sans`: UI copy, controls, tables, helper text.
-- `--font-display`: page titles, section landmarks, key numerics.
+- `--font-display`: page titles, section landmarks, key numerics. This uses the
+  sans family and relies on weight and scale for hierarchy.
 - `--font-mono`: technical identifiers, trace IDs, codes, and compact diagnostics.
 
 Use display type sparingly. It should create hierarchy, not ornament every card. Avoid

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,14 +7,14 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 69 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 531 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 533 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 5 file(s); key children: OperationsQueueView.auth.test.tsx, OperationsQueueView.test.tsx, OperationsQueueView.tsx, StockAdjustmentWorkspace.test.tsx, StockAdjustmentWorkspace.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 40 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 5 file(s); key children: OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx, ThemeContext.tsx, UserContext.tsx.
 - [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 78 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
-- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 10 file(s); key children: auth.ts, commandResult.test.ts, commandResult.ts, registerSessionStatus.test.ts, registerSessionStatus.ts.
+- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 12 file(s); key children: auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts, currencyFormatter.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 
 ## Backend and test surfaces

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -94,6 +94,7 @@ This index enumerates the current automated test files and ties them back to the
 ## Section `shared`
 
 - [`shared/commandResult.test.ts`](../../shared/commandResult.test.ts)
+- [`shared/currencyFormatter.test.ts`](../../shared/currencyFormatter.test.ts)
 - [`shared/registerSessionStatus.test.ts`](../../shared/registerSessionStatus.test.ts)
 - [`shared/staffDisplayName.test.ts`](../../shared/staffDisplayName.test.ts)
 
@@ -108,6 +109,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/cash-controls/RegisterCloseoutView.test.tsx`](../../src/components/cash-controls/RegisterCloseoutView.test.tsx)
 - [`src/components/cash-controls/RegisterSessionView.auth.test.tsx`](../../src/components/cash-controls/RegisterSessionView.auth.test.tsx)
 - [`src/components/cash-controls/RegisterSessionView.test.tsx`](../../src/components/cash-controls/RegisterSessionView.test.tsx)
+- [`src/components/cash-controls/formatReviewReason.test.ts`](../../src/components/cash-controls/formatReviewReason.test.ts)
 - [`src/components/join-team/index.test.tsx`](../../src/components/join-team/index.test.tsx)
 - [`src/components/operations/OperationsQueueView.auth.test.tsx`](../../src/components/operations/OperationsQueueView.auth.test.tsx)
 - [`src/components/operations/OperationsQueueView.test.tsx`](../../src/components/operations/OperationsQueueView.test.tsx)

--- a/packages/athena-webapp/shared/currencyFormatter.test.ts
+++ b/packages/athena-webapp/shared/currencyFormatter.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { currencyFormatter } from "./currencyFormatter";
+
+describe("currencyFormatter", () => {
+  it("uses the Ghana cedi symbol for GHS", () => {
+    expect(currencyFormatter("GHS").format(1250)).toBe("GH₵1,250");
+  });
+
+  it("keeps standard Intl formatting for other currencies", () => {
+    expect(currencyFormatter("USD").format(1250)).toBe("$1,250");
+  });
+});

--- a/packages/athena-webapp/shared/currencyFormatter.ts
+++ b/packages/athena-webapp/shared/currencyFormatter.ts
@@ -1,0 +1,34 @@
+const DISPLAY_CURRENCY_SYMBOLS: Record<string, string> = {
+  GHS: "GH₵",
+};
+
+export function currencyFormatter(currency: string): Intl.NumberFormat {
+  const normalizedCurrency = currency.toUpperCase();
+  const displaySymbol = DISPLAY_CURRENCY_SYMBOLS[normalizedCurrency];
+
+  if (displaySymbol) {
+    const numberFormatter = new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+    const formatter = new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+
+    Object.defineProperty(formatter, "format", {
+      value(amount: number) {
+        return `${displaySymbol}${numberFormatter.format(amount)}`;
+      },
+    });
+
+    return formatter;
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+}

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
@@ -88,6 +88,24 @@ const baseSnapshot = {
     registerNumber?: string | null;
     registerSessionId?: string | null;
   }>,
+  registerSessions: [] as Array<{
+    _id: string;
+    countedCash?: number;
+    expectedCash: number;
+    openedAt: number;
+    openingFloat: number;
+    pendingApprovalRequest?: {
+      _id: string;
+      reason?: string | null;
+      requestedByStaffName?: string | null;
+      status: string;
+    } | null;
+    registerNumber?: string | null;
+    status: string;
+    totalDeposited: number;
+    variance?: number;
+    workflowTraceId?: string | null;
+  }>,
   unresolvedVariances: [] as Array<{
     _id: string;
     countedCash?: number;
@@ -188,6 +206,49 @@ describe("CashControlsDashboardContent", () => {
               registerSessionId: "session-open",
             },
           ],
+          registerSessions: [
+            {
+              _id: "session-closing",
+              countedCash: 17100,
+              expectedCash: 17600,
+              openedAt: new Date("2026-04-21T07:30:00.000Z").getTime(),
+              openingFloat: 5000,
+              pendingApprovalRequest: {
+                _id: "approval-1",
+                reason: "Variance review required.",
+                requestedByStaffName: "Ama Mensah",
+                status: "pending",
+              },
+              registerNumber: "Register 3",
+              status: "closing",
+              totalDeposited: 2400,
+              variance: -500,
+              workflowTraceId: "register_session:reg-3",
+            },
+            {
+              _id: "session-open",
+              expectedCash: 24800,
+              openedAt: new Date("2026-04-21T09:15:00.000Z").getTime(),
+              openingFloat: 5000,
+              registerNumber: "Register 1",
+              status: "active",
+              totalDeposited: 8000,
+              variance: 0,
+              workflowTraceId: "register_session:reg-1",
+            },
+            {
+              _id: "session-closed",
+              countedCash: 5000,
+              expectedCash: 5000,
+              openedAt: new Date("2026-04-20T09:15:00.000Z").getTime(),
+              openingFloat: 5000,
+              registerNumber: "Register 4",
+              status: "closed",
+              totalDeposited: 0,
+              variance: 0,
+              workflowTraceId: "register_session:reg-4",
+            },
+          ],
           unresolvedVariances: [
             {
               _id: "session-closeout",
@@ -222,10 +283,9 @@ describe("CashControlsDashboardContent", () => {
     expect(screen.getAllByText("Recent deposits").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Register 1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Register 3").length).toBeGreaterThan(0);
+    expect(screen.getByText("Register 4")).toBeInTheDocument();
     expect(screen.getByText("Midday safe drop")).toBeInTheDocument();
     expect(screen.getByText("BANK-339")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Cash Controls" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Closeouts" })).toBeInTheDocument();
   });
 
   it("surfaces a drawer opened from POS in the cash-controls ledgers", () => {
@@ -235,6 +295,19 @@ describe("CashControlsDashboardContent", () => {
         dashboardSnapshot={{
           ...baseSnapshot,
           openSessions: [
+            {
+              _id: "session-pos-open",
+              expectedCash: 6200,
+              openedAt: new Date("2026-04-22T08:45:00.000Z").getTime(),
+              openingFloat: 5000,
+              registerNumber: "Register 2",
+              status: "active",
+              totalDeposited: 1200,
+              variance: 0,
+              workflowTraceId: "register_session:drawer-pos-open",
+            },
+          ],
+          registerSessions: [
             {
               _id: "session-pos-open",
               expectedCash: 6200,
@@ -278,6 +351,18 @@ describe("CashControlsDashboardContent", () => {
         dashboardSnapshot={{
           ...baseSnapshot,
           openSessions: [
+            {
+              _id: "session-open",
+              expectedCash: 24800,
+              openedAt: new Date("2026-04-21T09:15:00.000Z").getTime(),
+              openingFloat: 5000,
+              registerNumber: "Register 1",
+              status: "active",
+              totalDeposited: 8000,
+              variance: 0,
+            },
+          ],
+          registerSessions: [
             {
               _id: "session-open",
               expectedCash: 24800,

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -2,7 +2,7 @@ import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
-import { capitalizeWords, currencyFormatter } from "@/lib/utils";
+import { capitalizeWords, cn, currencyFormatter } from "@/lib/utils";
 import { formatStoredAmount } from "@/lib/pos/displayAmounts";
 import { api } from "~/convex/_generated/api";
 import View from "../View";
@@ -60,6 +60,7 @@ export type CashControlsDashboardSnapshot = {
   openSessions: CashControlsDashboardSession[];
   pendingCloseouts: CashControlsDashboardSession[];
   recentDeposits: CashControlsDashboardDeposit[];
+  registerSessions: CashControlsDashboardSession[];
   unresolvedVariances: CashControlsDashboardSession[];
 };
 
@@ -100,7 +101,22 @@ function getVarianceTone(variance?: number) {
     return "text-foreground";
   }
 
-  return variance > 0 ? "text-emerald-700" : "text-destructive";
+  return variance > 0 ? "text-success" : "text-danger";
+}
+
+function getStatusBadgeClass(status: string) {
+  switch (status) {
+    case "active":
+      return "border-transparent bg-success/10 text-success";
+    case "closing":
+      return "border-transparent bg-warning/15 text-warning";
+    case "open":
+      return "border-transparent bg-success/10 text-success";
+    case "closed":
+      return "border-transparent bg-muted text-muted-foreground";
+    default:
+      return "border-transparent bg-muted text-muted-foreground";
+  }
 }
 
 function SummaryStrip({
@@ -139,16 +155,16 @@ function SummaryStrip({
   ];
 
   return (
-    <dl className="grid gap-4 sm:grid-cols-2">
+    <dl className="divide-y divide-border/70 rounded-lg border border-border bg-surface-raised">
       {items.map((item) => (
         <div
-          className="space-y-1 border-b border-stone-200/70 pb-3 last:border-b-0 last:pb-0 sm:[&:nth-last-child(-n+2)]:border-b-0 sm:[&:nth-last-child(-n+2)]:pb-0"
+          className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-layout-md px-layout-md py-layout-sm"
           key={item.label}
         >
-          <dt className="text-[11px] font-medium uppercase tracking-[0.24em] text-amber-800/70">
+          <dt className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
             {item.label}
           </dt>
-          <dd className="font-mono text-2xl tracking-[-0.04em] text-stone-950">
+          <dd className="whitespace-nowrap text-right font-mono text-xl text-foreground">
             {item.value}
           </dd>
         </div>
@@ -179,51 +195,41 @@ function SessionLedger({
   title: string;
 }) {
   const navigate = useNavigate();
+  const tableHeadClass =
+    "text-[11px] uppercase tracking-[0.18em] text-muted-foreground";
 
   return (
-    <section className="space-y-4">
+    <section className="space-y-layout-md">
       <div className="flex items-end justify-between gap-4">
-        <div className="space-y-1">
-          <h2 className="text-2xl font-semibold tracking-[-0.04em] text-stone-950">
+        <div className="space-y-layout-2xs">
+          <h2 className="font-display text-2xl font-semibold tracking-tight text-foreground">
             {title}
           </h2>
-          <p className="text-sm text-stone-600">{description}</p>
+          <p className="text-sm text-muted-foreground">{description}</p>
         </div>
       </div>
 
       {sessions.length === 0 ? (
-        <div className="rounded-[22px] bg-white/70 px-6 py-8 ring-1 ring-stone-200/70">
+        <div className="rounded-lg border border-dashed border-border bg-surface-raised px-layout-lg py-layout-xl">
           <EmptyState description={emptyDescription} title={emptyTitle} />
         </div>
       ) : (
-        <div className="overflow-hidden rounded-[22px] bg-white/80 ring-1 ring-stone-200/70">
+        <div className="overflow-hidden rounded-lg border border-border bg-surface-raised">
           <Table>
             <TableHeader>
-              <TableRow className="border-b border-stone-200/80 hover:bg-transparent">
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Register
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Status
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Opened
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Expected
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Deposited
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Variance
-                </TableHead>
+              <TableRow className="border-b border-border hover:bg-transparent">
+                <TableHead className={tableHeadClass}>Register</TableHead>
+                <TableHead className={tableHeadClass}>Status</TableHead>
+                <TableHead className={tableHeadClass}>Opened</TableHead>
+                <TableHead className={tableHeadClass}>Expected</TableHead>
+                <TableHead className={tableHeadClass}>Deposited</TableHead>
+                <TableHead className={tableHeadClass}>Variance</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {sessions.map((session) => (
                 <TableRow
-                  className="group cursor-pointer border-b border-stone-200/70 hover:bg-[#f8f2e8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/70 focus-visible:ring-inset"
+                  className="group cursor-pointer border-b border-border/70 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
                   key={session._id}
                   onClick={() =>
                     navigate({
@@ -257,12 +263,12 @@ function SessionLedger({
                 >
                   <TableCell>
                     <div className="space-y-1">
-                      <p className="font-medium text-stone-950">
+                      <p className="font-medium text-foreground">
                         {formatRegisterName(session.registerNumber)}
                       </p>
                       {showPendingApproval &&
                       session.pendingApprovalRequest?.reason ? (
-                        <p className="max-w-md text-xs text-stone-500">
+                        <p className="max-w-md text-xs text-muted-foreground">
                           {session.pendingApprovalRequest.reason}
                         </p>
                       ) : null}
@@ -270,20 +276,20 @@ function SessionLedger({
                   </TableCell>
                   <TableCell>
                     <Badge
-                      className="border-stone-300/80 bg-stone-100 text-stone-700"
+                      className={getStatusBadgeClass(session.status)}
                       size="sm"
                       variant="outline"
                     >
                       {formatStatusLabel(session.status)}
                     </Badge>
                   </TableCell>
-                  <TableCell className="text-stone-600">
+                  <TableCell className="text-muted-foreground">
                     {formatTimestamp(session.openedAt)}
                   </TableCell>
-                  <TableCell className="font-mono text-stone-950">
+                  <TableCell className="font-mono text-foreground">
                     {formatCurrency(currency, session.expectedCash)}
                   </TableCell>
-                  <TableCell className="font-mono text-stone-950">
+                  <TableCell className="font-mono text-foreground">
                     {formatCurrency(currency, session.totalDeposited)}
                   </TableCell>
                   <TableCell
@@ -312,49 +318,40 @@ function DepositsLedger({
   orgUrlSlug: string;
   storeUrlSlug: string;
 }) {
+  const tableHeadClass =
+    "text-[11px] uppercase tracking-[0.18em] text-muted-foreground";
+
   return (
-    <section className="space-y-4">
-      <div className="space-y-1">
-        <h2 className="text-2xl font-semibold tracking-[-0.04em] text-stone-950">
+    <section className="space-y-layout-md">
+      <div className="space-y-layout-2xs">
+        <h2 className="font-display text-2xl font-semibold tracking-tight text-foreground">
           Recent deposits
         </h2>
-        <p className="text-sm text-stone-600">
+        <p className="text-sm text-muted-foreground">
           Recorded bank deposits grouped by register, with a quick path back
           into deposit entry when another drop needs logging.
         </p>
       </div>
 
       {deposits.length === 0 ? (
-        <div className="rounded-[22px] bg-white/70 px-6 py-8 ring-1 ring-stone-200/70">
+        <div className="rounded-lg border border-dashed border-border bg-surface-raised px-layout-lg py-layout-xl">
           <EmptyState
             description="Cash drops will appear here once deposits start getting recorded."
             title="No deposits recorded yet"
           />
         </div>
       ) : (
-        <div className="overflow-hidden rounded-[22px] bg-white/80 ring-1 ring-stone-200/70">
+        <div className="overflow-hidden rounded-lg border border-border bg-surface-raised">
           <Table>
             <TableHeader>
-              <TableRow className="border-b border-stone-200/80 hover:bg-transparent">
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Register
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Amount
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Recorded
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Reference
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  By
-                </TableHead>
-                <TableHead className="text-[11px] uppercase tracking-[0.18em] text-stone-500">
-                  Notes
-                </TableHead>
-                <TableHead className="text-right text-[11px] uppercase tracking-[0.18em] text-stone-500">
+              <TableRow className="border-b border-border hover:bg-transparent">
+                <TableHead className={tableHeadClass}>Register</TableHead>
+                <TableHead className={tableHeadClass}>Amount</TableHead>
+                <TableHead className={tableHeadClass}>Recorded</TableHead>
+                <TableHead className={tableHeadClass}>Reference</TableHead>
+                <TableHead className={tableHeadClass}>By</TableHead>
+                <TableHead className={tableHeadClass}>Notes</TableHead>
+                <TableHead className={cn(tableHeadClass, "text-right")}>
                   Next step
                 </TableHead>
               </TableRow>
@@ -362,16 +359,16 @@ function DepositsLedger({
             <TableBody>
               {deposits.map((deposit) => (
                 <TableRow
-                  className="group border-b border-stone-200/70 hover:bg-[#f8f2e8]"
+                  className="group border-b border-border/70 transition-colors hover:bg-muted/40"
                   key={deposit._id}
                 >
-                  <TableCell className="font-medium text-stone-950">
+                  <TableCell className="font-medium text-foreground">
                     {formatRegisterName(deposit.registerNumber)}
                   </TableCell>
-                  <TableCell className="font-mono text-stone-950">
+                  <TableCell className="font-mono text-foreground">
                     {formatCurrency(currency, deposit.amount)}
                   </TableCell>
-                  <TableCell className="text-stone-600">
+                  <TableCell className="text-muted-foreground">
                     {formatTimestamp(deposit.recordedAt)}
                   </TableCell>
                   <TableCell>{deposit.reference ?? "—"}</TableCell>
@@ -387,7 +384,7 @@ function DepositsLedger({
                     {deposit.registerSessionId ? (
                       <Button
                         asChild
-                        className="border-stone-300 bg-white/90 text-stone-800 hover:bg-white"
+                        className="border-border bg-background text-foreground hover:bg-surface"
                         size="sm"
                         variant="outline"
                       >
@@ -404,7 +401,7 @@ function DepositsLedger({
                         </Link>
                       </Button>
                     ) : (
-                      <span className="text-xs text-stone-400">—</span>
+                      <span className="text-xs text-muted-foreground">—</span>
                     )}
                   </TableCell>
                 </TableRow>
@@ -438,32 +435,13 @@ export function CashControlsDashboardContent({
         />
       }
     >
-      <FadeIn className="container mx-auto space-y-6 py-8">
-        <div className="space-y-6">
-          <section className="overflow-hidden rounded-[28px] bg-white/80 ring-1 ring-stone-200/70">
-            <div className="grid gap-0 xl:grid-cols-[minmax(0,1.22fr)_320px]">
-              <div className="border-b border-stone-200/80 px-6 py-6 xl:border-b-0 xl:border-r">
-                {isLoading ? (
-                  <div className="py-6 text-sm text-stone-600">
-                    Loading cash controls...
-                  </div>
-                ) : (
-                  <SessionLedger
-                    currency={currency}
-                    description="Live drawers with expected cash, deposited totals, and access to deposit entry."
-                    emptyDescription="New register sessions will appear here after the drawer opens."
-                    emptyTitle="No open register sessions"
-                    orgUrlSlug={orgUrlSlug}
-                    sessions={dashboardSnapshot.openSessions}
-                    storeUrlSlug={storeUrlSlug}
-                    title="Register sessions"
-                  />
-                )}
-              </div>
-
-              <aside className="px-6 py-6">
-                <div className="space-y-3">
-                  <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-stone-500">
+      <FadeIn className="container mx-auto py-layout-xl">
+        <div className="space-y-layout-lg">
+          <section className="overflow-hidden rounded-lg border border-border bg-surface shadow-surface">
+            <div className="grid gap-0 xl:grid-cols-[minmax(280px,320px)_minmax(0,1fr)]">
+              <aside className="border-b border-border bg-muted/20 p-layout-lg xl:border-b-0 xl:border-r">
+                <div className="space-y-layout-md">
+                  <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
                     Summary
                   </p>
                   <SummaryStrip
@@ -472,10 +450,29 @@ export function CashControlsDashboardContent({
                   />
                 </div>
               </aside>
+
+              <div className="p-layout-lg">
+                {isLoading ? (
+                  <div className="py-layout-lg text-sm text-muted-foreground">
+                    Loading cash controls...
+                  </div>
+                ) : (
+                  <SessionLedger
+                    currency={currency}
+                    description="Register sessions with expected cash, deposited totals, and access to session detail."
+                    emptyDescription="New register sessions will appear here after the drawer opens."
+                    emptyTitle="No register sessions"
+                    orgUrlSlug={orgUrlSlug}
+                    sessions={dashboardSnapshot.registerSessions}
+                    storeUrlSlug={storeUrlSlug}
+                    title="Register sessions"
+                  />
+                )}
+              </div>
             </div>
           </section>
 
-          <section className="rounded-[24px] bg-white/80 px-6 py-6 ring-1 ring-stone-200/70">
+          <section className="rounded-lg border border-border bg-surface p-layout-lg shadow-surface">
             <DepositsLedger
               currency={currency}
               deposits={dashboardSnapshot.recentDeposits}
@@ -553,6 +550,7 @@ export function CashControlsDashboard() {
           openSessions: [],
           pendingCloseouts: [],
           recentDeposits: [],
+          registerSessions: [],
           unresolvedVariances: [],
         }
       }

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx
@@ -27,43 +27,6 @@ export function CashControlsWorkspaceHeader({
           </h1>
           <p className="text-sm text-muted-foreground">{description}</p>
         </div>
-
-        <div className="flex flex-wrap gap-2 rounded-lg border border-border bg-surface-raised p-1.5 shadow-surface">
-          <Button
-            asChild
-            className={
-              activeView === "cash-controls"
-                ? "rounded-md border-transparent bg-shell text-shell-foreground hover:bg-shell/90 hover:text-shell-foreground"
-                : "rounded-md border-border bg-background text-muted-foreground hover:bg-surface hover:text-foreground"
-            }
-            size="sm"
-            variant="outline"
-          >
-            <Link
-              params={{ orgUrlSlug, storeUrlSlug }}
-              to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls"
-            >
-              Cash Controls
-            </Link>
-          </Button>
-          <Button
-            asChild
-            className={
-              activeView === "closeouts"
-                ? "rounded-md border-transparent bg-shell text-shell-foreground hover:bg-shell/90 hover:text-shell-foreground"
-                : "rounded-md border-border bg-background text-muted-foreground hover:bg-surface hover:text-foreground"
-            }
-            size="sm"
-            variant="outline"
-          >
-            <Link
-              params={{ orgUrlSlug, storeUrlSlug }}
-              to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/closeouts"
-            >
-              Closeouts
-            </Link>
-          </Button>
-        </div>
       </div>
     </div>
   );

--- a/packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.tsx
@@ -18,6 +18,7 @@ import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import { userError } from "~/shared/commandResult";
 import { formatStaffDisplayName } from "~/shared/staffDisplayName";
+import { formatReviewReason } from "./formatReviewReason";
 import { getOrigin } from "@/lib/navigationUtils";
 import { EmptyState } from "../states/empty/empty-state";
 import { WorkflowTraceRouteLink } from "../traces/WorkflowTraceRouteLink";
@@ -143,21 +144,6 @@ function getVarianceTone(variance: null | number) {
   }
 
   return variance > 0 ? "text-emerald-700" : "text-destructive";
-}
-
-function formatReviewReason(
-  formatter: ReturnType<typeof currencyFormatter>,
-  reason?: string,
-) {
-  if (!reason) {
-    return undefined;
-  }
-
-  return reason.replace(
-    /Variance of (-?\d+) exceeded the closeout approval threshold\./,
-    (_match, rawVariance) =>
-      `Variance of ${formatStoredAmount(formatter, Number(rawVariance))} exceeded the closeout approval threshold.`,
-  );
 }
 
 function getDefaultActiveSessionId(registerSessions: RegisterCloseoutSession[]) {

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -166,6 +166,7 @@ describe("RegisterSessionViewContent", () => {
     );
 
     expect(screen.getAllByText("Register 3").length).toBeGreaterThan(0);
+    expect(screen.getByText("Opened")).toBeInTheDocument();
     expect(
       screen.getByText((_, element) =>
         Boolean(
@@ -174,6 +175,10 @@ describe("RegisterSessionViewContent", () => {
         ),
       ),
     ).toBeInTheDocument();
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("1 linked sale")).toBeInTheDocument();
+    expect(screen.getAllByText("Closing").length).toBeGreaterThan(0);
+    expect(screen.getByText("Counted cash $171")).toBeInTheDocument();
     expect(screen.getByText("Linked transactions")).toBeInTheDocument();
     const transactionRow = screen.getByRole("link", {
       name: "Open transaction #TXN-0031",
@@ -188,6 +193,77 @@ describe("RegisterSessionViewContent", () => {
     expect(
       screen.getByRole("link", { name: "View trace" }),
     ).toBeInTheDocument();
+  });
+
+  it("communicates when a register session has closed", () => {
+    const closedAt = new Date("2026-04-21T19:45:00.000Z").getTime();
+    const expectedClosedAt = new Date(closedAt).toLocaleString("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+
+    render(
+      <RegisterSessionViewContent
+        actorUserId="user-1"
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            closedAt,
+            closedByStaffName: "Kojo Mensimah",
+            status: "closed",
+          },
+        }}
+        orgUrlSlug="wigclub"
+        storeId="store-1"
+        storeUrlSlug="wigclub"
+      />,
+    );
+
+    expect(screen.getAllByText("Closed").length).toBeGreaterThan(0);
+    expect(screen.getByText(expectedClosedAt)).toBeInTheDocument();
+    expect(screen.getByText("By Kojo M.")).toBeInTheDocument();
+  });
+
+  it("formats variance amounts in manager follow-up copy", () => {
+    render(
+      <RegisterSessionViewContent
+        actorUserId="user-1"
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          closeoutReview: {
+            hasVariance: true,
+            reason: "Variance of -6100 exceeded the closeout approval threshold.",
+            requiresApproval: true,
+            variance: -6100,
+          },
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            pendingApprovalRequest: {
+              _id: "approval-1",
+              reason: "Variance of -6100 exceeded the closeout approval threshold.",
+              requestedByStaffName: "Ama Mensah",
+              status: "pending",
+            },
+          },
+        }}
+        orgUrlSlug="wigclub"
+        storeId="store-1"
+        storeUrlSlug="wigclub"
+      />,
+    );
+
+    expect(
+      screen.getAllByText(
+        "Variance of GH₵-61 exceeded the closeout approval threshold.",
+      ).length,
+    ).toBeGreaterThan(0);
   });
 
   it("opens the transaction detail when the linked transaction row is clicked", async () => {

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -29,6 +29,7 @@ import { ComposedPageHeader } from "../common/PageHeader";
 import { EmptyState } from "../states/empty/empty-state";
 import { NoPermissionView } from "../states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSignInView";
+import { formatReviewReason } from "./formatReviewReason";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -55,6 +56,8 @@ type RegisterSessionApprovalRequest = {
 
 type RegisterSessionDetail = {
   _id: string;
+  closedAt?: number;
+  closedByStaffName?: string | null;
   countedCash?: number;
   expectedCash: number;
   netExpectedCash?: number;
@@ -199,6 +202,78 @@ function getVarianceTone(variance?: number) {
   }
 
   return variance > 0 ? "text-emerald-700" : "text-destructive";
+}
+
+function formatStaffByline(staffName?: string | null) {
+  if (!staffName) {
+    return undefined;
+  }
+
+  return `By ${formatStaffDisplayName({ fullName: staffName })}`;
+}
+
+function buildLifecycleRows({
+  currency,
+  registerSession,
+  transactionCount,
+}: {
+  currency: string;
+  registerSession: RegisterSessionDetail;
+  transactionCount: number;
+}) {
+  const status = registerSession.status;
+  const rows = [
+    {
+      label: "Opened",
+      primary: formatTimestamp(registerSession.openedAt),
+      secondary: formatStaffByline(registerSession.openedByStaffName),
+    },
+  ];
+
+  if (transactionCount > 0 || status === "active") {
+    rows.push({
+      label: status === "active" ? "Active" : "Activity",
+      primary:
+        transactionCount === 1
+          ? "1 linked sale"
+          : `${transactionCount} linked sales`,
+      secondary:
+        status === "active"
+          ? "Sales are recording against this register."
+          : "Sales recorded against this register.",
+    });
+  } else if (status === "open") {
+    rows.push({
+      label: "Open",
+      primary: "Ready for sales",
+      secondary: "No linked sales recorded yet.",
+    });
+  }
+
+  if (status === "closing" || status === "closed") {
+    rows.push({
+      label: "Closing",
+      primary:
+        registerSession.countedCash === undefined
+          ? "Closeout in progress"
+          : `Counted cash ${formatCurrency(currency, registerSession.countedCash)}`,
+      secondary: registerSession.pendingApprovalRequest
+        ? "Manager approval pending."
+        : "Closeout review submitted.",
+    });
+  }
+
+  if (status === "closed") {
+    rows.push({
+      label: "Closed",
+      primary: registerSession.closedAt
+        ? formatTimestamp(registerSession.closedAt)
+        : "Closed",
+      secondary: formatStaffByline(registerSession.closedByStaffName),
+    });
+  }
+
+  return rows;
 }
 
 function getPaymentMethodIcon({
@@ -363,6 +438,15 @@ export function RegisterSessionViewContent({
   );
   const expectedCash =
     registerSession?.netExpectedCash ?? registerSession?.expectedCash ?? 0;
+  const reviewReasonFormatter = currencyFormatter(currency);
+  const formattedApprovalReason = formatReviewReason(
+    reviewReasonFormatter,
+    registerSession?.pendingApprovalRequest?.reason,
+  );
+  const formattedCloseoutReviewReason = formatReviewReason(
+    reviewReasonFormatter,
+    registerSessionSnapshot?.closeoutReview?.reason,
+  );
   const summaryRows = registerSession
     ? [
         {
@@ -383,6 +467,13 @@ export function RegisterSessionViewContent({
           valueClassName: getVarianceTone(registerSession.variance),
         },
       ]
+    : [];
+  const lifecycleRows = registerSession
+    ? buildLifecycleRows({
+        currency,
+        registerSession,
+        transactionCount: transactions.length,
+      })
     : [];
   const headerTitle = registerSession
     ? formatRegisterHeaderName(registerSession.registerNumber)
@@ -459,21 +550,25 @@ export function RegisterSessionViewContent({
                       </dd>
                     </div>
 
-                    <div className="rounded-lg border border-border bg-surface-raised p-layout-md">
-                      <dt className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                        Opened
-                      </dt>
-                      <dd className="mt-2 text-sm text-foreground">
-                        {formatTimestamp(registerSession.openedAt)}
-                      </dd>
-                      {registerSession.openedByStaffName ? (
-                        <dd className="mt-1 text-xs text-muted-foreground">
-                          By{" "}
-                          {formatStaffDisplayName({
-                            fullName: registerSession.openedByStaffName,
-                          })}
-                        </dd>
-                      ) : null}
+                    <div className="divide-y divide-border rounded-lg border border-border bg-surface-raised">
+                      {lifecycleRows.map((row) => (
+                        <div
+                          className="grid gap-1 px-layout-md py-3"
+                          key={row.label}
+                        >
+                          <dt className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                            {row.label}
+                          </dt>
+                          <dd className="text-sm font-medium text-foreground">
+                            {row.primary}
+                          </dd>
+                          {row.secondary ? (
+                            <dd className="text-xs text-muted-foreground">
+                              {row.secondary}
+                            </dd>
+                          ) : null}
+                        </div>
+                      ))}
                     </div>
 
                     <div className="divide-y divide-border rounded-lg border border-border bg-surface-raised">
@@ -495,13 +590,13 @@ export function RegisterSessionViewContent({
                     </div>
                   </dl>
 
-                  {registerSession.pendingApprovalRequest?.reason ? (
+                  {formattedApprovalReason ? (
                     <div className="mt-layout-lg border-t border-border/70 pt-layout-lg">
                       <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
                         Manager follow-up
                       </p>
                       <p className="mt-2 text-sm text-foreground">
-                        {registerSession.pendingApprovalRequest.reason}
+                        {formattedApprovalReason}
                       </p>
                     </div>
                   ) : null}
@@ -794,9 +889,9 @@ export function RegisterSessionViewContent({
                         ? "Yes"
                         : "No"}
                     </p>
-                    {registerSessionSnapshot.closeoutReview.reason ? (
+                    {formattedCloseoutReviewReason ? (
                       <p className="text-sm text-foreground">
-                        {registerSessionSnapshot.closeoutReview.reason}
+                        {formattedCloseoutReviewReason}
                       </p>
                     ) : null}
                   </div>

--- a/packages/athena-webapp/src/components/cash-controls/formatReviewReason.test.ts
+++ b/packages/athena-webapp/src/components/cash-controls/formatReviewReason.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { currencyFormatter } from "~/shared/currencyFormatter";
+import { formatReviewReason } from "./formatReviewReason";
+
+describe("formatReviewReason", () => {
+  it("formats closeout variance amounts in threshold reasons", () => {
+    expect(
+      formatReviewReason(
+        currencyFormatter("GHS"),
+        "Variance of -6100 exceeded the closeout approval threshold.",
+      ),
+    ).toBe("Variance of GH₵-61 exceeded the closeout approval threshold.");
+  });
+
+  it("formats closeout variance amounts in manager signoff reasons", () => {
+    expect(
+      formatReviewReason(
+        currencyFormatter("GHS"),
+        "Manager signoff is required for any register variance (-6100).",
+      ),
+    ).toBe("Manager signoff is required for any register variance (GH₵-61).");
+  });
+});

--- a/packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts
+++ b/packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts
@@ -1,0 +1,22 @@
+import { formatStoredAmount } from "@/lib/pos/displayAmounts";
+
+export function formatReviewReason(
+  formatter: Intl.NumberFormat,
+  reason?: string | null,
+) {
+  if (!reason) {
+    return undefined;
+  }
+
+  return reason
+    .replace(
+      /Variance of (-?\d+) exceeded the closeout approval threshold\./,
+      (_match, rawVariance) =>
+        `Variance of ${formatStoredAmount(formatter, Number(rawVariance))} exceeded the closeout approval threshold.`,
+    )
+    .replace(
+      /Manager signoff is required for any register variance \((-?\d+)\)\./,
+      (_match, rawVariance) =>
+        `Manager signoff is required for any register variance (${formatStoredAmount(formatter, Number(rawVariance))}).`,
+    );
+}

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
+import { render as renderEmail } from "@react-email/components";
 
+import { currencyFormatter } from "~/shared/currencyFormatter";
 import { OrderSummary } from "./OrderSummary";
 
 vi.mock("@react-email/components", () => ({
-  render: vi.fn(),
+  render: vi.fn().mockResolvedValue("<receipt />"),
 }));
 
 vi.mock("~/src/hooks/useGetActiveStore", () => ({
@@ -25,12 +27,7 @@ vi.mock("~/src/hooks/usePrint", () => ({
   }),
 }));
 
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "GHS",
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-});
+const formatter = currencyFormatter("GHS");
 
 function stripWhitespace(value: string) {
   return value.replace(/\s/g, "");
@@ -63,6 +60,10 @@ function getBalanceDueLabel() {
 }
 
 describe("OrderSummary completed transaction summary", () => {
+  beforeEach(() => {
+    vi.mocked(renderEmail).mockClear();
+  });
+
   it("does not render the tax line in the completed sale totals", () => {
     render(
       <OrderSummary
@@ -156,8 +157,8 @@ describe("OrderSummary completed transaction summary", () => {
     expect(screen.getAllByText(/Cash Payment/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Card Payment/i).length).toBeGreaterThan(0);
     expect(screen.getByText("Payments")).toBeInTheDocument();
-    expect(screen.getByText("GHS 10")).toBeInTheDocument();
-    expect(screen.getByText("GHS 7")).toBeInTheDocument();
+    expect(screen.getByText("GH₵10")).toBeInTheDocument();
+    expect(screen.getByText("GH₵7")).toBeInTheDocument();
   });
 
   it("combines repeated completed payments by method in the rail breakdown", () => {
@@ -185,8 +186,72 @@ describe("OrderSummary completed transaction summary", () => {
     );
 
     expect(screen.getByText("Payments")).toBeInTheDocument();
-    expect(screen.getByText("GHS 10")).toBeInTheDocument();
-    expect(screen.getByText("GHS 7")).toBeInTheDocument();
+    expect(screen.getByText("GH₵10")).toBeInTheDocument();
+    expect(screen.getByText("GH₵7")).toBeInTheDocument();
+  });
+
+  it("uses the shared currency formatter for generated receipt amounts", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404927"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          completedAt: new Date("2026-04-25T18:08:00.000Z"),
+          cartItems: [
+            {
+              id: "item-1",
+              name: "keyboard",
+              barcode: "123456789012",
+              price: 29900,
+              quantity: 2,
+              productId: "product-1",
+              skuId: "sku-1",
+            },
+          ] as never,
+          customerInfo: undefined,
+          subtotal: 59800,
+          tax: 0,
+          total: 59800,
+          payments: [
+            { id: "payment-1", method: "cash", amount: 40000, timestamp: 1 },
+            { id: "payment-2", method: "card", amount: 19800, timestamp: 2 },
+          ],
+        }}
+        isTransactionCompleted
+        presentation="rail"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Print receipt/i }));
+
+    await waitFor(() => {
+      expect(renderEmail).toHaveBeenCalled();
+    });
+
+    const receiptElement = vi.mocked(renderEmail).mock.calls[0][0] as {
+      props: {
+        amountPaid: string;
+        items: Array<{ quantityLabel: string; totalPrice: string }>;
+        payments: Array<{ amount: string; method: string }>;
+        subtotal: string;
+        total: string;
+      };
+    };
+
+    expect(receiptElement.props.subtotal).toBe("GH₵598");
+    expect(receiptElement.props.total).toBe("GH₵598");
+    expect(receiptElement.props.amountPaid).toBe("GH₵598");
+    expect(receiptElement.props.items[0]).toMatchObject({
+      quantityLabel: "2 × GH₵299",
+      totalPrice: "GH₵598",
+    });
+    expect(receiptElement.props.payments).toEqual([
+      { method: "cash", amount: "GH₵400" },
+      { method: "card", amount: "GH₵198" },
+    ]);
   });
 
   it("reflects a draft amount equal to balance due as zero remaining", async () => {
@@ -216,7 +281,7 @@ describe("OrderSummary completed transaction summary", () => {
       const label = getBalanceDueLabel();
       expect(label).toHaveTextContent("Balance due");
       expect(stripWhitespace(getBalanceDueAmount())).toBe(
-        stripWhitespace(currencyFormatter.format(0)),
+        stripWhitespace(formatter.format(0)),
       );
     });
   });
@@ -254,7 +319,7 @@ describe("OrderSummary completed transaction summary", () => {
         const balanceDueLabel = getBalanceDueLabel();
         expect(balanceDueLabel).toHaveTextContent("Balance due");
         expect(stripWhitespace(getBalanceDueAmount())).toBe(
-          stripWhitespace(currencyFormatter.format(0)),
+          stripWhitespace(formatter.format(0)),
         );
       });
     },
@@ -290,7 +355,7 @@ describe("OrderSummary completed transaction summary", () => {
       const label = getBalanceDueLabel();
       expect(label).toHaveTextContent("Change due");
       expect(stripWhitespace(getBalanceDueAmount())).toBe(
-        stripWhitespace(currencyFormatter.format(300 / 100)),
+        stripWhitespace(formatter.format(300 / 100)),
       );
     });
   });
@@ -340,7 +405,7 @@ describe("OrderSummary completed transaction summary", () => {
       const label = getBalanceDueLabel();
       expect(label).toHaveTextContent("Balance due");
       expect(stripWhitespace(getBalanceDueAmount())).toBe(
-        stripWhitespace(currencyFormatter.format(0)),
+        stripWhitespace(formatter.format(0)),
       );
     });
   });
@@ -389,7 +454,7 @@ describe("OrderSummary completed transaction summary", () => {
       const label = getBalanceDueLabel();
       expect(label).toHaveTextContent("Change due");
       expect(stripWhitespace(getBalanceDueAmount())).toBe(
-        stripWhitespace(currencyFormatter.format(60 / 100)),
+        stripWhitespace(formatter.format(60 / 100)),
       );
     });
   });
@@ -429,7 +494,7 @@ describe("OrderSummary completed transaction summary", () => {
       const label = getBalanceDueLabel();
       expect(label).toHaveTextContent("Balance due");
       expect(stripWhitespace(getBalanceDueAmount())).toBe(
-        stripWhitespace(currencyFormatter.format(0)),
+        stripWhitespace(formatter.format(0)),
       );
     });
   });
@@ -472,7 +537,7 @@ describe("OrderSummary completed transaction summary", () => {
       const label = getBalanceDueLabel();
       expect(label).toHaveTextContent("Balance due");
       expect(stripWhitespace(getBalanceDueAmount())).toBe(
-        stripWhitespace(currencyFormatter.format(30 / 100)),
+        stripWhitespace(formatter.format(30 / 100)),
       );
     });
   });
@@ -515,7 +580,7 @@ describe("OrderSummary completed transaction summary", () => {
       const label = getBalanceDueLabel();
       expect(label).toHaveTextContent("Balance due");
       expect(stripWhitespace(getBalanceDueAmount())).toBe(
-        stripWhitespace(currencyFormatter.format(30 / 100)),
+        stripWhitespace(formatter.format(30 / 100)),
       );
     });
   });

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -20,7 +20,7 @@ import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 import { capitalizeWords, cn } from "~/src/lib/utils";
 import config from "~/src/config";
 import PosReceiptEmail from "~/convex/emails/PosReceiptEmail";
-import { currencyFormatter } from "~/convex/utils";
+import { currencyFormatter } from "~/shared/currencyFormatter";
 
 import { PaymentView, type SelectedPaymentMethod } from "./PaymentView";
 import { PaymentsAddedList } from "./PaymentsAddedList";

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
@@ -56,7 +56,9 @@ vi.mock("../../base/table/data-table", () => ({
         <div key={row.transactionNumber}>
           <span>{row.transactionNumber}</span>
           {row.sessionTraceId ? (
-            <span data-testid={`session-trace-${row.transactionNumber}`}>trace</span>
+            <span data-testid={`session-trace-${row.transactionNumber}`}>
+              trace
+            </span>
           ) : null}
         </div>
       ))}
@@ -66,7 +68,9 @@ vi.mock("../../base/table/data-table", () => ({
 
 vi.mock("@/components/ui/tabs", () => ({
   Tabs: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  TabsList: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   TabsTrigger: ({ children }: { children?: React.ReactNode }) => (
     <button type="button">{children}</button>
   ),
@@ -114,8 +118,12 @@ describe("TransactionsView", () => {
 
     render(<TransactionsView />);
 
-    expect(screen.queryByTestId("session-trace-POS-123456")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("session-trace-POS-654321")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("session-trace-POS-123456"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("session-trace-POS-654321"),
+    ).not.toBeInTheDocument();
   });
 
   it("passes the register session filter to the completed transactions query", () => {
@@ -126,22 +134,23 @@ describe("TransactionsView", () => {
         currency: "GHS",
       },
     });
-    useQueryMock.mockReturnValue([]);
+    useQueryMock.mockReturnValueOnce([]).mockReturnValueOnce({
+      registerSession: {
+        registerNumber: "3",
+      },
+    });
 
     render(<TransactionsView />);
 
-    expect(useQueryMock).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        storeId: "store-1",
-        registerSessionId: "session-1",
-      },
-    );
+    expect(useQueryMock).toHaveBeenNthCalledWith(1, expect.anything(), {
+      storeId: "store-1",
+      registerSessionId: "session-1",
+    });
     expect(
-      screen.getByText("Showing transactions linked to this register session."),
+      screen.getByText("Showing transactions linked to Register 3"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("No transactions for this register session"),
+      screen.getByText("No transactions for Register 3"),
     ).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
@@ -24,6 +24,18 @@ function formatPaymentMethod(method: string | null) {
   return capitalizeWords(method.replace(/_/g, " "));
 }
 
+function formatRegisterFilterLabel(registerNumber?: string | null) {
+  const trimmedRegisterNumber = registerNumber?.trim();
+
+  if (!trimmedRegisterNumber) {
+    return "this register";
+  }
+
+  return /^register\b/i.test(trimmedRegisterNumber)
+    ? trimmedRegisterNumber
+    : `Register ${trimmedRegisterNumber}`;
+}
+
 // Helper to check if timestamp is today
 const isToday = (timestamp: number) => {
   const date = new Date(timestamp);
@@ -47,10 +59,18 @@ export function TransactionsView() {
           storeId: activeStore._id,
           ...(registerSessionId
             ? {
-                registerSessionId:
-                  registerSessionId as Id<"registerSession">,
+                registerSessionId: registerSessionId as Id<"registerSession">,
               }
             : {}),
+        }
+      : "skip",
+  );
+  const registerSessionSnapshot = useQuery(
+    api.cashControls.deposits.getRegisterSessionSnapshot,
+    activeStore?._id && registerSessionId
+      ? {
+          registerSessionId: registerSessionId as Id<"registerSession">,
+          storeId: activeStore._id,
         }
       : "skip",
   );
@@ -58,6 +78,9 @@ export function TransactionsView() {
   const formatter = useMemo(
     () => (activeStore ? currencyFormatter(activeStore.currency) : null),
     [activeStore],
+  );
+  const registerFilterLabel = formatRegisterFilterLabel(
+    registerSessionSnapshot?.registerSession?.registerNumber,
   );
 
   const tableData: CompletedTransactionRow[] = useMemo(() => {
@@ -102,7 +125,7 @@ export function TransactionsView() {
         <div className="container mx-auto p-6 space-y-4">
           {registerSessionId ? (
             <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-              Showing transactions linked to this register session.
+              Showing transactions linked to {registerFilterLabel}
             </div>
           ) : null}
 
@@ -131,8 +154,8 @@ export function TransactionsView() {
                     {filter === "today"
                       ? "No completed transactions today"
                       : registerSessionId
-                        ? "No transactions for this register session"
-                      : "No completed transactions"}
+                        ? `No transactions for ${registerFilterLabel}`
+                        : "No completed transactions"}
                   </p>
                 }
               />

--- a/packages/athena-webapp/src/index.css
+++ b/packages/athena-webapp/src/index.css
@@ -17,8 +17,7 @@
 @layer base {
   :root {
     --font-sans: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-    --font-display: "Inter", "Palatino Linotype", "Book Antiqua",
-      Georgia, serif;
+    --font-display: var(--font-sans);
     --font-mono: "SFMono-Regular", "JetBrains Mono", "Menlo", monospace;
 
     --background: 0 0% 100%;

--- a/packages/athena-webapp/src/lib/moneyEntryAudit.test.ts
+++ b/packages/athena-webapp/src/lib/moneyEntryAudit.test.ts
@@ -68,7 +68,7 @@ const reviewedRawParses: ReviewedRawParse[] = [
       "Shared parser implementation: raw parse is contained inside parseDisplayAmountInput.",
   },
   {
-    file: "src/components/cash-controls/RegisterCloseoutView.tsx",
+    file: "src/components/cash-controls/formatReviewReason.ts",
     textIncludes: "formatStoredAmount(formatter, Number(rawVariance))",
     reason:
       "Display-only formatting for a backend-generated minor-unit variance reason; no persisted money input boundary.",

--- a/packages/athena-webapp/src/lib/utils.test.ts
+++ b/packages/athena-webapp/src/lib/utils.test.ts
@@ -64,6 +64,7 @@ describe("utils", () => {
 
   it("formats and normalizes display strings", () => {
     expect(currencyFormatter("USD").format(1250)).toBe("$1,250");
+    expect(currencyFormatter("GHS").format(1250)).toBe("GH₵1,250");
     expect(toSlug("  Raw Hair Bundle! Deal  ")).toBe("raw-hair-bundle-deal");
     expect(slugToWords("same-day-delivery")).toBe("same day delivery");
   });

--- a/packages/athena-webapp/src/lib/utils.ts
+++ b/packages/athena-webapp/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { ZodError } from "zod";
+import { currencyFormatter as sharedCurrencyFormatter } from "~/shared/currencyFormatter";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -26,12 +27,7 @@ export function capitalizeWords(str: string): string {
 }
 
 export function currencyFormatter(currency: string) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
+  return sharedCurrencyFormatter(currency);
 }
 
 export function toSlug(str: string) {


### PR DESCRIPTION
## Summary
- Refresh cash-controls dashboard/detail views around the repo design system, all-register session visibility, register lifecycle context, linked transaction navigation, and abbreviated staff names.
- Standardize Ghana cedi formatting through the shared formatter and apply it to POS receipts, transaction lists, cash-controls copy, and closeout review text.
- Keep POS keyboard shortcuts, payment breakdowns, and receipt generation covered with targeted tests.

## Validation
- [x] `bun run --filter '@athena/webapp' test -- src/lib/moneyEntryAudit.test.ts`
- [x] `bun run --filter '@athena/webapp' test -- convex/cashControls/registerSessions.test.ts convex/cashControls/closeouts.test.ts convex/cashControls/deposits.test.ts src/components/cash-controls/RegisterCloseoutView.test.tsx src/components/cash-controls/CashControlsDashboard.test.tsx src/components/cash-controls/RegisterSessionView.test.tsx src/components/operations/OperationsQueueView.test.tsx`
- [x] Pre-push suite: graphify check, architecture check, harness review, typecheck, production build, full webapp tests, Storybook build, and selected runtime behavior scenarios.

pr:athena=harness-reviewed
