### PR TITLE
fix(auth): refine login OTP flow

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3984 nodes · 3556 edges · 1453 communities detected
+- 3987 nodes · 3559 edges · 1453 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1663,20 +1663,20 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 43 - "Community 43"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 44 - "Community 44"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 46 - "Community 46"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 47 - "Community 47"
 Cohesion: 0.18
@@ -1979,16 +1979,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 122 - "Community 122"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 123 - "Community 123"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 124 - "Community 124"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 124 - "Community 124"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 125 - "Community 125"
 Cohesion: 0.33
@@ -2003,16 +2003,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 128 - "Community 128"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 129 - "Community 129"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.4
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
-
-### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 131 - "Community 131"
 Cohesion: 0.33
@@ -2023,36 +2023,36 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 133 - "Community 133"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 134 - "Community 134"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 135 - "Community 135"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 140 - "Community 140"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 141 - "Community 141"
 Cohesion: 0.53
@@ -2132,7 +2132,7 @@ Nodes (0):
 
 ### Community 160 - "Community 160"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 161 - "Community 161"
 Cohesion: 0.4
@@ -2143,16 +2143,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 163 - "Community 163"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 164 - "Community 164"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 165 - "Community 165"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 166 - "Community 166"
 Cohesion: 0.4
@@ -2160,15 +2160,15 @@ Nodes (0):
 
 ### Community 167 - "Community 167"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 168 - "Community 168"
-Cohesion: 0.6
-Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 169 - "Community 169"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 169 - "Community 169"
+Cohesion: 0.6
+Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.4
@@ -2183,28 +2183,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 173 - "Community 173"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 174 - "Community 174"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 176 - "Community 176"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.4
@@ -2215,40 +2215,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 181 - "Community 181"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 182 - "Community 182"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 183 - "Community 183"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 184 - "Community 184"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 185 - "Community 185"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 186 - "Community 186"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 188 - "Community 188"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 188 - "Community 188"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 189 - "Community 189"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 190 - "Community 190"
 Cohesion: 0.5
@@ -2259,104 +2259,104 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 192 - "Community 192"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 194 - "Community 194"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 195 - "Community 195"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 196 - "Community 196"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 197 - "Community 197"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 199 - "Community 199"
-Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 202 - "Community 202"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 203 - "Community 203"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 204 - "Community 204"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 206 - "Community 206"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 205 - "Community 205"
+### Community 207 - "Community 207"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 206 - "Community 206"
+### Community 208 - "Community 208"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 207 - "Community 207"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 208 - "Community 208"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 209 - "Community 209"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 210 - "Community 210"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 211 - "Community 211"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 212 - "Community 212"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 211 - "Community 211"
+### Community 213 - "Community 213"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 212 - "Community 212"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 213 - "Community 213"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 214 - "Community 214"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 216 - "Community 216"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.5
@@ -2371,44 +2371,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 220 - "Community 220"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 221 - "Community 221"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 222 - "Community 222"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 223 - "Community 223"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 224 - "Community 224"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 225 - "Community 225"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.67
-Nodes (2): getSummaryAmount(), getSummaryLabel()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 228 - "Community 228"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 229 - "Community 229"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getSummaryAmount(), getSummaryLabel()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.5
@@ -2431,68 +2431,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 235 - "Community 235"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 237 - "Community 237"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 238 - "Community 238"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 239 - "Community 239"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 240 - "Community 240"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 242 - "Community 242"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 244 - "Community 244"
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+
+### Community 245 - "Community 245"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 246 - "Community 246"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 245 - "Community 245"
+### Community 247 - "Community 247"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 246 - "Community 246"
-Cohesion: 0.67
-Nodes (2): completePendingAuthSync(), sleep()
-
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 250 - "Community 250"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 0.5
@@ -2519,55 +2519,55 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 257 - "Community 257"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 259 - "Community 259"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 260 - "Community 260"
 Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 261 - "Community 261"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 262 - "Community 262"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 264 - "Community 264"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 266 - "Community 266"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 267 - "Community 267"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 269 - "Community 269"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 270 - "Community 270"
@@ -2611,44 +2611,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 280 - "Community 280"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 281 - "Community 281"
 Cohesion: 1.0
 Nodes (2): buildRegisterState(), getRegisterState()
 
-### Community 281 - "Community 281"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 282 - "Community 282"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 284 - "Community 284"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 285 - "Community 285"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 286 - "Community 286"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 286 - "Community 286"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 288 - "Community 288"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 289 - "Community 289"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 289 - "Community 289"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.67
@@ -2659,36 +2659,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 292 - "Community 292"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 295 - "Community 295"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 296 - "Community 296"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 297 - "Community 297"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 298 - "Community 298"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 298 - "Community 298"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 299 - "Community 299"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
@@ -2703,16 +2703,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 305 - "Community 305"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 306 - "Community 306"
 Cohesion: 0.67

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -6179,7 +6179,7 @@
       "relation": "calls",
       "source": "layout_sleep",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L144",
+      "source_location": "L150",
       "target": "layout_completependingauthsync",
       "weight": 1
     },
@@ -17789,14 +17789,38 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "_tgt": "inputotp_formatrequestdelay",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L33",
+      "target": "inputotp_formatrequestdelay",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "_tgt": "inputotp_handlepinchange",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L43",
+      "source_location": "L81",
       "target": "inputotp_handlepinchange",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "_tgt": "inputotp_handlerequestnewcode",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L120",
+      "target": "inputotp_handlerequestnewcode",
       "weight": 1
     },
     {
@@ -17807,7 +17831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L51",
+      "source_location": "L89",
       "target": "inputotp_onsubmit",
       "weight": 1
     },
@@ -26807,7 +26831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_login_layout_tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L108",
+      "source_location": "L114",
       "target": "layout_completependingauthsync",
       "weight": 1
     },
@@ -26819,7 +26843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_login_layout_tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L75",
+      "source_location": "L81",
       "target": "layout_handlependingauthsync",
       "weight": 1
     },
@@ -26831,8 +26855,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_login_layout_tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L48",
+      "source_location": "L23",
       "target": "layout_sleep",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "_tgt": "layout_usedocumentscrolllock",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L27",
