### PR TITLE
fix(webapp): deploy active checkout styles

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -4859,7 +4859,7 @@
       "relation": "calls",
       "source": "harness_repo_validation_sortuniquepaths",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L45",
+      "source_location": "L46",
       "target": "harness_repo_validation_collectharnessrepovalidationselection",
       "weight": 1
     },
@@ -4871,7 +4871,7 @@
       "relation": "calls",
       "source": "harness_repo_validation_normalizerepopath",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L37",
+      "source_location": "L38",
       "target": "harness_repo_validation_matchesharnessrepovalidationpath",
       "weight": 1
     },
@@ -35735,7 +35735,7 @@
       "relation": "contains",
       "source": "scripts_harness_app_registry_ts",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L874",
+      "source_location": "L876",
       "target": "harness_app_registry_getharnesspackageregistration",
       "weight": 1
     },
@@ -38075,7 +38075,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L44",
+      "source_location": "L45",
       "target": "harness_repo_validation_collectharnessrepovalidationselection",
       "weight": 1
     },
@@ -38087,7 +38087,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L36",
+      "source_location": "L37",
       "target": "harness_repo_validation_matchesharnessrepovalidationpath",
       "weight": 1
     },
@@ -38099,7 +38099,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L26",
+      "source_location": "L27",
       "target": "harness_repo_validation_normalizerepopath",
       "weight": 1
     },
@@ -38111,7 +38111,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L30",
+      "source_location": "L31",
       "target": "harness_repo_validation_sortuniquepaths",
       "weight": 1
     },
@@ -53611,7 +53611,7 @@
       "label": "collectHarnessRepoValidationSelection()",
       "norm_label": "collectharnessrepovalidationselection()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L44"
