### PR TITLE
fix(webapp): recover auth handoff from Convex session

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -23951,7 +23951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_hooks_useauth_ts",
       "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
-      "source_location": "L8",
+      "source_location": "L7",
       "target": "useauth_useauth",
       "weight": 1
     },

--- a/packages/athena-webapp/convex/inventory/athenaUser.ts
+++ b/packages/athena-webapp/convex/inventory/athenaUser.ts
@@ -1,6 +1,14 @@
 import { v } from "convex/values";
 import { query } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
+import { getAuthenticatedAthenaUserWithCtx } from "../lib/athenaUserAuth";
+
+export const getAuthenticatedUser = query({
+  args: {},
+  handler: async (ctx) => {
+    return getAuthenticatedAthenaUserWithCtx(ctx);
+  },
+});
 
 export const getUserById = query({
   args: { id: v.union(v.string(), v.null()) },
@@ -10,7 +18,7 @@ export const getUserById = query({
     }
 
     try {
-      const res = await ctx.db.get(args.id as Id<"athenaUser">);
+      const res = await ctx.db.get("athenaUser", args.id as Id<"athenaUser">);
 
       return res;
     } catch (e) {

--- a/packages/athena-webapp/src/hooks/useAuth.test.tsx
+++ b/packages/athena-webapp/src/hooks/useAuth.test.tsx
@@ -27,6 +27,7 @@ describe("useAuth", () => {
     mocked.useAuthToken.mockReturnValue(null);
     window.localStorage.clear();
     vi.mocked(window.localStorage.getItem).mockReset();
+    vi.mocked(window.localStorage.setItem).mockReset();
     vi.mocked(window.localStorage.removeItem).mockReset();
   });
 
@@ -67,9 +68,7 @@ describe("useAuth", () => {
     expect(window.localStorage.removeItem).toHaveBeenCalledWith(
       LOGGED_IN_USER_ID_KEY
     );
-    expect(mocked.useQuery.mock.calls.at(-1)?.[1]).toEqual({
-      id: null,
-    });
+    expect(mocked.useQuery.mock.calls.at(-1)?.[1]).toBe("skip");
   });
 
   it("keeps loading while Convex re-establishes the backend session for a stored token", () => {
@@ -90,20 +89,26 @@ describe("useAuth", () => {
     expect(window.localStorage.removeItem).not.toHaveBeenCalled();
   });
 
-  it("loads the Athena user once the Convex session is ready", async () => {
-    vi.mocked(window.localStorage.getItem).mockReturnValue("user-1");
+  it("loads the Athena user from the authenticated Convex session when local storage is missing", async () => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
     mocked.useConvexAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
     });
     mocked.useQuery.mockImplementation((_ref, args) => {
       if (args && typeof args === "object" && "id" in args) {
-        return args.id
-          ? {
-              _id: "user-1",
-              email: "manager@example.com",
-            }
-          : null;
+        return null;
+      }
+
+      if (
+        args &&
+        typeof args === "object" &&
+        Object.keys(args).length === 0
+      ) {
+        return {
+          _id: "user-1",
+          email: "manager@example.com",
+        };
       }
 
       return {
@@ -120,8 +125,44 @@ describe("useAuth", () => {
       _id: "user-1",
       email: "manager@example.com",
     });
-    expect(mocked.useQuery.mock.calls.at(-1)?.[1]).toEqual({
-      id: "user-1",
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      LOGGED_IN_USER_ID_KEY,
+      "user-1"
+    );
+  });
+
+  it("loads the Athena user once the Convex session is ready", async () => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue("user-1");
+    mocked.useConvexAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
     });
+    mocked.useQuery.mockImplementation((_ref, args) => {
+      if (
+        args &&
+        typeof args === "object" &&
+        Object.keys(args).length === 0
+      ) {
+        return {
+          _id: "user-1",
+          email: "manager@example.com",
+        };
+      }
+
+      return {
+        _id: "convex-user-1",
+        email: "manager@example.com",
+      };
+    });
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.user).toMatchObject({
+      _id: "user-1",
+      email: "manager@example.com",
+    });
+    expect(mocked.useQuery.mock.calls.at(-1)?.[1]).toEqual({});
   });
 });

--- a/packages/athena-webapp/src/hooks/useAuth.ts
+++ b/packages/athena-webapp/src/hooks/useAuth.ts
@@ -2,7 +2,6 @@ import { useConvexAuth, useQuery } from "convex/react";
 import { useAuthToken } from "@convex-dev/auth/react";
 import { LOGGED_IN_USER_ID_KEY } from "../lib/constants";
 import { api } from "~/convex/_generated/api";
-import { Id } from "~/convex/_generated/dataModel";
 import { useEffect, useState } from "react";
 
 export const useAuth = () => {
@@ -15,6 +14,12 @@ export const useAuth = () => {
   const hasReadyConvexUser = Boolean(isAuthenticated && currentConvexUser);
   const isLoadingConvexUser =
     isAuthenticated && currentConvexUser === undefined;
+  const authenticatedAthenaUser = useQuery(
+    api.inventory.athenaUser.getAuthenticatedUser,
+    hasReadyConvexUser ? {} : "skip"
+  );
+  const isLoadingAthenaUser =
+    hasReadyConvexUser && authenticatedAthenaUser === undefined;
 
   useEffect(() => {
     const id = localStorage.getItem(LOGGED_IN_USER_ID_KEY);
@@ -28,38 +33,47 @@ export const useAuth = () => {
       isLoadingConvexAuth ||
       isRecoveringConvexSession ||
       isLoadingConvexUser ||
-      hasReadyConvexUser ||
-      !loggedInUserId
+      isLoadingAthenaUser
     ) {
       return;
     }
 
-    localStorage.removeItem(LOGGED_IN_USER_ID_KEY);
-    setLoggedInUserId(null);
+    const authenticatedAthenaUserId = authenticatedAthenaUser?._id ?? null;
+
+    if (authenticatedAthenaUserId) {
+      if (loggedInUserId !== authenticatedAthenaUserId) {
+        localStorage.setItem(LOGGED_IN_USER_ID_KEY, authenticatedAthenaUserId);
+        setLoggedInUserId(authenticatedAthenaUserId);
+      }
+      return;
+    }
+
+    if (loggedInUserId) {
+      localStorage.removeItem(LOGGED_IN_USER_ID_KEY);
+      setLoggedInUserId(null);
+    }
   }, [
+    authenticatedAthenaUser,
     isLoadingConvexAuth,
     isRecoveringConvexSession,
     isLoadingConvexUser,
+    isLoadingAthenaUser,
     isStorageLoaded,
     loggedInUserId,
-    hasReadyConvexUser,
   ]);
-
-  const user = useQuery(api.inventory.athenaUser.getUserById, {
-    id:
-      isStorageLoaded && hasReadyConvexUser
-        ? (loggedInUserId as Id<"athenaUser"> | null)
-        : null,
-  });
   const isLoading =
     !isStorageLoaded ||
     isLoadingConvexAuth ||
     isRecoveringConvexSession ||
     isLoadingConvexUser ||
-    (hasReadyConvexUser && user === undefined);
+    isLoadingAthenaUser;
 
   return {
-    user: isLoading ? undefined : hasReadyConvexUser ? user : null,
+    user: isLoading
+      ? undefined
+      : hasReadyConvexUser
+        ? authenticatedAthenaUser
+        : null,
     isLoading,
   };
 };


### PR DESCRIPTION
## Summary
- Resolve the Athena user from the authenticated Convex session instead of depending on `localStorage.logged_in_user_id` during sign-in handoff.
- Mirror the resolved Athena user id back into local storage so existing consumers still have the cached id.
- Add a regression test for the missing-local-storage handoff that can leave the authenticated UI empty after OTP sign-in.

## Validation
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' test -- src/hooks/useAuth.test.tsx src/routes/login/_layout.test.tsx src/routes/_authed.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild`
- `bun run --filter '@athena/webapp' build`