### PR TITLE
fix(repo): point git hooks at tracked husky scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Key repo-level commands:
 - `bun run pr:athena`
 - `bun run graphify:check`
 
+Run `bun install` (or `bun run prepare`) after cloning to point Git at the tracked hooks in `.husky/`. Worktrees inherit the repo config, so using the tracked `.husky` directory avoids the missing generated shim problem we saw with `.husky/_`.
+
 For repo-harness edits such as `scripts/harness-app-registry.ts`, keep
 `bun run harness:review --base origin/main` and
 `bun run harness:inferential-review` in the local ladder so a missing sibling

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "bun@1.1.29",
   "scripts": {
-    "prepare": "husky",
+    "prepare": "sh scripts/configure-git-hooks.sh",
     "architecture:check": "bun scripts/architecture-boundary-check.ts",
     "graphify:check": "bun scripts/graphify-check.ts",
     "graphify:rebuild": "bun scripts/graphify-rebuild.ts",

--- a/scripts/configure-git-hooks.sh
+++ b/scripts/configure-git-hooks.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+git config core.hooksPath .husky

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -834,6 +834,18 @@ describe("repo harness ergonomics", () => {
     );
   });
 
+  it("configures Git to use the tracked .husky hooks directory", async () => {
+    const [packageJson, configureHooksScript] = await Promise.all([
+      readFile(path.join(ROOT_DIR, "package.json"), "utf8"),
+      readFile(path.join(ROOT_DIR, "scripts/configure-git-hooks.sh"), "utf8"),
+    ]);
+
+    expect(JSON.parse(packageJson).scripts?.prepare).toBe(
+      "sh scripts/configure-git-hooks.sh"
+    );
+    expect(configureHooksScript).toContain("git config core.hooksPath .husky");
+  });
+
   it("pins Bun in package.json and keeps GitHub Actions aligned with that repo version", async () => {
     const [packageJsonText, workflow] = await Promise.all([
       readFile(path.join(ROOT_DIR, "package.json"), "utf8"),


### PR DESCRIPTION
## Summary
- point Git's hooks path at the tracked `.husky` directory instead of Husky's generated `.husky/_` shim directory
- add a small setup script and wire `prepare` to configure the repo consistently after clone or install
- cover the behavior with a regression test and README guidance so worktrees keep running the tracked pre-push hook

## Verification
- `bun run graphify:rebuild`
- `bun run harness:test`
- `bun run harness:review --base origin/main`
- `git push -u origin HEAD` (verified the tracked pre-push hook executed and passed)