+      "source_location": "L45"
     },
     {
       "community": 188,
@@ -53620,7 +53620,7 @@
       "label": "matchesHarnessRepoValidationPath()",
       "norm_label": "matchesharnessrepovalidationpath()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L36"
+      "source_location": "L37"
     },
     {
       "community": 188,
@@ -53629,7 +53629,7 @@
       "label": "normalizeRepoPath()",
       "norm_label": "normalizerepopath()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L26"
+      "source_location": "L27"
     },
     {
       "community": 188,
@@ -53638,7 +53638,7 @@
       "label": "sortUniquePaths()",
       "norm_label": "sortuniquepaths()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L30"
+      "source_location": "L31"
     },
     {
       "community": 188,
@@ -57877,7 +57877,7 @@
       "label": "getHarnessPackageRegistration()",
       "norm_label": "getharnesspackageregistration()",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L874"
+      "source_location": "L876"
     },
     {
       "community": 264,

--- a/manage-athena-versions.sh
+++ b/manage-athena-versions.sh
@@ -16,9 +16,30 @@ REMOTE_HOST="178.128.161.200"
 REMOTE="$REMOTE_USER@$REMOTE_HOST"
 
 # Local paths
-ATHENA_WEBAPP_DIR="$HOME/athena/packages/athena-webapp"
-STOREFRONT_DIR="$HOME/athena/packages/storefront-webapp"
-VALKEY_PROXY_DIR="$HOME/athena/packages/valkey-proxy-server"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+resolve_repo_root() {
+  if [ -n "$ATHENA_REPO_ROOT" ]; then
+    cd "$ATHENA_REPO_ROOT" 2>/dev/null && pwd
+    return
+  fi
+
+  if command -v git &> /dev/null; then
+    local cwd_root
+    cwd_root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$cwd_root" ] && [ -d "$cwd_root/packages/athena-webapp" ]; then
+      echo "$cwd_root"
+      return
+    fi
+  fi
+
+  echo "$SCRIPT_DIR"
+}
+
+REPO_ROOT="$(resolve_repo_root)"
+ATHENA_WEBAPP_DIR="$REPO_ROOT/packages/athena-webapp"
+STOREFRONT_DIR="$REPO_ROOT/packages/storefront-webapp"
+VALKEY_PROXY_DIR="$REPO_ROOT/packages/valkey-proxy-server"
 
 # =============================================
 # Helper Functions
@@ -112,6 +133,9 @@ deploy_app() {
   # Build the app
   echo "Building $app_name..."
   cd "$app_dir" || { echo "Failed to change to $app_dir"; return 1; }
+  local git_branch=$(git -C "$app_dir" branch --show-current 2>/dev/null || echo "unknown")
+  local git_commit=$(git -C "$app_dir" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  echo "Build source: $app_dir ($git_branch@$git_commit)"
   eval "$env_vars bun run build" || { echo "Build failed"; return 1; }
   
   # Deploy to server

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -206,7 +206,7 @@ Run these when bootstrap, generated router state, or package build configuration
 
 ## Storybook and frontend tooling edits
 
-Touched surfaces: `.storybook`, `src/stories`, `src/index.css`, `src/design-system-build-config.test.ts`, `tailwind.config.js`, `postcss.config.js`, `package.json`, `eslint.config.js`, `.gitignore`
+Touched surfaces: `.storybook`, `index.html`, `src/stories`, `src/index.css`, `src/design-system-build-config.test.ts`, `tailwind.config.js`, `postcss.config.js`, `package.json`, `eslint.config.js`, `.gitignore`
 
 Run:
 
@@ -214,5 +214,5 @@ Run:
 - `bun run --filter '@athena/webapp' build`
 - `bun run --filter '@athena/webapp' storybook:build`
 
-Use this when Storybook config, story files, or package-level frontend tooling changes need isolated validation.
+Use this when the document shell, Storybook config, story files, or package-level frontend tooling changes need isolated validation.
 

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -441,6 +441,7 @@
       "name": "storybook-and-frontend-tooling-edits",
       "pathPrefixes": [
         "packages/athena-webapp/.storybook",
+        "packages/athena-webapp/index.html",
         "packages/athena-webapp/src/stories",
         "packages/athena-webapp/src/index.css",
         "packages/athena-webapp/src/design-system-build-config.test.ts",

--- a/packages/athena-webapp/index.html
+++ b/packages/athena-webapp/index.html
@@ -4,18 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Athena</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style type="text/tailwindcss">
-      html {
-        color-scheme: light;
-      }
-      * {
-        @apply border-gray-200;
-      }
-      body {
-        @apply text-gray-950 bg-white;
-      }
-    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/packages/athena-webapp/src/design-system-build-config.test.ts
+++ b/packages/athena-webapp/src/design-system-build-config.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
@@ -24,6 +25,29 @@ describe("design system build config", () => {
 
     expect(path.resolve(tailwindPlugin.config)).toBe(
       path.join(packageDir, "tailwind.config.js"),
+    );
+  });
+
+  it("keeps runtime Tailwind out of the production document shell", () => {
+    const indexHtml = fs.readFileSync(path.join(packageDir, "index.html"), "utf8");
+
+    expect(indexHtml).not.toContain("cdn.tailwindcss.com");
+    expect(indexHtml).not.toContain('type="text/tailwindcss"');
+  });
+
+  it("lets the deployment helper build the active checkout", () => {
+    const repoRoot = path.resolve(packageDir, "../..");
+    const deployScript = fs.readFileSync(
+      path.join(repoRoot, "manage-athena-versions.sh"),
+      "utf8",
+    );
+
+    expect(deployScript).toContain('git -C "$PWD" rev-parse --show-toplevel');
+    expect(deployScript).toContain(
+      'ATHENA_WEBAPP_DIR="$REPO_ROOT/packages/athena-webapp"',
+    );
+    expect(deployScript).not.toContain(
+      'ATHENA_WEBAPP_DIR="$HOME/athena/packages/athena-webapp"',
     );
   });
 });

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -668,6 +668,7 @@ describe("HARNESS_APP_REGISTRY", () => {
     expect(storybookScenario).toMatchObject({
       touchedPaths: [
         ".storybook",
+        "index.html",
         "src/stories",
         "src/index.css",
         "src/design-system-build-config.test.ts",
@@ -683,7 +684,7 @@ describe("HARNESS_APP_REGISTRY", () => {
         { kind: "script", script: "storybook:build" },
       ],
       note:
-        "Use this when Storybook config, story files, or package-level frontend tooling changes need isolated validation.",
+        "Use this when the document shell, Storybook config, story files, or package-level frontend tooling changes need isolated validation.",
     });
   });
 

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -637,6 +637,7 @@ export const HARNESS_APP_REGISTRY = [
         title: "Storybook and frontend tooling edits",
         touchedPaths: [
           ".storybook",
+          "index.html",
           "src/stories",
           "src/index.css",
           "src/design-system-build-config.test.ts",
@@ -651,7 +652,8 @@ export const HARNESS_APP_REGISTRY = [
           { kind: "script", script: "build" },
           { kind: "script", script: "storybook:build" },
         ],
-        note: "Use this when Storybook config, story files, or package-level frontend tooling changes need isolated validation.",
+        note:
+          "Use this when the document shell, Storybook config, story files, or package-level frontend tooling changes need isolated validation.",
       },
     ],
   },

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -149,6 +149,7 @@ async function createFixtureRepo() {
     rootDir
   );
   await write("packages/athena-webapp/.storybook/main.ts", "export default {};\n", rootDir);
+  await write("packages/athena-webapp/index.html", "<div id=\"app\"></div>\n", rootDir);
   await write(
     "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
     "export default {};\n",

--- a/scripts/harness-repo-validation.test.ts
+++ b/scripts/harness-repo-validation.test.ts
@@ -14,6 +14,7 @@ describe("matchesHarnessRepoValidationPath", () => {
     "packages/AGENTS.md",
     "README.md",
     "package.json",
+    "manage-athena-versions.sh",
     ".github/workflows/athena-pr-tests.yml",
     ".husky/pre-commit",
     ".husky/pre-push",

--- a/scripts/harness-repo-validation.ts
+++ b/scripts/harness-repo-validation.ts
@@ -5,6 +5,7 @@ const HARNESS_REPO_VALIDATION_PATTERNS = [
   /^packages\/AGENTS\.md$/,
   /^README\.md$/,
   /^package\.json$/,
+  /^manage-athena-versions\.sh$/,
   /^\.github\/workflows\/athena-pr-tests\.yml$/,
   /^\.husky\/pre-commit$/,
   /^\.husky\/pre-push$/,


### PR DESCRIPTION
## Summary

Production Athena builds no longer load Tailwind twice. The app document shell now relies only on the Vite-built CSS bundle, so shared utilities like `rounded-md` keep the design-system radius tokens instead of being overridden by Tailwind CDN defaults.

The `athena` deployment helper also resolves the active git checkout from the directory where it is invoked. That keeps the alias from silently deploying `/Users/kwamina/athena` when you run it inside a worktree, and the deploy log now prints the exact build source path, branch, and commit.

## Verification

- `bash -n manage-athena-versions.sh`
- `bun run --filter '@athena/webapp' test -- src/design-system-build-config.test.ts`
- `bun test scripts/harness-repo-validation.test.ts scripts/harness-app-registry.test.ts scripts/harness-audit.test.ts`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- pre-push suite on `git push -u origin HEAD`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)