### PR TITLE
fix(skills): protect worktree branch names

### DIFF
--- a/.agents/skills/ce-worktree/SKILL.md
+++ b/.agents/skills/ce-worktree/SKILL.md
@@ -21,6 +21,7 @@ bash scripts/worktree-manager.sh create <branch-name> [from-branch]
 Defaults:
 - `from-branch` defaults to origin's default branch (or `main` if that cannot be resolved)
 - The new branch is created at `origin/<from-branch>` (or the local ref if the remote is unavailable)
+- `branch-name` must be a feature branch name, not a protected branch like `main`, `master`, `develop`, `dev`, `trunk`, `staging`, or `release/*`
 
 Examples:
 ```bash
@@ -68,9 +69,13 @@ Do not create a worktree for single-task work that can happen on a branch in the
 
 `ce-work` and `ce-code-review` offer this skill as an option. When the user selects "worktree" in those flows, invoke `bash scripts/worktree-manager.sh create <branch>` with a meaningful branch name derived from the work description (e.g., `feat/crowd-sniff`, `fix/email-validation`). Avoid auto-generated names like `worktree-jolly-beaming-raven` that obscure the work.
 
+Never check out `main` itself inside a linked worktree. Start from `origin/main` when needed, but always create a separate branch for the worktree checkout.
+
 ## Troubleshooting
 
 **"Worktree already exists"**: the path is already in use. Either switch to it (`cd .worktrees/<branch>`) or remove it (`git worktree remove .worktrees/<branch>`) before recreating.
+
+**"Refusing to create a linked worktree on protected branch"**: choose a feature branch name such as `codex/<ticket-id>` or `feat/<topic>`. Protected long-lived branches stay in the main checkout.
 
 **"Cannot remove worktree: it is the current worktree"**: `cd` out of the worktree first, then `git worktree remove`.
 

--- a/.agents/skills/ce-worktree/scripts/worktree-manager.sh
+++ b/.agents/skills/ce-worktree/scripts/worktree-manager.sh
@@ -34,6 +34,9 @@ Creates .worktrees/<branch-name> with <branch-name> branched from
 
 The main repo checkout is not modified; from-branch is fetched but
 not checked out.
+
+Protected branch names such as main, master, develop, dev, trunk,
+staging, and release/* are rejected as worktree branch names.
 EOF
 }
 
@@ -104,6 +107,14 @@ is_trusted_base_branch() {
   esac
 }
 
+is_protected_branch_name() {
+  local branch="$1"
+  case "$branch" in
+    main|master|develop|dev|trunk|staging|release/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Return 0 if worktree's copy of $file has the same blob hash as $base_ref's.
 # Symlinks are rejected (can't verify content).
 config_unchanged() {
@@ -160,6 +171,11 @@ create_worktree() {
   if [[ -z "$branch_name" ]]; then
     echo "Error: branch name required" >&2
     usage >&2
+    exit 1
+  fi
+  if is_protected_branch_name "$branch_name"; then
+    echo "Error: refusing to create a linked worktree on protected branch '$branch_name'" >&2
+    echo "Create a feature branch instead, for example 'codex/<ticket-id>' or 'feat/<name>'." >&2
     exit 1
   fi
 

--- a/.agents/skills/execute-linear-ticket/SKILL.md
+++ b/.agents/skills/execute-linear-ticket/SKILL.md
@@ -62,6 +62,7 @@ Use this resolution order before asking the user for context:
 ## Defaults
 
 - Start each ticket from the latest `origin/main` in a fresh worktree and `codex/` branch.
+- Never check out `main` itself inside a linked worktree; use `origin/main` only as the base ref for a ticket branch.
 - Include the Linear ticket id in every commit message.
 - Prefer Linear MCP operations for status changes, comments, and follow-up issue creation.
 - Prefer sub-agents when the work can be split into parallelizable chunks with clear ownership.
@@ -87,6 +88,7 @@ Use this resolution order before asking the user for context:
 
 - Create a fresh worktree from the latest `origin/main`.
 - Use a `codex/` branch name that includes the ticket id.
+- Treat any attempt to create a worktree on `main` or another protected long-lived branch as a setup error and fix it before editing.
 - Respect repo rules in `AGENTS.md` and related docs before coding.
 - If the overall batch is expected to land through one integration PR, still keep each ticket's implementation isolated in its own worktree or branch so the final integration step is deliberate.
 

--- a/.agents/skills/using-git-worktrees/SKILL.md
+++ b/.agents/skills/using-git-worktrees/SKILL.md
@@ -11,6 +11,8 @@ Git worktrees create isolated workspaces sharing the same repository, allowing w
 
 **Core principle:** Systematic directory selection + safety verification = reliable isolation.
 
+**Branch rule:** Base from `origin/main` when appropriate, but never create a linked worktree whose checked-out branch is `main` or another protected long-lived branch.
+
 **Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
 
 ## Directory Selection Process
@@ -98,6 +100,8 @@ git worktree add "$path" -b "$BRANCH_NAME"
 cd "$path"
 ```
 
+`$BRANCH_NAME` must be a feature branch such as `codex/<ticket-id>`, `feat/<topic>`, or `fix/<topic>`, not `main`, `master`, `develop`, `dev`, `trunk`, `staging`, or `release/*`.
+
 ### 3. Run Project Setup
 
 Auto-detect and run appropriate setup:
@@ -164,6 +168,11 @@ Ready to implement <feature-name>
 
 - **Problem:** Creates inconsistency, violates project conventions
 - **Fix:** Follow priority: existing > CLAUDE.md > ask
+
+### Reusing a protected branch name
+
+- **Problem:** A linked worktree can block later `git switch main` or produce "`main` is already checked out" failures
+- **Fix:** Always branch the worktree off `origin/main`; never make the worktree checkout itself `main`
 
 ### Proceeding with failing tests
 


### PR DESCRIPTION
## Summary
- reject protected long-lived branch names like `main` and `release/*` in the repo worktree helper
- document the new worktree branch rule in the repo-local worktree and Linear execution skills
- keep agents anchored on `origin/main` as a base ref while requiring a separate feature branch checkout

## Why
Creating a linked worktree directly on `main` can leave later sessions unable to switch the main checkout cleanly. This change turns that mistake into an immediate setup error and teaches the nearby skills to avoid it.

## Validation
- `bash .agents/skills/ce-worktree/scripts/worktree-manager.sh create main` (fails with the new protected-branch error)
- `bash .agents/skills/ce-worktree/scripts/worktree-manager.sh --help`
- `git diff --check`
- `bun run graphify:rebuild`