### PR TITLE
[V26-414]: Align storefront Ghana cedi price display

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -32651,7 +32651,7 @@
       "relation": "contains",
       "source": "utils_currencyformatter",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L35",
+      "source_location": "L39",
       "target": "packages_storefront_webapp_src_lib_utils_ts",
       "weight": 1
     },
@@ -32663,7 +32663,7 @@
       "relation": "contains",
       "source": "packages_storefront_webapp_src_lib_utils_ts",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L60",
+      "source_location": "L86",
       "target": "utils_enablequery",
       "weight": 1
     },
@@ -32675,7 +32675,7 @@
       "relation": "contains",
       "source": "utils_formatdate",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L44",
+      "source_location": "L70",
       "target": "packages_storefront_webapp_src_lib_utils_ts",
       "weight": 1
     },
@@ -32699,7 +32699,7 @@
       "relation": "contains",
       "source": "utils_getrelativetime",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L67",
+      "source_location": "L93",
       "target": "packages_storefront_webapp_src_lib_utils_ts",
       "weight": 1
     },
@@ -32711,7 +32711,7 @@
       "relation": "contains",
       "source": "packages_storefront_webapp_src_lib_utils_ts",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L53",
+      "source_location": "L79",
       "target": "utils_getstoredetails",
       "weight": 1
     },
@@ -50191,7 +50191,7 @@
       "label": "currencyFormatter()",
       "norm_label": "currencyformatter()",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L35"
+      "source_location": "L39"
     },
     {
       "community": 14,
@@ -50200,7 +50200,7 @@
       "label": "enableQuery()",
       "norm_label": "enablequery()",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L60"
+      "source_location": "L86"
     },
     {
       "community": 14,
@@ -50209,7 +50209,7 @@
       "label": "formatDate()",
       "norm_label": "formatdate()",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L44"
+      "source_location": "L70"
     },
     {
       "community": 14,
@@ -50263,7 +50263,7 @@
       "label": "getRelativeTime()",
       "norm_label": "getrelativetime()",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L67"
+      "source_location": "L93"
     },
     {
       "community": 14,
@@ -50272,7 +50272,7 @@
       "label": "getStoreDetails()",
       "norm_label": "getstoredetails()",
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L53"
+      "source_location": "L79"
     },
     {
       "community": 14,

--- a/packages/storefront-webapp/src/components/ProductCard.test.tsx
+++ b/packages/storefront-webapp/src/components/ProductCard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ProductSkuCard } from "./ProductCard";
+import { currencyFormatter } from "@/lib/utils";
 
 vi.mock("@/hooks/useProductDiscount", () => ({
   useProductDiscount: () => ({
@@ -40,5 +41,22 @@ describe("ProductSkuCard", () => {
       "sizes",
       "(max-width: 768px) 50vw, (max-width: 1280px) 33vw, 25vw",
     );
+  });
+
+  it("renders stored GHS prices with the Athena cedi symbol", () => {
+    render(
+      <ProductSkuCard
+        sku={{
+          _id: "sku_1",
+          productName: "Wigclub Bonnets",
+          price: 6500,
+          quantityAvailable: 4,
+          images: ["https://images.example.com/bonnet.webp"],
+        } as any}
+        currencyFormatter={currencyFormatter("GHS")}
+      />,
+    );
+
+    expect(screen.getByText("GH₵65")).toBeInTheDocument();
   });
 });

--- a/packages/storefront-webapp/src/lib/utils.test.ts
+++ b/packages/storefront-webapp/src/lib/utils.test.ts
@@ -26,4 +26,8 @@ describe("utils", () => {
   it("formats currency values without decimals", () => {
     expect(currencyFormatter("USD").format(1250)).toBe("$1,250");
   });
+
+  it("uses the Athena Ghana cedi symbol for GHS", () => {
+    expect(currencyFormatter("GHS").format(1250)).toBe("GH₵1,250");
+  });
 });

--- a/packages/storefront-webapp/src/lib/utils.ts
+++ b/packages/storefront-webapp/src/lib/utils.ts
@@ -32,7 +32,33 @@ export function slugToWords(input: string): string {
   return input.replace(/-/g, " ");
 }
 
-export function currencyFormatter(currency: string) {
+const DISPLAY_CURRENCY_SYMBOLS: Record<string, string> = {
+  GHS: "GH₵",
+};
+
+export function currencyFormatter(currency: string): Intl.NumberFormat {
+  const normalizedCurrency = currency.toUpperCase();
+  const displaySymbol = DISPLAY_CURRENCY_SYMBOLS[normalizedCurrency];
+
+  if (displaySymbol) {
+    const numberFormatter = new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+    const formatter = new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+
+    Object.defineProperty(formatter, "format", {
+      value(amount: number) {
+        return `${displaySymbol}${numberFormatter.format(amount)}`;
+      },
+    });
+
+    return formatter;
+  }
+
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,


### PR DESCRIPTION
## Summary
- Mirror Athena webapp's custom GHS formatter behavior in storefront-webapp so customer prices render with `GH₵`.
- Add storefront formatter coverage for GHS plus a product-card price assertion proving stored pesewas display as `GH₵65`.
- Refresh graphify artifacts after the storefront code change.

## Why
Storefront price surfaces already convert stored pesewa values to display units, but the central formatter used the runtime default `Intl` currency display for `GHS`, which can render as `GHS 65` instead of Athena's `GH₵65`.

## Validation
- `bun run --filter '@athena/storefront-webapp' test -- src/lib/utils.test.ts src/components/ProductCard.test.tsx`\n- `bun run --filter '@athena/storefront-webapp' test`\n- `bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json`\n- `bun run graphify:rebuild`\n- `git diff --check`\n- pre-push validation: graphify:check, architecture:check, harness:review, harness:inferential-review\n\nLinear: https://linear.app/v26-labs/issue/V26-414/align-storefront-ghana-cedi-price-display-with-athena-formatter