+      "target": "layout_usedocumentscrolllock",
       "weight": 1
     },
     {
@@ -47325,56 +47361,56 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1220,
@@ -47469,56 +47505,56 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1230,
@@ -47613,56 +47649,56 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1240,
@@ -47757,56 +47793,56 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L17"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L24"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 1250,
@@ -47901,56 +47937,56 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L31"
     },
     {
       "community": 1260,
@@ -48045,56 +48081,56 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L97"
     },
     {
       "community": 1270,
@@ -48189,56 +48225,56 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L1"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L107"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L63"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L80"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L46"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L97"
     },
     {
       "community": 1280,
@@ -48333,56 +48369,56 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexquickaddcatalogitem",
-      "label": "useConvexQuickAddCatalogItem()",
-      "norm_label": "useconvexquickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
     },
     {
       "community": 1290,
@@ -48657,56 +48693,56 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexquickaddcatalogitem",
+      "label": "useConvexQuickAddCatalogItem()",
+      "norm_label": "useconvexquickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L49"
     },
     {
       "community": 1300,
@@ -48801,56 +48837,56 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L28"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L37"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L12"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L6"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L49"
     },
     {
       "community": 1310,
@@ -48945,56 +48981,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1320,
@@ -49089,56 +49125,56 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1330,
@@ -49233,56 +49269,56 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
+      "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L155"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storesettingsview_onsubmit",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L197"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L104"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L72"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1340,
@@ -49377,56 +49413,56 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L83"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
     },
     {
       "community": 1350,
@@ -49521,56 +49557,56 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1360,
@@ -49665,56 +49701,56 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1370,
@@ -49809,55 +49845,55 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
     },
     {
@@ -49953,55 +49989,55 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
       "source_location": "L1"
     },
     {
@@ -50277,55 +50313,55 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
@@ -52041,321 +52077,6 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 165,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 165,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 165,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 165,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 165,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
       "norm_label": "feesview()",
@@ -52363,7 +52084,7 @@
       "source_location": "L30"
     },
     {
-      "community": 167,
+      "community": 160,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -52372,7 +52093,7 @@
       "source_location": "L43"
     },
     {
-      "community": 167,
+      "community": 160,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -52381,7 +52102,7 @@
       "source_location": "L106"
     },
     {
-      "community": 167,
+      "community": 160,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -52390,7 +52111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 160,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -52399,7 +52120,367 @@
       "source_location": "L1"
     },
     {
+      "community": 161,
+      "file_type": "code",
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 168,
+      "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -52408,7 +52489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -52417,7 +52498,7 @@
       "source_location": "L270"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -52426,7 +52507,7 @@
       "source_location": "L275"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -52435,58 +52516,13 @@
       "source_location": "L304"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
       "norm_label": "resetquickaddform()",
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L295"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
-      "label": "ReceivingView.tsx",
-      "norm_label": "receivingview.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "receivingview_builddefaultreceivedquantities",
-      "label": "buildDefaultReceivedQuantities()",
-      "norm_label": "builddefaultreceivedquantities()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "receivingview_buildreceivedquantitiesaftersubmission",
-      "label": "buildReceivedQuantitiesAfterSubmission()",
-      "norm_label": "buildreceivedquantitiesaftersubmission()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "receivingview_buildsubmissionkey",
-      "label": "buildSubmissionKey()",
-      "norm_label": "buildsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "receivingview_receivingview",
-      "label": "ReceivingView()",
-      "norm_label": "receivingview()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
-      "source_location": "L72"
     },
     {
       "community": 17,
@@ -52653,6 +52689,51 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
+      "label": "ReceivingView.tsx",
+      "norm_label": "receivingview.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "receivingview_builddefaultreceivedquantities",
+      "label": "buildDefaultReceivedQuantities()",
+      "norm_label": "builddefaultreceivedquantities()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "receivingview_buildreceivedquantitiesaftersubmission",
+      "label": "buildReceivedQuantitiesAfterSubmission()",
+      "norm_label": "buildreceivedquantitiesaftersubmission()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "receivingview_buildsubmissionkey",
+      "label": "buildSubmissionKey()",
+      "norm_label": "buildsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "receivingview_receivingview",
+      "label": "ReceivingView()",
+      "norm_label": "receivingview()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
       "norm_label": "promocodeview.tsx",
@@ -52660,7 +52741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -52669,7 +52750,7 @@
       "source_location": "L157"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -52678,7 +52759,7 @@
       "source_location": "L230"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -52687,7 +52768,7 @@
       "source_location": "L322"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -52696,7 +52777,7 @@
       "source_location": "L377"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -52705,7 +52786,7 @@
       "source_location": "L99"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -52714,7 +52795,7 @@
       "source_location": "L53"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -52723,7 +52804,7 @@
       "source_location": "L75"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -52732,7 +52813,7 @@
       "source_location": "L63"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -52741,7 +52822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -52750,7 +52831,7 @@
       "source_location": "L7"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -52759,7 +52840,7 @@
       "source_location": "L69"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -52768,7 +52849,7 @@
       "source_location": "L44"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -52777,7 +52858,7 @@
       "source_location": "L103"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -52786,7 +52867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -52795,7 +52876,7 @@
       "source_location": "L18"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -52804,7 +52885,7 @@
       "source_location": "L23"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -52813,7 +52894,7 @@
       "source_location": "L65"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -52822,7 +52903,7 @@
       "source_location": "L45"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -52831,7 +52912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -52840,7 +52921,7 @@
       "source_location": "L78"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -52849,7 +52930,7 @@
       "source_location": "L74"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -52858,7 +52939,7 @@
       "source_location": "L103"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -52867,7 +52948,7 @@
       "source_location": "L109"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -52876,7 +52957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -52885,7 +52966,7 @@
       "source_location": "L75"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -52894,7 +52975,7 @@
       "source_location": "L26"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -52903,7 +52984,7 @@
       "source_location": "L38"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -52912,7 +52993,7 @@
       "source_location": "L4"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -52921,7 +53002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -52930,7 +53011,7 @@
       "source_location": "L3"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -52939,7 +53020,7 @@
       "source_location": "L29"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -52948,7 +53029,7 @@
       "source_location": "L33"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -52957,7 +53038,7 @@
       "source_location": "L40"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -52966,7 +53047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -52975,7 +53056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -52984,7 +53065,7 @@
       "source_location": "L12"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -52993,7 +53074,7 @@
       "source_location": "L27"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -53002,7 +53083,7 @@
       "source_location": "L33"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -53011,7 +53092,7 @@
       "source_location": "L55"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -53020,7 +53101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -53029,7 +53110,7 @@
       "source_location": "L42"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -53038,7 +53119,7 @@
       "source_location": "L29"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -53047,58 +53128,13 @@
       "source_location": "L49"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
       "norm_label": "generatetransactionnumber()",
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_timelineutils_ts",
-      "label": "timelineUtils.ts",
-      "norm_label": "timelineutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "timelineutils_enrichtimelineevent",
-      "label": "enrichTimelineEvent()",
-      "norm_label": "enrichtimelineevent()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "timelineutils_enrichtimelineevents",
-      "label": "enrichTimelineEvents()",
-      "norm_label": "enrichtimelineevents()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L200"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "timelineutils_gettimerangelabel",
-      "label": "getTimeRangeLabel()",
-      "norm_label": "gettimerangelabel()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "timelineutils_groupeventsbytimeframe",
-      "label": "groupEventsByTimeframe()",
-      "norm_label": "groupeventsbytimeframe()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L206"
     },
     {
       "community": 18,
@@ -53265,6 +53301,96 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_timelineutils_ts",
+      "label": "timelineUtils.ts",
+      "norm_label": "timelineutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "timelineutils_enrichtimelineevent",
+      "label": "enrichTimelineEvent()",
+      "norm_label": "enrichtimelineevent()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "timelineutils_enrichtimelineevents",
+      "label": "enrichTimelineEvents()",
+      "norm_label": "enrichtimelineevents()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "timelineutils_gettimerangelabel",
+      "label": "getTimeRangeLabel()",
+      "norm_label": "gettimerangelabel()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "timelineutils_groupeventsbytimeframe",
+      "label": "groupEventsByTimeframe()",
+      "norm_label": "groupeventsbytimeframe()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "layout_completependingauthsync",
+      "label": "completePendingAuthSync()",
+      "norm_label": "completependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "layout_handlependingauthsync",
+      "label": "handlePendingAuthSync()",
+      "norm_label": "handlependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "layout_sleep",
+      "label": "sleep()",
+      "norm_label": "sleep()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "layout_usedocumentscrolllock",
+      "label": "useDocumentScrollLock()",
+      "norm_label": "usedocumentscrolllock()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
       "norm_label": "getproductviewcount()",
@@ -53272,7 +53398,7 @@
       "source_location": "L93"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -53281,7 +53407,7 @@
       "source_location": "L75"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -53290,7 +53416,7 @@
       "source_location": "L4"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -53299,7 +53425,7 @@
       "source_location": "L47"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -53308,7 +53434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -53317,7 +53443,7 @@
       "source_location": "L11"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -53326,7 +53452,7 @@
       "source_location": "L25"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -53335,7 +53461,7 @@
       "source_location": "L9"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -53344,7 +53470,7 @@
       "source_location": "L39"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -53353,7 +53479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -53362,7 +53488,7 @@
       "source_location": "L4"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -53371,7 +53497,7 @@
       "source_location": "L24"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -53380,7 +53506,7 @@
       "source_location": "L6"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -53389,7 +53515,7 @@
       "source_location": "L42"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -53398,7 +53524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -53407,7 +53533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -53416,7 +53542,7 @@
       "source_location": "L28"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -53425,7 +53551,7 @@
       "source_location": "L5"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -53434,7 +53560,7 @@
       "source_location": "L7"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -53443,7 +53569,7 @@
       "source_location": "L46"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -53452,7 +53578,7 @@
       "source_location": "L147"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -53461,7 +53587,7 @@
       "source_location": "L185"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -53470,7 +53596,7 @@
       "source_location": "L115"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -53479,7 +53605,7 @@
       "source_location": "L31"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -53488,7 +53614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -53497,7 +53623,7 @@
       "source_location": "L14"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -53506,7 +53632,7 @@
       "source_location": "L22"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -53515,7 +53641,7 @@
       "source_location": "L30"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -53524,7 +53650,7 @@
       "source_location": "L3"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -53533,7 +53659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -53542,7 +53668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -53551,7 +53677,7 @@
       "source_location": "L136"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -53560,7 +53686,7 @@
       "source_location": "L154"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -53569,7 +53695,7 @@
       "source_location": "L25"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -53578,7 +53704,7 @@
       "source_location": "L47"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -53587,7 +53713,7 @@
       "source_location": "L45"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -53596,7 +53722,7 @@
       "source_location": "L37"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -53605,7 +53731,7 @@
       "source_location": "L27"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -53614,84 +53740,12 @@
       "source_location": "L31"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
       "norm_label": "harness-repo-validation.ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
-      "label": "registerSessionTraceLifecycle.test.ts",
-      "norm_label": "registersessiontracelifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "registersessiontracelifecycle_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "registersessiontracelifecycle_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "registersessiontracelifecycle_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L263"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_createtemproot",
-      "label": "createTempRoot()",
-      "norm_label": "createtemproot()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
-      "label": "runPaginationCheck()",
-      "norm_label": "runpaginationcheck()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_writeconvexfile",
-      "label": "writeConvexFile()",
-      "norm_label": "writeconvexfile()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
-      "label": "convexPaginationAntiPatternCheck.test.ts",
-      "norm_label": "convexpaginationantipatterncheck.test.ts",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
       "source_location": "L1"
     },
     {
@@ -53859,6 +53913,78 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
+      "label": "registerSessionTraceLifecycle.test.ts",
+      "norm_label": "registersessiontracelifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "registersessiontracelifecycle_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "registersessiontracelifecycle_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "registersessiontracelifecycle_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L263"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_createtemproot",
+      "label": "createTempRoot()",
+      "norm_label": "createtemproot()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
+      "label": "runPaginationCheck()",
+      "norm_label": "runpaginationcheck()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_writeconvexfile",
+      "label": "writeConvexFile()",
+      "norm_label": "writeconvexfile()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
+      "label": "convexPaginationAntiPatternCheck.test.ts",
+      "norm_label": "convexpaginationantipatterncheck.test.ts",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
       "norm_label": "hasallvisibilesessionitems()",
@@ -53866,7 +53992,7 @@
       "source_location": "L109"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -53875,7 +54001,7 @@
       "source_location": "L84"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -53884,7 +54010,7 @@
       "source_location": "L95"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -53893,7 +54019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -53902,7 +54028,7 @@
       "source_location": "L145"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -53911,7 +54037,7 @@
       "source_location": "L35"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -53920,7 +54046,7 @@
       "source_location": "L160"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -53929,7 +54055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -53938,7 +54064,7 @@
       "source_location": "L50"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -53947,7 +54073,7 @@
       "source_location": "L23"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -53956,7 +54082,7 @@
       "source_location": "L37"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -53965,7 +54091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -53974,7 +54100,7 @@
       "source_location": "L21"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -53983,7 +54109,7 @@
       "source_location": "L35"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -53992,7 +54118,7 @@
       "source_location": "L45"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -54001,7 +54127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -54010,7 +54136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -54019,7 +54145,7 @@
       "source_location": "L21"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -54028,7 +54154,7 @@
       "source_location": "L35"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -54037,7 +54163,7 @@
       "source_location": "L45"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -54046,7 +54172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -54055,7 +54181,7 @@
       "source_location": "L227"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -54064,7 +54190,7 @@
       "source_location": "L90"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -54073,7 +54199,7 @@
       "source_location": "L244"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -54082,7 +54208,7 @@
       "source_location": "L5"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -54091,7 +54217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -54100,7 +54226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -54109,7 +54235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -54118,7 +54244,7 @@
       "source_location": "L26"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -54127,7 +54253,7 @@
       "source_location": "L79"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -54136,84 +54262,12 @@
       "source_location": "L33"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
       "norm_label": "collections.ts",
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "normalize_maskmtnpartyid",
-      "label": "maskMtnPartyId()",
-      "norm_label": "maskmtnpartyid()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "normalize_normalizecollectionstransaction",
-      "label": "normalizeCollectionsTransaction()",
-      "norm_label": "normalizecollectionstransaction()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "normalize_parsecollectionsnotificationrequest",
-      "label": "parseCollectionsNotificationRequest()",
-      "norm_label": "parsecollectionsnotificationrequest()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "label": "normalize.ts",
-      "norm_label": "normalize.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -54678,6 +54732,78 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "normalize_maskmtnpartyid",
+      "label": "maskMtnPartyId()",
+      "norm_label": "maskmtnpartyid()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "normalize_normalizecollectionstransaction",
+      "label": "normalizeCollectionsTransaction()",
+      "norm_label": "normalizecollectionstransaction()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "normalize_parsecollectionsnotificationrequest",
+      "label": "parseCollectionsNotificationRequest()",
+      "norm_label": "parsecollectionsnotificationrequest()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
+      "label": "normalize.ts",
+      "norm_label": "normalize.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
       "norm_label": "buildoperationalworkitem()",
@@ -54685,7 +54811,7 @@
       "source_location": "L8"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -54694,7 +54820,7 @@
       "source_location": "L32"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -54703,7 +54829,7 @@
       "source_location": "L64"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -54712,7 +54838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -54721,7 +54847,7 @@
       "source_location": "L18"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -54730,7 +54856,7 @@
       "source_location": "L25"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -54739,7 +54865,7 @@
       "source_location": "L11"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -54748,7 +54874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -54757,7 +54883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -54766,7 +54892,7 @@
       "source_location": "L33"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -54775,7 +54901,7 @@
       "source_location": "L19"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -54784,7 +54910,7 @@
       "source_location": "L42"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -54793,7 +54919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -54802,7 +54928,7 @@
       "source_location": "L31"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -54811,7 +54937,7 @@
       "source_location": "L48"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -54820,7 +54946,7 @@
       "source_location": "L131"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -54829,7 +54955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -54838,7 +54964,7 @@
       "source_location": "L37"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -54847,7 +54973,7 @@
       "source_location": "L24"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -54856,7 +54982,7 @@
       "source_location": "L19"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -54865,7 +54991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -54874,7 +55000,7 @@
       "source_location": "L29"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -54883,7 +55009,7 @@
       "source_location": "L24"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -54892,7 +55018,7 @@
       "source_location": "L51"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -54901,7 +55027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -54910,7 +55036,7 @@
       "source_location": "L122"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -54919,7 +55045,7 @@
       "source_location": "L34"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -54928,7 +55054,7 @@
       "source_location": "L72"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -54937,7 +55063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -54946,7 +55072,7 @@
       "source_location": "L162"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -54955,85 +55081,13 @@
       "source_location": "L56"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
       "norm_label": "findsessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L180"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "adjustments_test_createapprovaldecisionmutationctx",
-      "label": "createApprovalDecisionMutationCtx()",
-      "norm_label": "createapprovaldecisionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "adjustments_test_createsubmissionmutationctx",
-      "label": "createSubmissionMutationCtx()",
-      "norm_label": "createsubmissionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L176"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "adjustments_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
-      "label": "adjustments.test.ts",
-      "norm_label": "adjustments.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
-      "label": "replenishment.test.ts",
-      "norm_label": "replenishment.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "replenishment_test_createreplenishmentqueryctx",
-      "label": "createReplenishmentQueryCtx()",
-      "norm_label": "createreplenishmentqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "replenishment_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "replenishment_test_toasynciterable",
-      "label": "toAsyncIterable()",
-      "norm_label": "toasynciterable()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L13"
     },
     {
       "community": 21,
@@ -55191,6 +55245,78 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "adjustments_test_createapprovaldecisionmutationctx",
+      "label": "createApprovalDecisionMutationCtx()",
+      "norm_label": "createapprovaldecisionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "adjustments_test_createsubmissionmutationctx",
+      "label": "createSubmissionMutationCtx()",
+      "norm_label": "createsubmissionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "adjustments_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "label": "adjustments.test.ts",
+      "norm_label": "adjustments.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
+      "label": "replenishment.test.ts",
+      "norm_label": "replenishment.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "replenishment_test_createreplenishmentqueryctx",
+      "label": "createReplenishmentQueryCtx()",
+      "norm_label": "createreplenishmentqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "replenishment_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "replenishment_test_toasynciterable",
+      "label": "toAsyncIterable()",
+      "norm_label": "toasynciterable()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -55198,7 +55324,7 @@
       "source_location": "L19"
     },
     {
-      "community": 210,
+      "community": 212,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -55207,7 +55333,7 @@
       "source_location": "L26"
     },
     {
-      "community": 210,
+      "community": 212,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -55216,7 +55342,7 @@
       "source_location": "L12"
     },
     {
-      "community": 210,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -55225,7 +55351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -55234,7 +55360,7 @@
       "source_location": "L21"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -55243,7 +55369,7 @@
       "source_location": "L63"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -55252,7 +55378,7 @@
       "source_location": "L71"
     },
     {
-      "community": 211,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -55261,7 +55387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -55270,7 +55396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -55279,7 +55405,7 @@
       "source_location": "L13"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -55288,7 +55414,7 @@
       "source_location": "L31"
     },
     {
-      "community": 212,
+      "community": 214,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -55297,7 +55423,7 @@
       "source_location": "L9"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -55306,7 +55432,7 @@
       "source_location": "L51"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -55315,7 +55441,7 @@
       "source_location": "L37"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -55324,7 +55450,7 @@
       "source_location": "L44"
     },
     {
-      "community": 213,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -55333,7 +55459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -55342,7 +55468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -55351,7 +55477,7 @@
       "source_location": "L12"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -55360,7 +55486,7 @@
       "source_location": "L46"
     },
     {
-      "community": 214,
+      "community": 216,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -55369,7 +55495,7 @@
       "source_location": "L7"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -55378,7 +55504,7 @@
       "source_location": "L227"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -55387,7 +55513,7 @@
       "source_location": "L46"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -55396,7 +55522,7 @@
       "source_location": "L27"
     },
     {
-      "community": 215,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -55405,7 +55531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -55414,7 +55540,7 @@
       "source_location": "L55"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -55423,7 +55549,7 @@
       "source_location": "L32"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -55432,7 +55558,7 @@
       "source_location": "L211"
     },
     {
-      "community": 216,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -55441,7 +55567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -55450,7 +55576,7 @@
       "source_location": "L52"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -55459,7 +55585,7 @@
       "source_location": "L27"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -55468,85 +55594,13 @@
       "source_location": "L288"
     },
     {
-      "community": 217,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
       "norm_label": "categorysubcategorymanager.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "analyticsview_activecheckoutsessions",
-      "label": "ActiveCheckoutSessions()",
-      "norm_label": "activecheckoutsessions()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "analyticsview_analyticsview",
-      "label": "AnalyticsView()",
-      "norm_label": "analyticsview()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "analyticsview_storevisitors",
-      "label": "StoreVisitors()",
-      "norm_label": "storevisitors()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "label": "AnalyticsView.tsx",
-      "norm_label": "analyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "label": "StorefrontObservabilityPanel.tsx",
-      "norm_label": "storefrontobservabilitypanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_formatlabel",
-      "label": "formatLabel()",
-      "norm_label": "formatlabel()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
-      "label": "getTrafficSourceBadge()",
-      "norm_label": "gettrafficsourcebadge()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L19"
     },
     {
       "community": 22,
@@ -55704,6 +55758,78 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "analyticsview_activecheckoutsessions",
+      "label": "ActiveCheckoutSessions()",
+      "norm_label": "activecheckoutsessions()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "analyticsview_analyticsview",
+      "label": "AnalyticsView()",
+      "norm_label": "analyticsview()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "analyticsview_storevisitors",
+      "label": "StoreVisitors()",
+      "norm_label": "storevisitors()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
+      "label": "AnalyticsView.tsx",
+      "norm_label": "analyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
+      "label": "StorefrontObservabilityPanel.tsx",
+      "norm_label": "storefrontobservabilitypanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_formatlabel",
+      "label": "formatLabel()",
+      "norm_label": "formatlabel()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
+      "label": "getTrafficSourceBadge()",
+      "norm_label": "gettrafficsourcebadge()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
       "norm_label": "utils.ts",
@@ -55711,7 +55837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -55720,7 +55846,7 @@
       "source_location": "L52"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -55729,7 +55855,7 @@
       "source_location": "L3"
     },
     {
-      "community": 220,
+      "community": 222,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -55738,7 +55864,7 @@
       "source_location": "L90"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -55747,7 +55873,7 @@
       "source_location": "L86"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -55756,7 +55882,7 @@
       "source_location": "L76"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -55765,7 +55891,7 @@
       "source_location": "L52"
     },
     {
-      "community": 221,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -55774,7 +55900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -55783,7 +55909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -55792,7 +55918,7 @@
       "source_location": "L67"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -55801,7 +55927,7 @@
       "source_location": "L90"
     },
     {
-      "community": 222,
+      "community": 224,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -55810,7 +55936,7 @@
       "source_location": "L73"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -55819,7 +55945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -55828,7 +55954,7 @@
       "source_location": "L105"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -55837,7 +55963,7 @@
       "source_location": "L97"
     },
     {
-      "community": 223,
+      "community": 225,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -55846,7 +55972,7 @@
       "source_location": "L83"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -55855,7 +55981,7 @@
       "source_location": "L91"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -55864,7 +55990,7 @@
       "source_location": "L68"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -55873,7 +55999,7 @@
       "source_location": "L22"
     },
     {
-      "community": 224,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -55882,7 +56008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -55891,7 +56017,7 @@
       "source_location": "L36"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -55900,7 +56026,7 @@
       "source_location": "L53"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -55909,7 +56035,7 @@
       "source_location": "L32"
     },
     {
-      "community": 225,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -55918,7 +56044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "ordersummary_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -55927,7 +56053,7 @@
       "source_location": "L377"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -55936,7 +56062,7 @@
       "source_location": "L259"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -55945,7 +56071,7 @@
       "source_location": "L276"
     },
     {
-      "community": 226,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -55954,7 +56080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -55963,7 +56089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -55972,7 +56098,7 @@
       "source_location": "L27"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -55981,85 +56107,13 @@
       "source_location": "L18"
     },
     {
-      "community": 227,
+      "community": 229,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
       "norm_label": "stripwhitespace()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L60"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "label": "POSSettingsView.tsx",
-      "norm_label": "possettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "possettingsview_handleregisterterminal",
-      "label": "handleRegisterTerminal()",
-      "norm_label": "handleregisterterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L312"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "possettingsview_handleupdateexistingterminal",
-      "label": "handleUpdateExistingTerminal()",
-      "norm_label": "handleupdateexistingterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L364"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "possettingsview_loadfingerprint",
-      "label": "loadFingerprint()",
-      "norm_label": "loadfingerprint()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L219"
     },
     {
       "community": 23,
@@ -56217,6 +56271,78 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L60"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
+      "label": "POSSettingsView.tsx",
+      "norm_label": "possettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "possettingsview_handleregisterterminal",
+      "label": "handleRegisterTerminal()",
+      "norm_label": "handleregisterterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L312"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "possettingsview_handleupdateexistingterminal",
+      "label": "handleUpdateExistingTerminal()",
+      "norm_label": "handleupdateexistingterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L364"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "possettingsview_loadfingerprint",
+      "label": "loadFingerprint()",
+      "norm_label": "loadfingerprint()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L219"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
       "norm_label": "transactionsview.tsx",
@@ -56224,7 +56350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -56233,7 +56359,7 @@
       "source_location": "L22"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -56242,7 +56368,7 @@
       "source_location": "L27"
     },
     {
-      "community": 230,
+      "community": 232,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -56251,7 +56377,7 @@
       "source_location": "L40"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -56260,7 +56386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -56269,7 +56395,7 @@
       "source_location": "L78"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -56278,7 +56404,7 @@
       "source_location": "L118"
     },
     {
-      "community": 231,
+      "community": 233,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -56287,7 +56413,7 @@
       "source_location": "L89"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -56296,7 +56422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -56305,7 +56431,7 @@
       "source_location": "L63"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -56314,7 +56440,7 @@
       "source_location": "L54"
     },
     {
-      "community": 232,
+      "community": 234,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -56323,7 +56449,7 @@
       "source_location": "L11"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -56332,7 +56458,7 @@
       "source_location": "L16"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -56341,7 +56467,7 @@
       "source_location": "L35"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -56350,7 +56476,7 @@
       "source_location": "L6"
     },
     {
-      "community": 233,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -56359,7 +56485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -56368,7 +56494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -56377,7 +56503,7 @@
       "source_location": "L5"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -56386,7 +56512,7 @@
       "source_location": "L30"
     },
     {
-      "community": 234,
+      "community": 236,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -56395,7 +56521,7 @@
       "source_location": "L21"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -56404,7 +56530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -56413,7 +56539,7 @@
       "source_location": "L178"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -56422,7 +56548,7 @@
       "source_location": "L205"
     },
     {
-      "community": 235,
+      "community": 237,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -56431,7 +56557,7 @@
       "source_location": "L806"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -56440,7 +56566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -56449,7 +56575,7 @@
       "source_location": "L41"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -56458,7 +56584,7 @@
       "source_location": "L45"
     },
     {
-      "community": 236,
+      "community": 238,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -56467,7 +56593,7 @@
       "source_location": "L65"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -56476,7 +56602,7 @@
       "source_location": "L75"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -56485,7 +56611,7 @@
       "source_location": "L82"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -56494,84 +56620,12 @@
       "source_location": "L93"
     },
     {
-      "community": 237,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
       "norm_label": "engagementmetrics.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "label": "RiskIndicators.tsx",
-      "norm_label": "riskindicators.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "riskindicators_getriskicon",
-      "label": "getRiskIcon()",
-      "norm_label": "getriskicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "riskindicators_getriskstyles",
-      "label": "getRiskStyles()",
-      "norm_label": "getriskstyles()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "riskindicators_riskindicators",
-      "label": "RiskIndicators()",
-      "norm_label": "riskindicators()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "label": "formatObservabilityLabel()",
-      "norm_label": "formatobservabilitylabel()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_getdeviceicon",
-      "label": "getDeviceIcon()",
-      "norm_label": "getdeviceicon()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "label": "getObservabilityStatusStyles()",
-      "norm_label": "getobservabilitystatusstyles()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
-      "label": "customerObservabilityTimeline.ts",
-      "norm_label": "customerobservabilitytimeline.ts",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1"
     },
     {
@@ -56730,6 +56784,78 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
+      "label": "RiskIndicators.tsx",
+      "norm_label": "riskindicators.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "riskindicators_getriskicon",
+      "label": "getRiskIcon()",
+      "norm_label": "getriskicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "riskindicators_getriskstyles",
+      "label": "getRiskStyles()",
+      "norm_label": "getriskstyles()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "riskindicators_riskindicators",
+      "label": "RiskIndicators()",
+      "norm_label": "riskindicators()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_formatobservabilitylabel",
+      "label": "formatObservabilityLabel()",
+      "norm_label": "formatobservabilitylabel()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_getdeviceicon",
+      "label": "getDeviceIcon()",
+      "norm_label": "getdeviceicon()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
+      "label": "getObservabilityStatusStyles()",
+      "norm_label": "getobservabilitystatusstyles()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
+      "label": "customerObservabilityTimeline.ts",
+      "norm_label": "customerobservabilitytimeline.ts",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
       "norm_label": "extractbarcodefrominput()",
@@ -56737,7 +56863,7 @@
       "source_location": "L51"
     },
     {
-      "community": 240,
+      "community": 242,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -56746,7 +56872,7 @@
       "source_location": "L92"
     },
     {
-      "community": 240,
+      "community": 242,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -56755,7 +56881,7 @@
       "source_location": "L16"
     },
     {
-      "community": 240,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -56764,7 +56890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -56773,7 +56899,7 @@
       "source_location": "L22"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -56782,7 +56908,7 @@
       "source_location": "L10"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -56791,7 +56917,7 @@
       "source_location": "L57"
     },
     {
-      "community": 241,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -56800,7 +56926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -56809,7 +56935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -56818,7 +56944,7 @@
       "source_location": "L83"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -56827,7 +56953,7 @@
       "source_location": "L100"
     },
     {
-      "community": 242,
+      "community": 244,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -56836,7 +56962,7 @@
       "source_location": "L79"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -56845,7 +56971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -56854,7 +56980,7 @@
       "source_location": "L38"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -56863,7 +56989,7 @@
       "source_location": "L65"
     },
     {
-      "community": 243,
+      "community": 245,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -56872,7 +56998,7 @@
       "source_location": "L91"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -56881,7 +57007,7 @@
       "source_location": "L4"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -56890,7 +57016,7 @@
       "source_location": "L20"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -56899,7 +57025,7 @@
       "source_location": "L42"
     },
     {
-      "community": 244,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -56908,7 +57034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -56917,7 +57043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -56926,7 +57052,7 @@
       "source_location": "L36"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -56935,7 +57061,7 @@
       "source_location": "L48"
     },
     {
-      "community": 245,
+      "community": 247,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -56944,43 +57070,7 @@
       "source_location": "L64"
     },
     {
-      "community": 246,
-      "file_type": "code",
-      "id": "layout_completependingauthsync",
-      "label": "completePendingAuthSync()",
-      "norm_label": "completependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L108"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "layout_handlependingauthsync",
-      "label": "handlePendingAuthSync()",
-      "norm_label": "handlependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "layout_sleep",
-      "label": "sleep()",
-      "norm_label": "sleep()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -56989,7 +57079,7 @@
       "source_location": "L13"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -56998,7 +57088,7 @@
       "source_location": "L46"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -57007,7 +57097,7 @@
       "source_location": "L21"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -57016,7 +57106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -57025,7 +57115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -57034,7 +57124,7 @@
       "source_location": "L8"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -57043,49 +57133,13 @@
       "source_location": "L5"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "subcategory_getallsubcategories",
-      "label": "getAllSubcategories()",
-      "norm_label": "getallsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "subcategory_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "subcategory_getsubategory",
-      "label": "getSubategory()",
-      "norm_label": "getsubategory()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L25"
     },
     {
       "community": 25,
@@ -57234,6 +57288,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "subcategory_getallsubcategories",
+      "label": "getAllSubcategories()",
+      "norm_label": "getallsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "subcategory_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "subcategory_getsubategory",
+      "label": "getSubategory()",
+      "norm_label": "getsubategory()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
       "norm_label": "productactionbar.tsx",
@@ -57241,7 +57331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -57250,7 +57340,7 @@
       "source_location": "L50"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -57259,7 +57349,7 @@
       "source_location": "L92"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -57268,7 +57358,7 @@
       "source_location": "L74"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -57277,7 +57367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -57286,7 +57376,7 @@
       "source_location": "L62"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -57295,7 +57385,7 @@
       "source_location": "L109"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -57304,7 +57394,7 @@
       "source_location": "L177"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -57313,7 +57403,7 @@
       "source_location": "L18"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -57322,7 +57412,7 @@
       "source_location": "L52"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -57331,7 +57421,7 @@
       "source_location": "L68"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -57340,7 +57430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -57349,7 +57439,7 @@
       "source_location": "L68"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -57358,7 +57448,7 @@
       "source_location": "L26"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -57367,7 +57457,7 @@
       "source_location": "L7"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -57376,7 +57466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -57385,7 +57475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -57394,7 +57484,7 @@
       "source_location": "L81"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -57403,7 +57493,7 @@
       "source_location": "L85"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -57412,7 +57502,7 @@
       "source_location": "L27"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -57421,7 +57511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -57430,7 +57520,7 @@
       "source_location": "L43"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -57439,7 +57529,7 @@
       "source_location": "L13"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -57448,7 +57538,7 @@
       "source_location": "L88"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -57457,7 +57547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -57466,7 +57556,7 @@
       "source_location": "L111"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -57475,7 +57565,7 @@
       "source_location": "L66"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -57484,7 +57574,7 @@
       "source_location": "L127"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -57493,7 +57583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -57502,7 +57592,7 @@
       "source_location": "L25"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -57511,7 +57601,7 @@
       "source_location": "L90"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -57520,7 +57610,7 @@
       "source_location": "L82"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -57529,7 +57619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -57538,7 +57628,7 @@
       "source_location": "L115"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -57547,49 +57637,13 @@
       "source_location": "L105"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
       "norm_label": "onmobilefilterscloseclick()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "index_cancelorder",
-      "label": "cancelOrder()",
-      "norm_label": "cancelorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "index_geterrormessage",
-      "label": "getErrorMessage()",
-      "norm_label": "geterrormessage()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "index_placeorder",
-      "label": "placeOrder()",
-      "norm_label": "placeorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 26,
@@ -57738,6 +57792,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "index_cancelorder",
+      "label": "cancelOrder()",
+      "norm_label": "cancelorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_geterrormessage",
+      "label": "getErrorMessage()",
+      "norm_label": "geterrormessage()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_placeorder",
+      "label": "placeOrder()",
+      "norm_label": "placeorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
       "norm_label": "bootstrapcheckout()",
@@ -57745,7 +57835,7 @@
       "source_location": "L46"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -57754,7 +57844,7 @@
       "source_location": "L24"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -57763,7 +57853,7 @@
       "source_location": "L20"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -57772,7 +57862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -57781,7 +57871,7 @@
       "source_location": "L33"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -57790,7 +57880,7 @@
       "source_location": "L6"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -57799,7 +57889,7 @@
       "source_location": "L25"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -57808,7 +57898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -57817,7 +57907,7 @@
       "source_location": "L17"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -57826,7 +57916,7 @@
       "source_location": "L11"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -57835,7 +57925,7 @@
       "source_location": "L24"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -57844,7 +57934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -57853,7 +57943,7 @@
       "source_location": "L20"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -57862,7 +57952,7 @@
       "source_location": "L65"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -57871,7 +57961,7 @@
       "source_location": "L14"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -57880,7 +57970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -57889,7 +57979,7 @@
       "source_location": "L126"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -57898,7 +57988,7 @@
       "source_location": "L130"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -57907,7 +57997,7 @@
       "source_location": "L875"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -57916,7 +58006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -57925,7 +58015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -57934,7 +58024,7 @@
       "source_location": "L8"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -57943,7 +58033,7 @@
       "source_location": "L79"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -57952,7 +58042,7 @@
       "source_location": "L61"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -57961,7 +58051,7 @@
       "source_location": "L49"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -57970,7 +58060,7 @@
       "source_location": "L17"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -57979,7 +58069,7 @@
       "source_location": "L11"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -57988,7 +58078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -57997,7 +58087,7 @@
       "source_location": "L26"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -58006,7 +58096,7 @@
       "source_location": "L72"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -58015,7 +58105,7 @@
       "source_location": "L36"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -58024,7 +58114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -58033,7 +58123,7 @@
       "source_location": "L96"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -58042,7 +58132,7 @@
       "source_location": "L94"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -58051,39 +58141,12 @@
       "source_location": "L95"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
       "norm_label": "pre-push-review.test.ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "discountcode_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "discountcode_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "label": "DiscountCode.tsx",
-      "norm_label": "discountcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1"
     },
     {
@@ -58233,6 +58296,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "discountcode_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "discountcode_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
+      "label": "DiscountCode.tsx",
+      "norm_label": "discountcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -58240,7 +58330,7 @@
       "source_location": "L85"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -58249,7 +58339,7 @@
       "source_location": "L31"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -58258,7 +58348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -58267,7 +58357,7 @@
       "source_location": "L12"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -58276,7 +58366,7 @@
       "source_location": "L21"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -58285,7 +58375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -58294,7 +58384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -58303,7 +58393,7 @@
       "source_location": "L5"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -58312,7 +58402,7 @@
       "source_location": "L12"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -58321,7 +58411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -58330,7 +58420,7 @@
       "source_location": "L14"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -58339,7 +58429,7 @@
       "source_location": "L10"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -58348,7 +58438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -58357,7 +58447,7 @@
       "source_location": "L6"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -58366,7 +58456,7 @@
       "source_location": "L9"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -58375,7 +58465,7 @@
       "source_location": "L43"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -58384,7 +58474,7 @@
       "source_location": "L11"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -58393,7 +58483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -58402,7 +58492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -58411,7 +58501,7 @@
       "source_location": "L23"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -58420,7 +58510,7 @@
       "source_location": "L105"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -58429,7 +58519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -58438,7 +58528,7 @@
       "source_location": "L16"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -58447,7 +58537,7 @@
       "source_location": "L92"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -58456,7 +58546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -58465,40 +58555,13 @@
       "source_location": "L21"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
       "norm_label": "uniqueoperationalroles()",
       "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
       "source_location": "L31"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "index_listtransactions",
-      "label": "listTransactions()",
-      "norm_label": "listtransactions()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "index_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L1"
     },
     {
       "community": 28,
@@ -58647,6 +58710,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "index_listtransactions",
+      "label": "listTransactions()",
+      "norm_label": "listtransactions()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "index_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_paystack_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
       "norm_label": "buildregisterstate()",
@@ -58654,7 +58744,7 @@
       "source_location": "L17"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -58663,7 +58753,7 @@
       "source_location": "L37"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -58672,7 +58762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -58681,7 +58771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -58690,7 +58780,7 @@
       "source_location": "L18"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -58699,7 +58789,7 @@
       "source_location": "L9"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -58708,7 +58798,7 @@
       "source_location": "L8"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -58717,7 +58807,7 @@
       "source_location": "L9"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -58726,7 +58816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -58735,7 +58825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -58744,7 +58834,7 @@
       "source_location": "L7"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -58753,7 +58843,7 @@
       "source_location": "L29"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -58762,7 +58852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -58771,7 +58861,7 @@
       "source_location": "L13"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -58780,7 +58870,7 @@
       "source_location": "L45"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -58789,7 +58879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -58798,7 +58888,7 @@
       "source_location": "L33"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -58807,7 +58897,7 @@
       "source_location": "L13"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -58816,7 +58906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -58825,7 +58915,7 @@
       "source_location": "L13"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -58834,7 +58924,7 @@
       "source_location": "L17"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -58843,7 +58933,7 @@
       "source_location": "L17"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -58852,7 +58942,7 @@
       "source_location": "L61"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -58861,7 +58951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -58870,7 +58960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -58879,39 +58969,12 @@
       "source_location": "L23"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
       "norm_label": "gettableindexes()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
-      "label": "receiving.test.ts",
-      "norm_label": "receiving.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "receiving_test_createreceivingmutationctx",
-      "label": "createReceivingMutationCtx()",
-      "norm_label": "createreceivingmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "receiving_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
       "source_location": "L16"
     },
     {
@@ -59052,6 +59115,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
+      "label": "receiving.test.ts",
+      "norm_label": "receiving.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "receiving_test_createreceivingmutationctx",
+      "label": "createReceivingMutationCtx()",
+      "norm_label": "createreceivingmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "receiving_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
       "norm_label": "vendors.ts",
@@ -59059,7 +59149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -59068,7 +59158,7 @@
       "source_location": "L12"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -59077,7 +59167,7 @@
       "source_location": "L7"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -59086,7 +59176,7 @@
       "source_location": "L25"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -59095,7 +59185,7 @@
       "source_location": "L21"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -59104,7 +59194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -59113,7 +59203,7 @@
       "source_location": "L7"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -59122,7 +59212,7 @@
       "source_location": "L14"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -59131,7 +59221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -59140,7 +59230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -59149,7 +59239,7 @@
       "source_location": "L45"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -59158,7 +59248,7 @@
       "source_location": "L37"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -59167,7 +59257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -59176,7 +59266,7 @@
       "source_location": "L10"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -59185,7 +59275,7 @@
       "source_location": "L44"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -59194,7 +59284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -59203,7 +59293,7 @@
       "source_location": "L84"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -59212,7 +59302,7 @@
       "source_location": "L100"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -59221,7 +59311,7 @@
       "source_location": "L5"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -59230,7 +59320,7 @@
       "source_location": "L25"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -59239,7 +59329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -59248,7 +59338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -59257,7 +59347,7 @@
       "source_location": "L35"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -59266,7 +59356,7 @@
       "source_location": "L25"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -59275,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -59284,40 +59374,13 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
       "norm_label": "view()",
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "label": "ProductAvailability.tsx",
-      "norm_label": "productavailability.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "productavailability_productavailability",
-      "label": "ProductAvailability()",
-      "norm_label": "productavailability()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "productavailability_productavailabilityview",
-      "label": "ProductAvailabilityView()",
-      "norm_label": "productavailabilityview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L5"
     },
     {
       "community": 3,
@@ -59736,6 +59799,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
+      "label": "ProductAvailability.tsx",
+      "norm_label": "productavailability.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "productavailability_productavailability",
+      "label": "ProductAvailability()",
+      "norm_label": "productavailability()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "productavailability_productavailabilityview",
+      "label": "ProductAvailabilityView()",
+      "norm_label": "productavailabilityview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
       "norm_label": "sheetprovider.tsx",
@@ -59743,7 +59833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -59752,7 +59842,7 @@
       "source_location": "L19"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -59761,7 +59851,7 @@
       "source_location": "L11"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -59770,7 +59860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -59779,7 +59869,7 @@
       "source_location": "L22"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -59788,7 +59878,7 @@
       "source_location": "L8"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -59797,7 +59887,7 @@
       "source_location": "L21"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -59806,7 +59896,7 @@
       "source_location": "L13"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -59815,7 +59905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -59824,7 +59914,7 @@
       "source_location": "L100"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -59833,7 +59923,7 @@
       "source_location": "L10"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -59842,7 +59932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -59851,7 +59941,7 @@
       "source_location": "L100"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -59860,7 +59950,7 @@
       "source_location": "L10"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -59869,7 +59959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -59878,7 +59968,7 @@
       "source_location": "L15"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -59887,39 +59977,12 @@
       "source_location": "L39"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
       "norm_label": "log-items-provider.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 306,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 306,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 306,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
     },
     {
@@ -64794,101 +64857,101 @@
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 43,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 43,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 43,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 430,
@@ -65073,101 +65136,101 @@
     {
       "community": 44,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 44,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
     },
     {
       "community": 44,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 44,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 440,
@@ -65352,101 +65415,101 @@
     {
       "community": 45,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 45,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 45,
-      "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
     },
     {
       "community": 450,
@@ -65631,101 +65694,101 @@
     {
       "community": 46,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 46,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 46,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 460,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1525
-- Graph nodes: 3984
-- Graph edges: 3556
+- Graph nodes: 3987
+- Graph edges: 3559
 - Communities: 1453
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 261) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 262) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 41) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
@@ -39,7 +39,9 @@ describe("InputOTPForm", () => {
 
     mocked.signIn.mockResolvedValue({ signingIn: true });
 
-    render(<InputOTPForm email=" Manager@Example.com " />);
+    render(
+      <InputOTPForm email=" Manager@Example.com " onBack={vi.fn()} />
+    );
 
     await user.type(screen.getByLabelText(/verification code/i), "123456");
 
@@ -60,12 +62,52 @@ describe("InputOTPForm", () => {
 
     mocked.signIn.mockResolvedValue({ signingIn: false });
 
-    render(<InputOTPForm email="manager@example.com" />);
+    render(
+      <InputOTPForm email="manager@example.com" onBack={vi.fn()} />
+    );
 
     await user.type(screen.getByLabelText(/verification code/i), "123456");
 
     await waitFor(() =>
       expect(screen.getByText("Invalid code entered")).toBeInTheDocument()
     );
+  });
+
+  it("lets the operator return to the email step", async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+
+    render(
+      <InputOTPForm email="manager@example.com" onBack={onBack} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /change email/i }));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests a fresh code for the same email after the resend delay", async () => {
+    const user = userEvent.setup();
+
+    mocked.signIn.mockResolvedValue({});
+
+    render(
+      <InputOTPForm
+        email=" Manager@Example.com "
+        onBack={vi.fn()}
+        requestNewCodeDelaySeconds={0}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /request a new code/i })
+    );
+
+    await waitFor(() =>
+      expect(mocked.signIn).toHaveBeenCalledWith(ATHENA_EMAIL_OTP_PROVIDER_ID, {
+        email: "manager@example.com",
+      })
+    );
+    expect(screen.getByText(/request a new code/i)).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
@@ -18,8 +18,11 @@ import { ATHENA_EMAIL_OTP_PROVIDER_ID } from "../../../../shared/auth";
 import { LoadingButton } from "~/src/components/ui/loading-button";
 import { PENDING_ATHENA_AUTH_SYNC_KEY } from "~/src/lib/constants";
 import { useForm } from "react-hook-form";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+const REQUEST_NEW_CODE_DELAY_SECONDS = 90;
 
 const FormSchema = z.object({
   pin: z.string().min(6, {
@@ -27,7 +30,22 @@ const FormSchema = z.object({
   }),
 });
 
-export function InputOTPForm({ email }: { email: string }) {
+function formatRequestDelay(seconds: number) {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
+export function InputOTPForm({
+  email,
+  onBack,
+  requestNewCodeDelaySeconds = REQUEST_NEW_CODE_DELAY_SECONDS,
+}: {
+  email: string;
+  onBack: () => void;
+  requestNewCodeDelaySeconds?: number;
+}) {
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
@@ -36,8 +54,28 @@ export function InputOTPForm({ email }: { email: string }) {
   });
 
   const [isSigningIn, setIsSigningIn] = useState(false);
+  const [isRequestingNewCode, setIsRequestingNewCode] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [requestDelaySeconds, setRequestDelaySeconds] = useState(
+    requestNewCodeDelaySeconds,
+  );
   const { signIn } = useAuthActions();
+
+  useEffect(() => {
+    setRequestDelaySeconds(requestNewCodeDelaySeconds);
+  }, [email, requestNewCodeDelaySeconds]);
+
+  useEffect(() => {
+    if (requestDelaySeconds <= 0) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setRequestDelaySeconds((seconds) => Math.max(seconds - 1, 0));
+    }, 1000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [requestDelaySeconds]);
 
   // Automatically submit the form when 6 digits are entered
   const handlePinChange = (newValue: string) => {
@@ -68,30 +106,70 @@ export function InputOTPForm({ email }: { email: string }) {
       window.dispatchEvent(new Event("athena:pending-auth-sync"));
       return;
     } catch (e) {
-      const message =
-        e instanceof Error ? e.message : "Could not verify code";
+      const message = e instanceof Error ? e.message : "Could not verify code";
 
       setErrorMessage(
         message.includes("Could not verify code")
           ? "Invalid code entered"
-          : message
+          : message,
       );
       setIsSigningIn(false);
     }
   }
 
+  async function handleRequestNewCode() {
+    try {
+      setIsRequestingNewCode(true);
+      setErrorMessage(null);
+
+      await signIn(ATHENA_EMAIL_OTP_PROVIDER_ID, {
+        email: email.trim().toLowerCase(),
+      });
+
+      form.reset({ pin: "" });
+      setRequestDelaySeconds(requestNewCodeDelaySeconds);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Could not request a new code";
+
+      setErrorMessage(message);
+    } finally {
+      setIsRequestingNewCode(false);
+    }
+  }
+
   return (
-    <div className="mx-auto flex h-full w-full max-w-96 flex-col items-center justify-center gap-6">
+    <div className="flex w-full flex-col gap-layout-lg">
+      <div className="space-y-layout-sm">
+        <h2 className="font-display text-2xl font-light uppercase tracking-[0.18em] text-foreground">
+          Enter code
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Sent to {email}
+        </p>
+        <button
+          type="button"
+          className="group inline-flex items-center gap-layout-xs text-sm text-muted-foreground underline-offset-4 transition-colors duration-standard ease-standard hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onBack}
+        >
+          <ArrowLeft className="h-3.5 w-3.5 transition-transform duration-standard ease-emphasized group-hover:-translate-x-1 group-focus-visible:-translate-x-1" />
+          Change email
+        </button>
+      </div>
+
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className="w-2/3 space-y-6"
+          className="w-full space-y-layout-lg"
         >
           <FormField
             control={form.control}
             name="pin"
             render={({ field }) => (
-              <FormItem>
+              <FormItem className="space-y-layout-sm">
+                <FormLabel className="text-sm font-medium text-foreground">
+                  One-time code
+                </FormLabel>
                 <FormControl>
                   <InputOTP maxLength={6} {...field} onChange={handlePinChange}>
                     <InputOTPGroup>
@@ -104,33 +182,45 @@ export function InputOTPForm({ email }: { email: string }) {
                     </InputOTPGroup>
                   </InputOTP>
                 </FormControl>
-                <FormDescription>
-                  {errorMessage
-                    ? errorMessage
-                    : `Enter the one-time code sent to ${email}`}
+                <FormDescription
+                  className={errorMessage ? "text-danger" : undefined}
+                >
+                  {errorMessage ? errorMessage : ""}
                 </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <LoadingButton isLoading={isSigningIn} type="submit">
+          <LoadingButton
+            isLoading={isSigningIn}
+            type="submit"
+            className="group h-control-standard w-fit px-layout-lg"
+          >
             Continue
+            <ArrowRight className="h-4 w-4 transition-transform duration-standard ease-emphasized group-hover:translate-x-1 group-focus-visible:translate-x-1" />
           </LoadingButton>
+
+          <div className="pt-layout-xs text-sm text-muted-foreground">
+            {requestDelaySeconds > 0 ? (
+              <p>
+                Request a new code in {formatRequestDelay(requestDelaySeconds)}
+              </p>
+            ) : (
+              <button
+                type="button"
+                className="text-signal underline-offset-4 transition-colors duration-standard ease-standard hover:text-signal/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                disabled={isRequestingNewCode}
+                onClick={handleRequestNewCode}
+              >
+                {isRequestingNewCode
+                  ? "Requesting new code..."
+                  : "Request a new code"}
+              </button>
+            )}
+          </div>
         </form>
       </Form>
-
-      {/* <div className="flex w-full flex-col">
-        <p className="text-center text-sm font-normal text-primary/60">
-          Did not receive the code?
-        </p>
-        <Button
-          variant="ghost"
-          className="w-full hover:bg-transparent"
-        >
-          Request New Code
-        </Button>
-      </div> */}
     </div>
   );
 }

--- a/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
@@ -6,6 +6,7 @@ import { Input } from "../../ui/input";
 import { LoadingButton } from "../../ui/loading-button";
 import { ATHENA_EMAIL_OTP_PROVIDER_ID } from "../../../../shared/auth";
 import { z } from "zod";
+import { ArrowRight } from "lucide-react";
 
 export function LoginForm({
   setStep,
@@ -36,24 +37,21 @@ export function LoginForm({
     },
   });
   return (
-    <div className="mx-auto flex h-full w-full max-w-96 flex-col items-center justify-center gap-6">
-      <div className="mb-2 flex flex-col gap-4">
-        <h3 className="text-center text-xl font-medium text-primary">
+    <div className="flex w-full flex-col gap-layout-xl">
+      <div>
+        <h2 className="font-display text-2xl font-light uppercase tracking-[0.18em] text-foreground">
           Log in to athena
-        </h3>
+        </h2>
       </div>
       <form
-        className="flex w-full flex-col items-start gap-4"
+        className="flex w-full flex-col items-start gap-layout-md"
         onSubmit={(e) => {
           e.preventDefault();
           e.stopPropagation();
           form.handleSubmit();
         }}
       >
-        <div className="flex w-full flex-col gap-1.5">
-          <label htmlFor="email" className="sr-only">
-            Email
-          </label>
+        <div className="flex w-full flex-col gap-layout-xs">
           <form.Field
             name="email"
             validators={{
@@ -64,11 +62,14 @@ export function LoginForm({
             }}
             children={(field) => (
               <Input
+                id="email"
+                type="email"
+                autoComplete="email"
                 placeholder="Email"
                 value={field.state.value}
                 onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(e.target.value)}
-                className={`bg-transparent ${
+                className={`h-control-standard bg-background ${
                   field.state.meta?.errors.length > 0 &&
                   "border-destructive focus-visible:ring-destructive"
                 }`}
@@ -77,9 +78,9 @@ export function LoginForm({
           />
         </div>
 
-        <div className="flex flex-col">
+        <div className="min-h-5">
           {form.state.fieldMeta.email?.errors.length > 0 && (
-            <span className="mb-2 text-sm text-destructive">
+            <span className="text-sm text-destructive">
               {form.state.fieldMeta.email?.errors.join(" ")}
             </span>
           )}
@@ -88,9 +89,10 @@ export function LoginForm({
         <LoadingButton
           isLoading={isSubmitting}
           type="submit"
-          className="w-full"
+          className="group h-control-standard w-full"
         >
           Continue
+          <ArrowRight className="h-4 w-4 transition-transform duration-standard ease-emphasized group-hover:translate-x-1 group-focus-visible:translate-x-1" />
         </LoadingButton>
       </form>
     </div>

--- a/packages/athena-webapp/src/components/auth/Login/index.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.tsx
@@ -8,5 +8,7 @@ export function Login() {
   if (step === "signIn") {
     return <LoginForm setStep={setStep} />;
   }
-  return <InputOTPForm email={step.email} />;
+  return (
+    <InputOTPForm email={step.email} onBack={() => setStep("signIn")} />
+  );
 }

--- a/packages/athena-webapp/src/routes/login/_layout.test.tsx
+++ b/packages/athena-webapp/src/routes/login/_layout.test.tsx
@@ -63,7 +63,7 @@ describe("LoginLayout", () => {
     render(<LoginLayout />);
 
     expect(screen.getByText("Mock Login Outlet")).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /athena/i })).toHaveLength(2);
+    expect(screen.getAllByRole("link", { name: /athena/i })).toHaveLength(1);
   });
 
   it("waits for the Convex session before retrying the pending Athena-user sync", async () => {

--- a/packages/athena-webapp/src/routes/login/_layout.tsx
+++ b/packages/athena-webapp/src/routes/login/_layout.tsx
@@ -16,31 +16,6 @@ import { runCommand } from "~/src/lib/errors/runCommand";
 
 const HOME_PATH = "/";
 
-const QUOTES = [
-  {
-    quote: "There is nothing impossible to they who will try.",
-    author: "Alexander the Great",
-  },
-  {
-    quote: "The only way to do great work is to love what you do.",
-    author: "Steve Jobs",
-  },
-  {
-    quote: "The best way to predict the future is to create it.",
-    author: "Peter Drucker",
-  },
-  {
-    quote:
-      "The only limit to our realization of tomorrow will be our doubts of today.",
-    author: "Franklin D. Roosevelt",
-  },
-  {
-    quote: "The only thing we have to fear is fear itself.",
-    author: "Franklin D. Roosevelt",
-  },
-];
-
-const randomQuote = QUOTES[Math.floor(Math.random() * QUOTES.length)];
 const AUTH_SYNC_RETRY_DELAY_MS = 100;
 const AUTH_SYNC_MAX_ATTEMPTS = 20;
 const AUTH_SYNC_RETRYABLE_MESSAGE = "Sign in again to continue.";
@@ -49,11 +24,42 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function useDocumentScrollLock() {
+  useEffect(() => {
+    const htmlStyle = document.documentElement.style;
+    const bodyStyle = document.body.style;
+    const previousHtmlHeight = htmlStyle.height;
+    const previousHtmlOverflow = htmlStyle.overflow;
+    const previousHtmlOverscrollBehaviorY = htmlStyle.overscrollBehaviorY;
+    const previousBodyHeight = bodyStyle.height;
+    const previousBodyOverflow = bodyStyle.overflow;
+    const previousBodyOverscrollBehaviorY = bodyStyle.overscrollBehaviorY;
+
+    htmlStyle.height = "100%";
+    htmlStyle.overflow = "hidden";
+    htmlStyle.overscrollBehaviorY = "none";
+    bodyStyle.height = "100%";
+    bodyStyle.overflow = "hidden";
+    bodyStyle.overscrollBehaviorY = "none";
+
+    return () => {
+      htmlStyle.height = previousHtmlHeight;
+      htmlStyle.overflow = previousHtmlOverflow;
+      htmlStyle.overscrollBehaviorY = previousHtmlOverscrollBehaviorY;
+      bodyStyle.height = previousBodyHeight;
+      bodyStyle.overflow = previousBodyOverflow;
+      bodyStyle.overscrollBehaviorY = previousBodyOverscrollBehaviorY;
+    };
+  }, []);
+}
+
 export const Route = createFileRoute("/login/_layout")({
   component: LoginLayout,
 });
 
 export function LoginLayout() {
+  useDocumentScrollLock();
+
   const { isAuthenticated, isLoading } = useConvexAuth();
   const authToken = useAuthToken();
   const syncAuthenticatedAthenaUser = useMutation(
@@ -183,38 +189,32 @@ export function LoginLayout() {
   ]);
 
   return (
-    <div className="flex h-screen w-full" aria-busy={isLoading}>
-      <div className="absolute left-1/2 top-10 mx-auto flex -translate-x-1/2 transform lg:hidden">
+    <main
+      className="flex h-screen w-full overflow-hidden bg-background text-foreground"
+      aria-busy={isLoading}
+    >
+      <div className="absolute left-layout-xl top-layout-xl z-20">
         <Link
           to={HOME_PATH}
-          className="z-10 flex h-10 flex-col items-center justify-center gap-2"
+          className="flex h-10 items-center justify-center rounded-md px-layout-sm font-display text-base font-semibold text-foreground transition-colors duration-standard ease-standard hover:text-signal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           athena
         </Link>
       </div>
-      <div className="relative hidden h-full w-[50%] flex-col justify-between overflow-hidden bg-card p-10 lg:flex">
-        <Link to={HOME_PATH} className="z-10 flex h-10 w-10 items-center gap-1">
-          athena
-        </Link>
 
-        {/* <div className="z-10 flex flex-col items-start gap-2">
-          <p className="text-base font-normal text-primary">
-            {randomQuote.quote}
-          </p>
-          <p className="text-base font-normal text-primary/60">
-            -{randomQuote.author}
-          </p>
-        </div> */}
-        <div className="base-grid absolute left-0 top-0 z-0 h-full w-full opacity-40" />
+      <div className="flex h-full w-full items-center justify-center px-layout-md py-layout-xl sm:px-layout-xl">
+        <section className="w-full max-w-[25rem]">
+          {authSyncError && (
+            <div
+              className="mb-layout-md rounded-md border border-danger/20 bg-danger/10 px-layout-md py-layout-sm text-sm text-danger"
+              role="alert"
+            >
+              {authSyncError}
+            </div>
+          )}
+          <Outlet />
+        </section>
       </div>
-      <div className="flex h-full w-full flex-col border-l border-primary/5 bg-card lg:w-[50%]">
-        {authSyncError && (
-          <div className="px-6 pt-6 text-sm text-destructive">
-            {authSyncError}
-          </div>
-        )}
-        <Outlet />
-      </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- simplify the login screen to match the minimal app design direction
- keep the OTP input compact while aligning OTP typography, spacing, and button treatment with the login step
- add in-place OTP resend after 90 seconds plus a change-email escape path

## Validation
- bun run --filter '@athena/webapp' test -- src/routes/login/_layout.test.tsx src/routes/login/_layout.index.test.tsx src/components/auth/Login/InputOTP.test.tsx\n- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json\n- bun run graphify:rebuild\n- pre-push hook: graphify check, harness self-review, architecture check, full webapp test shard, TypeScript, production build, inferential review\n\nVisual validation intentionally left to the product review flow.